### PR TITLE
chore: enhance linter config and clean dependencies

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,8 @@ linters:
     - errcheck
     - ineffassign
     - unused
+    - gosec
+    - misspell
 
   settings:
     errcheck:
@@ -35,6 +37,12 @@ linters:
         - "-SA4023"
         - "-SA4031"
         - "-QF1011"
+    gosec:
+      excludes:
+        - G104  # Audit errors not checked (covered by errcheck)
+        - G304  # File path from variable (necessary for config loading)
+        - G101  # False positive: env var names, not credentials
+        - G404  # Retry jitter doesn't need cryptographic randomness
 
   exclusions:
     rules:
@@ -42,3 +50,21 @@ linters:
       - path: _test\.go
         linters:
           - errcheck
+      # Allow relaxed permissions in tests (test data files)
+      - path: _test\.go
+        linters:
+          - gosec
+        text: "G301|G306"
+      # Project scaffolding needs standard permissions (0755 dirs, 0644 files)
+      - path: cli/commands/init\.go
+        linters:
+          - gosec
+        text: "G301|G306"
+
+formatters:
+  enable:
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/petal-labs/iris

--- a/cli/commands/chat.go
+++ b/cli/commands/chat.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/petal-labs/iris/cli/keystore"
 	"github.com/petal-labs/iris/core"
 	"github.com/petal-labs/iris/providers"
@@ -17,7 +19,6 @@ import (
 	"github.com/petal-labs/iris/providers/openai"
 	"github.com/petal-labs/iris/providers/xai"
 	"github.com/petal-labs/iris/providers/zai"
-	"github.com/spf13/cobra"
 )
 
 // Exit codes

--- a/cli/commands/keys.go
+++ b/cli/commands/keys.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/petal-labs/iris/cli/keystore"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
+
+	"github.com/petal-labs/iris/cli/keystore"
 )
 
 var keysCmd = &cobra.Command{

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -2,8 +2,9 @@
 package commands
 
 import (
-	"github.com/petal-labs/iris/cli/config"
 	"github.com/spf13/cobra"
+
+	"github.com/petal-labs/iris/cli/config"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,13 @@ go 1.24.0
 
 require (
 	github.com/spf13/cobra v1.8.0
+	golang.org/x/crypto v0.47.0
 	golang.org/x/term v0.39.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
## Summary

- Add security and quality linters (gosec, misspell, goimports)
- Remove unused `github.com/google/uuid` dependency
- Fix import grouping to follow Go conventions

## Changes

| File | Change |
|------|--------|
| `.golangci.yml` | Add gosec, misspell, goimports; document exclusions |
| `go.mod`, `go.sum` | Remove unused uuid dependency |
| `cli/commands/*.go` | Fix import grouping (stdlib → third-party → local) |

## Verification

- [x] `golangci-lint run ./...` passes with 0 issues
- [x] `go test ./...` passes all tests