### PR TITLE
feat: add ease-of-use improvements for SDK

### DIFF
--- a/core/errors.go
+++ b/core/errors.go
@@ -42,8 +42,8 @@ var (
 	ErrNotSupported = errors.New("operation not supported")
 )
 
-// Validation errors.
+// Validation errors with actionable guidance.
 var (
-	ErrModelRequired = errors.New("model required")
-	ErrNoMessages    = errors.New("no messages")
+	ErrModelRequired = errors.New("model required: pass a model ID to Client.Chat(), e.g., client.Chat(\"gpt-4\")")
+	ErrNoMessages    = errors.New("no messages: add at least one message using .System(), .User(), or .Assistant()")
 )

--- a/core/errors_test.go
+++ b/core/errors_test.go
@@ -181,8 +181,8 @@ func TestSentinelErrorsAreDifferent(t *testing.T) {
 
 func TestSentinelErrorMessages(t *testing.T) {
 	tests := []struct {
-		err  error
-		want string
+		err          error
+		wantContains string
 	}{
 		{ErrUnauthorized, "unauthorized"},
 		{ErrRateLimited, "rate limited"},
@@ -196,11 +196,24 @@ func TestSentinelErrorMessages(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.want, func(t *testing.T) {
-			if tt.err.Error() != tt.want {
-				t.Errorf("Error() = %q, want %q", tt.err.Error(), tt.want)
+		t.Run(tt.wantContains, func(t *testing.T) {
+			if !contains(tt.err.Error(), tt.wantContains) {
+				t.Errorf("Error() = %q, should contain %q", tt.err.Error(), tt.wantContains)
 			}
 		})
+	}
+}
+
+func TestValidationErrorMessagesHaveGuidance(t *testing.T) {
+	// Verify the validation errors contain actionable guidance
+	modelErr := ErrModelRequired.Error()
+	if !contains(modelErr, "Client.Chat") {
+		t.Errorf("ErrModelRequired should contain guidance mentioning Client.Chat(), got: %q", modelErr)
+	}
+
+	messagesErr := ErrNoMessages.Error()
+	if !contains(messagesErr, ".User()") || !contains(messagesErr, ".System()") {
+		t.Errorf("ErrNoMessages should contain guidance mentioning builder methods, got: %q", messagesErr)
 	}
 }
 

--- a/core/types.go
+++ b/core/types.go
@@ -161,6 +161,29 @@ type ChatResponse struct {
 	Status    string           `json:"status,omitempty"`
 }
 
+// HasToolCalls reports whether the response contains any tool calls.
+func (r *ChatResponse) HasToolCalls() bool {
+	return len(r.ToolCalls) > 0
+}
+
+// FirstToolCall returns the first tool call, or nil if there are none.
+// This is convenient for single-tool scenarios:
+//
+//	if tc := resp.FirstToolCall(); tc != nil {
+//	    // handle tool call
+//	}
+func (r *ChatResponse) FirstToolCall() *ToolCall {
+	if len(r.ToolCalls) > 0 {
+		return &r.ToolCalls[0]
+	}
+	return nil
+}
+
+// HasReasoning reports whether the response contains reasoning output.
+func (r *ChatResponse) HasReasoning() bool {
+	return r.Reasoning != nil && len(r.Reasoning.Summary) > 0
+}
+
 // ChatChunk represents an incremental streaming response.
 // Delta contains incremental assistant text.
 type ChatChunk struct {

--- a/providers/anthropic/provider.go
+++ b/providers/anthropic/provider.go
@@ -2,10 +2,36 @@ package anthropic
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"os"
 
 	"github.com/petal-labs/iris/core"
 )
+
+// DefaultAPIKeyEnvVar is the environment variable name for the Anthropic API key.
+const DefaultAPIKeyEnvVar = "ANTHROPIC_API_KEY"
+
+// ErrAPIKeyNotFound is returned when the API key environment variable is not set.
+var ErrAPIKeyNotFound = errors.New("anthropic: ANTHROPIC_API_KEY environment variable not set")
+
+// NewFromEnv creates a new Anthropic provider using the ANTHROPIC_API_KEY environment variable.
+// This is a convenience factory for quick setup:
+//
+//	provider, err := anthropic.NewFromEnv()
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	client := core.NewClient(provider)
+//
+// Additional options can be passed to customize the provider.
+func NewFromEnv(opts ...Option) (*Anthropic, error) {
+	apiKey := os.Getenv(DefaultAPIKeyEnvVar)
+	if apiKey == "" {
+		return nil, ErrAPIKeyNotFound
+	}
+	return New(apiKey, opts...), nil
+}
 
 // Anthropic is an LLM provider implementation for the Anthropic API.
 // Anthropic is safe for concurrent use.

--- a/providers/gemini/provider.go
+++ b/providers/gemini/provider.go
@@ -2,10 +2,42 @@ package gemini
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"os"
 
 	"github.com/petal-labs/iris/core"
 )
+
+// Environment variable names for the Gemini API key.
+const (
+	GeminiAPIKeyEnvVar = "GEMINI_API_KEY"
+	GoogleAPIKeyEnvVar = "GOOGLE_API_KEY"
+)
+
+// ErrAPIKeyNotFound is returned when no API key environment variable is set.
+var ErrAPIKeyNotFound = errors.New("gemini: GEMINI_API_KEY or GOOGLE_API_KEY environment variable not set")
+
+// NewFromEnv creates a new Gemini provider using the GEMINI_API_KEY or GOOGLE_API_KEY environment variable.
+// GEMINI_API_KEY takes precedence if both are set.
+//
+// This is a convenience factory for quick setup:
+//
+//	provider, err := gemini.NewFromEnv()
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	client := core.NewClient(provider)
+func NewFromEnv(opts ...Option) (*Gemini, error) {
+	apiKey := os.Getenv(GeminiAPIKeyEnvVar)
+	if apiKey == "" {
+		apiKey = os.Getenv(GoogleAPIKeyEnvVar)
+	}
+	if apiKey == "" {
+		return nil, ErrAPIKeyNotFound
+	}
+	return New(apiKey, opts...), nil
+}
 
 // Gemini is an LLM provider implementation for the Google Gemini API.
 // Gemini is safe for concurrent use.

--- a/providers/huggingface/provider.go
+++ b/providers/huggingface/provider.go
@@ -2,10 +2,42 @@ package huggingface
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"os"
 
 	"github.com/petal-labs/iris/core"
 )
+
+// Environment variable names for the Hugging Face API token.
+const (
+	HFTokenEnvVar          = "HF_TOKEN"
+	HuggingFaceTokenEnvVar = "HUGGINGFACE_TOKEN"
+)
+
+// ErrAPIKeyNotFound is returned when no API token environment variable is set.
+var ErrAPIKeyNotFound = errors.New("huggingface: HF_TOKEN or HUGGINGFACE_TOKEN environment variable not set")
+
+// NewFromEnv creates a new Hugging Face provider using the HF_TOKEN or HUGGINGFACE_TOKEN environment variable.
+// HF_TOKEN takes precedence if both are set.
+//
+// This is a convenience factory for quick setup:
+//
+//	provider, err := huggingface.NewFromEnv()
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	client := core.NewClient(provider)
+func NewFromEnv(opts ...Option) (*HuggingFace, error) {
+	apiKey := os.Getenv(HFTokenEnvVar)
+	if apiKey == "" {
+		apiKey = os.Getenv(HuggingFaceTokenEnvVar)
+	}
+	if apiKey == "" {
+		return nil, ErrAPIKeyNotFound
+	}
+	return New(apiKey, opts...), nil
+}
 
 // HuggingFace is an LLM provider implementation for Hugging Face Inference Providers.
 // HuggingFace is safe for concurrent use.

--- a/providers/openai/provider.go
+++ b/providers/openai/provider.go
@@ -2,10 +2,38 @@ package openai
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"os"
 
 	"github.com/petal-labs/iris/core"
 )
+
+// DefaultAPIKeyEnvVar is the environment variable name for the OpenAI API key.
+const DefaultAPIKeyEnvVar = "OPENAI_API_KEY"
+
+// ErrAPIKeyNotFound is returned when the API key environment variable is not set.
+var ErrAPIKeyNotFound = errors.New("openai: OPENAI_API_KEY environment variable not set")
+
+// NewFromEnv creates a new OpenAI provider using the OPENAI_API_KEY environment variable.
+// This is a convenience factory for quick setup:
+//
+//	provider, err := openai.NewFromEnv()
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	client := core.NewClient(provider)
+//
+// Additional options can be passed to customize the provider:
+//
+//	provider, err := openai.NewFromEnv(openai.WithOrgID("org-xxx"))
+func NewFromEnv(opts ...Option) (*OpenAI, error) {
+	apiKey := os.Getenv(DefaultAPIKeyEnvVar)
+	if apiKey == "" {
+		return nil, ErrAPIKeyNotFound
+	}
+	return New(apiKey, opts...), nil
+}
 
 // OpenAI is an LLM provider implementation for the OpenAI API.
 // OpenAI is safe for concurrent use.

--- a/providers/perplexity/provider.go
+++ b/providers/perplexity/provider.go
@@ -2,10 +2,34 @@ package perplexity
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"os"
 
 	"github.com/petal-labs/iris/core"
 )
+
+// DefaultAPIKeyEnvVar is the environment variable name for the Perplexity API key.
+const DefaultAPIKeyEnvVar = "PERPLEXITY_API_KEY"
+
+// ErrAPIKeyNotFound is returned when the API key environment variable is not set.
+var ErrAPIKeyNotFound = errors.New("perplexity: PERPLEXITY_API_KEY environment variable not set")
+
+// NewFromEnv creates a new Perplexity provider using the PERPLEXITY_API_KEY environment variable.
+// This is a convenience factory for quick setup:
+//
+//	provider, err := perplexity.NewFromEnv()
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	client := core.NewClient(provider)
+func NewFromEnv(opts ...Option) (*Perplexity, error) {
+	apiKey := os.Getenv(DefaultAPIKeyEnvVar)
+	if apiKey == "" {
+		return nil, ErrAPIKeyNotFound
+	}
+	return New(apiKey, opts...), nil
+}
 
 // Perplexity is an LLM provider implementation for the Perplexity Search API.
 // Perplexity is safe for concurrent use.

--- a/providers/voyageai/provider.go
+++ b/providers/voyageai/provider.go
@@ -2,10 +2,34 @@ package voyageai
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"os"
 
 	"github.com/petal-labs/iris/core"
 )
+
+// DefaultAPIKeyEnvVar is the environment variable name for the Voyage AI API key.
+const DefaultAPIKeyEnvVar = "VOYAGE_API_KEY"
+
+// ErrAPIKeyNotFound is returned when the API key environment variable is not set.
+var ErrAPIKeyNotFound = errors.New("voyageai: VOYAGE_API_KEY environment variable not set")
+
+// NewFromEnv creates a new Voyage AI provider using the VOYAGE_API_KEY environment variable.
+// This is a convenience factory for quick setup:
+//
+//	provider, err := voyageai.NewFromEnv()
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	client := core.NewClient(provider)
+func NewFromEnv(opts ...Option) (*VoyageAI, error) {
+	apiKey := os.Getenv(DefaultAPIKeyEnvVar)
+	if apiKey == "" {
+		return nil, ErrAPIKeyNotFound
+	}
+	return New(apiKey, opts...), nil
+}
 
 // VoyageAI is an embedding and reranking provider implementation for the Voyage AI API.
 // VoyageAI is safe for concurrent use.

--- a/providers/xai/provider.go
+++ b/providers/xai/provider.go
@@ -2,10 +2,34 @@ package xai
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"os"
 
 	"github.com/petal-labs/iris/core"
 )
+
+// DefaultAPIKeyEnvVar is the environment variable name for the xAI API key.
+const DefaultAPIKeyEnvVar = "XAI_API_KEY"
+
+// ErrAPIKeyNotFound is returned when the API key environment variable is not set.
+var ErrAPIKeyNotFound = errors.New("xai: XAI_API_KEY environment variable not set")
+
+// NewFromEnv creates a new xAI provider using the XAI_API_KEY environment variable.
+// This is a convenience factory for quick setup:
+//
+//	provider, err := xai.NewFromEnv()
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	client := core.NewClient(provider)
+func NewFromEnv(opts ...Option) (*Xai, error) {
+	apiKey := os.Getenv(DefaultAPIKeyEnvVar)
+	if apiKey == "" {
+		return nil, ErrAPIKeyNotFound
+	}
+	return New(apiKey, opts...), nil
+}
 
 // Xai is an LLM provider implementation for the xAI Grok API.
 // Xai is safe for concurrent use.

--- a/providers/zai/provider.go
+++ b/providers/zai/provider.go
@@ -2,10 +2,34 @@ package zai
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"os"
 
 	"github.com/petal-labs/iris/core"
 )
+
+// DefaultAPIKeyEnvVar is the environment variable name for the Z.ai API key.
+const DefaultAPIKeyEnvVar = "ZAI_API_KEY"
+
+// ErrAPIKeyNotFound is returned when the API key environment variable is not set.
+var ErrAPIKeyNotFound = errors.New("zai: ZAI_API_KEY environment variable not set")
+
+// NewFromEnv creates a new Z.ai provider using the ZAI_API_KEY environment variable.
+// This is a convenience factory for quick setup:
+//
+//	provider, err := zai.NewFromEnv()
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	client := core.NewClient(provider)
+func NewFromEnv(opts ...Option) (*Zai, error) {
+	apiKey := os.Getenv(DefaultAPIKeyEnvVar)
+	if apiKey == "" {
+		return nil, ErrAPIKeyNotFound
+	}
+	return New(apiKey, opts...), nil
+}
 
 // Zai is an LLM provider implementation for the Z.ai GLM API.
 // Zai is safe for concurrent use.


### PR DESCRIPTION
## Summary

- **Context helpers**: `ChatBuilder.Timeout(duration)` auto-creates timeout context for `GetResponse()`
- **Builder clone**: `ChatBuilder.Clone()` enables reusable builder patterns
- **Response helpers**: `HasToolCalls()`, `FirstToolCall()`, `HasReasoning()` on `ChatResponse`
- **Better errors**: Validation errors now include actionable guidance
- **Factory functions**: `NewFromEnv()` for all providers to read API keys from environment variables

## Details

### Timeout Helper
```go
// Instead of:
ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
defer cancel()
resp, err := client.Chat(model).User("Hello").GetResponse(ctx)

// You can write:
resp, err := client.Chat(model).User("Hello").Timeout(30*time.Second).GetResponse(context.Background())
```

### Builder Clone
```go
base := client.Chat(model).System("You are helpful").Temperature(0.7)
resp1, _ := base.Clone().User("Question 1").GetResponse(ctx)
resp2, _ := base.Clone().User("Question 2").GetResponse(ctx)
```

### Factory Functions
```go
// Quick setup from environment variables
provider, err := openai.NewFromEnv()
client := core.NewClient(provider)
```

Supported environment variables:
- `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY` / `GOOGLE_API_KEY`
- `XAI_API_KEY`, `VOYAGE_API_KEY`, `HF_TOKEN` / `HUGGINGFACE_TOKEN`
- `ZAI_API_KEY`, `PERPLEXITY_API_KEY`, `OLLAMA_API_KEY` (for cloud)

## Test plan

- [x] All existing tests pass
- [x] New unit tests for Timeout, Clone, response helpers
- [x] NewFromEnv tests for OpenAI provider
- [x] Linter passes with no issues