### PR TITLE
test: add comprehensive test coverage for huggingface and perplexity providers

### DIFF
--- a/providers/huggingface/client_test.go
+++ b/providers/huggingface/client_test.go
@@ -1,0 +1,328 @@
+package huggingface
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestDoChat(t *testing.T) {
+	t.Run("successful response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Verify request
+			if r.Method != http.MethodPost {
+				t.Errorf("Method = %q, want POST", r.Method)
+			}
+			if r.URL.Path != "/v1/chat/completions" {
+				t.Errorf("Path = %q, want /v1/chat/completions", r.URL.Path)
+			}
+			if r.Header.Get("Authorization") != "Bearer test-key" {
+				t.Errorf("Authorization = %q, want Bearer test-key", r.Header.Get("Authorization"))
+			}
+			if r.Header.Get("Content-Type") != "application/json" {
+				t.Errorf("Content-Type = %q, want application/json", r.Header.Get("Content-Type"))
+			}
+
+			// Verify request body
+			body, _ := io.ReadAll(r.Body)
+			var req hfRequest
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("Failed to unmarshal request: %v", err)
+			}
+			if req.Model != "meta-llama/Llama-3-8B-Instruct" {
+				t.Errorf("Model = %q, want %q", req.Model, "meta-llama/Llama-3-8B-Instruct")
+			}
+			if req.Stream {
+				t.Error("Stream should be false")
+			}
+
+			// Write response
+			w.Header().Set("x-request-id", "req-123")
+			json.NewEncoder(w).Encode(hfResponse{
+				ID:    "resp-456",
+				Model: "meta-llama/Llama-3-8B-Instruct",
+				Choices: []hfChoice{
+					{
+						Index:        0,
+						Message:      hfRespMsg{Role: "assistant", Content: "Hello!"},
+						FinishReason: "stop",
+					},
+				},
+				Usage: hfUsage{
+					PromptTokens:     10,
+					CompletionTokens: 5,
+					TotalTokens:      15,
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL))
+		resp, err := p.doChat(context.Background(), &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if err != nil {
+			t.Fatalf("doChat() error = %v", err)
+		}
+
+		if resp.ID != "resp-456" {
+			t.Errorf("ID = %q, want %q", resp.ID, "resp-456")
+		}
+		if resp.Model != "meta-llama/Llama-3-8B-Instruct" {
+			t.Errorf("Model = %q, want %q", resp.Model, "meta-llama/Llama-3-8B-Instruct")
+		}
+		if resp.Output != "Hello!" {
+			t.Errorf("Output = %q, want %q", resp.Output, "Hello!")
+		}
+		if resp.Usage.TotalTokens != 15 {
+			t.Errorf("TotalTokens = %d, want 15", resp.Usage.TotalTokens)
+		}
+	})
+
+	t.Run("with tool calls", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(hfResponse{
+				ID:    "resp-789",
+				Model: "meta-llama/Llama-3-8B-Instruct",
+				Choices: []hfChoice{
+					{
+						Index: 0,
+						Message: hfRespMsg{
+							Role:    "assistant",
+							Content: "",
+							ToolCalls: []hfToolCall{
+								{
+									ID:   "call_1",
+									Type: "function",
+									Function: hfFunctionCall{
+										Name:      "get_weather",
+										Arguments: `{"city":"Tokyo"}`,
+									},
+								},
+							},
+						},
+						FinishReason: "tool_calls",
+					},
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL))
+		resp, err := p.doChat(context.Background(), &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "What's the weather?"}},
+		})
+
+		if err != nil {
+			t.Fatalf("doChat() error = %v", err)
+		}
+
+		if len(resp.ToolCalls) != 1 {
+			t.Fatalf("ToolCalls count = %d, want 1", len(resp.ToolCalls))
+		}
+		if resp.ToolCalls[0].Name != "get_weather" {
+			t.Errorf("ToolCall.Name = %q, want %q", resp.ToolCalls[0].Name, "get_weather")
+		}
+	})
+
+	t.Run("error response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("x-request-id", "req-err")
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]string{
+					"message": "Invalid API key",
+					"type":    "authentication_error",
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("bad-key", WithBaseURL(server.URL))
+		_, err := p.doChat(context.Background(), &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if err == nil {
+			t.Fatal("doChat() should return error")
+		}
+
+		var provErr *core.ProviderError
+		if !errors.As(err, &provErr) {
+			t.Fatal("err should be *core.ProviderError")
+		}
+
+		if provErr.Status != http.StatusUnauthorized {
+			t.Errorf("Status = %d, want %d", provErr.Status, http.StatusUnauthorized)
+		}
+		if provErr.RequestID != "req-err" {
+			t.Errorf("RequestID = %q, want %q", provErr.RequestID, "req-err")
+		}
+		if !errors.Is(err, core.ErrUnauthorized) {
+			t.Error("err should wrap core.ErrUnauthorized")
+		}
+	})
+
+	t.Run("rate limited", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTooManyRequests)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]string{
+					"message": "Rate limit exceeded",
+					"type":    "rate_limit_error",
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL))
+		_, err := p.doChat(context.Background(), &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if !errors.Is(err, core.ErrRateLimited) {
+			t.Error("err should wrap core.ErrRateLimited")
+		}
+	})
+
+	t.Run("invalid response JSON", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{invalid json`))
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL))
+		_, err := p.doChat(context.Background(), &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if !errors.Is(err, core.ErrDecode) {
+			t.Error("err should wrap core.ErrDecode")
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		p := New("test-key", WithBaseURL("http://localhost:0"))
+		_, err := p.doChat(context.Background(), &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if !errors.Is(err, core.ErrNetwork) {
+			t.Error("err should wrap core.ErrNetwork")
+		}
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		}))
+		defer server.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		p := New("test-key", WithBaseURL(server.URL))
+		_, err := p.doChat(ctx, &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if err == nil {
+			t.Fatal("doChat() should return error on cancelled context")
+		}
+	})
+}
+
+func TestBuildModelString(t *testing.T) {
+	tests := []struct {
+		name           string
+		model          core.ModelID
+		providerPolicy string
+		want           string
+	}{
+		{
+			name:           "no policy",
+			model:          "meta-llama/Llama-3-8B-Instruct",
+			providerPolicy: "",
+			want:           "meta-llama/Llama-3-8B-Instruct",
+		},
+		{
+			name:           "auto policy (default)",
+			model:          "meta-llama/Llama-3-8B-Instruct",
+			providerPolicy: PolicyAuto,
+			want:           "meta-llama/Llama-3-8B-Instruct",
+		},
+		{
+			name:           "fastest policy",
+			model:          "meta-llama/Llama-3-8B-Instruct",
+			providerPolicy: PolicyFastest,
+			want:           "meta-llama/Llama-3-8B-Instruct:fastest",
+		},
+		{
+			name:           "cheapest policy",
+			model:          "meta-llama/Llama-3-8B-Instruct",
+			providerPolicy: PolicyCheapest,
+			want:           "meta-llama/Llama-3-8B-Instruct:cheapest",
+		},
+		{
+			name:           "specific provider",
+			model:          "meta-llama/Llama-3-8B-Instruct",
+			providerPolicy: "cerebras",
+			want:           "meta-llama/Llama-3-8B-Instruct:cerebras",
+		},
+		{
+			name:           "model already has suffix",
+			model:          "meta-llama/Llama-3-8B-Instruct:together",
+			providerPolicy: PolicyFastest,
+			want:           "meta-llama/Llama-3-8B-Instruct:together",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opts []Option
+			if tt.providerPolicy != "" {
+				opts = append(opts, WithProviderPolicy(tt.providerPolicy))
+			}
+			p := New("test-key", opts...)
+
+			got := p.buildModelString(tt.model)
+			if got != tt.want {
+				t.Errorf("buildModelString(%q) = %q, want %q", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestChatURL(t *testing.T) {
+	p := New("test-key")
+	expected := DefaultBaseURL + "/v1/chat/completions"
+	if got := p.chatURL(); got != expected {
+		t.Errorf("chatURL() = %q, want %q", got, expected)
+	}
+
+	p = New("test-key", WithBaseURL("https://custom.api.co"))
+	expected = "https://custom.api.co/v1/chat/completions"
+	if got := p.chatURL(); got != expected {
+		t.Errorf("chatURL() = %q, want %q", got, expected)
+	}
+}
+
+func TestChatCompletionsPath(t *testing.T) {
+	if chatCompletionsPath != "/v1/chat/completions" {
+		t.Errorf("chatCompletionsPath = %q, want %q", chatCompletionsPath, "/v1/chat/completions")
+	}
+}

--- a/providers/huggingface/discovery.go
+++ b/providers/huggingface/discovery.go
@@ -85,7 +85,7 @@ type hubInferenceProviderInfo struct {
 
 // hubAPIURL constructs a URL for the Hub API.
 func (p *HuggingFace) hubAPIURL(path string) string {
-	return HubAPIBaseURL + path
+	return p.config.HubAPIBaseURL + path
 }
 
 // GetModelStatus checks if a model has available inference providers.

--- a/providers/huggingface/discovery_test.go
+++ b/providers/huggingface/discovery_test.go
@@ -1,0 +1,512 @@
+package huggingface
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestGetModelStatus(t *testing.T) {
+	t.Run("warm status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				t.Errorf("Method = %q, want GET", r.Method)
+			}
+			if r.URL.Path != "/api/models/meta-llama/Llama-3-8B-Instruct" {
+				t.Errorf("Path = %q, want /api/models/meta-llama/Llama-3-8B-Instruct", r.URL.Path)
+			}
+			if r.URL.Query().Get("expand") != "inference" {
+				t.Errorf("expand param = %q, want inference", r.URL.Query().Get("expand"))
+			}
+			if r.Header.Get("Authorization") != "Bearer test-key" {
+				t.Errorf("Authorization = %q, want Bearer test-key", r.Header.Get("Authorization"))
+			}
+
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":        "meta-llama/Llama-3-8B-Instruct",
+				"inference": "warm",
+			})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		status, err := p.GetModelStatus(context.Background(), "meta-llama/Llama-3-8B-Instruct")
+
+		if err != nil {
+			t.Fatalf("GetModelStatus() error = %v", err)
+		}
+		if status != ModelStatusWarm {
+			t.Errorf("status = %v, want %v", status, ModelStatusWarm)
+		}
+	})
+
+	t.Run("unknown status", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":        "some/model",
+				"inference": "",
+			})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		status, err := p.GetModelStatus(context.Background(), "some/model")
+
+		if err != nil {
+			t.Fatalf("GetModelStatus() error = %v", err)
+		}
+		if status != ModelStatusUnknown {
+			t.Errorf("status = %v, want %v", status, ModelStatusUnknown)
+		}
+	})
+
+	t.Run("model not found", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]string{
+					"message": "Model not found",
+					"type":    "not_found_error",
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		_, err := p.GetModelStatus(context.Background(), "invalid/model")
+
+		if err == nil {
+			t.Fatal("GetModelStatus() should return error for 404")
+		}
+
+		var provErr *core.ProviderError
+		if !errors.As(err, &provErr) {
+			t.Fatal("err should be *core.ProviderError")
+		}
+		if provErr.Status != http.StatusNotFound {
+			t.Errorf("Status = %d, want %d", provErr.Status, http.StatusNotFound)
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		p := New("test-key", WithBaseURL("http://localhost:0"), WithHubAPIBaseURL("http://localhost:0/api"))
+		_, err := p.GetModelStatus(context.Background(), "some/model")
+
+		if !errors.Is(err, core.ErrNetwork) {
+			t.Error("err should wrap core.ErrNetwork")
+		}
+	})
+
+	t.Run("invalid JSON response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{invalid json`))
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		_, err := p.GetModelStatus(context.Background(), "some/model")
+
+		if !errors.Is(err, core.ErrDecode) {
+			t.Error("err should wrap core.ErrDecode")
+		}
+	})
+
+	t.Run("without API key", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "" {
+				t.Error("Authorization header should be empty")
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":        "public/model",
+				"inference": "warm",
+			})
+		}))
+		defer server.Close()
+
+		p := New("", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		status, err := p.GetModelStatus(context.Background(), "public/model")
+
+		if err != nil {
+			t.Fatalf("GetModelStatus() error = %v", err)
+		}
+		if status != ModelStatusWarm {
+			t.Errorf("status = %v, want %v", status, ModelStatusWarm)
+		}
+	})
+}
+
+func TestGetModelProviders(t *testing.T) {
+	t.Run("with providers", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("expand") != "inferenceProviderMapping" {
+				t.Errorf("expand param = %q, want inferenceProviderMapping", r.URL.Query().Get("expand"))
+			}
+
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":        "meta-llama/Llama-3-8B-Instruct",
+				"inference": "warm",
+				"inferenceProviderMapping": map[string]any{
+					"cerebras": map[string]any{
+						"status":     "live",
+						"providerId": "llama-3-8b",
+						"task":       "conversational",
+					},
+					"together": map[string]any{
+						"status":     "staging",
+						"providerId": "meta-llama/Llama-3-8B-Instruct",
+						"task":       "text-generation",
+					},
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		providers, err := p.GetModelProviders(context.Background(), "meta-llama/Llama-3-8B-Instruct")
+
+		if err != nil {
+			t.Fatalf("GetModelProviders() error = %v", err)
+		}
+		if len(providers) != 2 {
+			t.Fatalf("providers count = %d, want 2", len(providers))
+		}
+
+		// Find cerebras provider
+		var cerebras *InferenceProvider
+		for i := range providers {
+			if providers[i].Name == "cerebras" {
+				cerebras = &providers[i]
+				break
+			}
+		}
+
+		if cerebras == nil {
+			t.Fatal("cerebras provider not found")
+		}
+		if cerebras.Status != "live" {
+			t.Errorf("cerebras.Status = %q, want %q", cerebras.Status, "live")
+		}
+		if cerebras.ProviderID != "llama-3-8b" {
+			t.Errorf("cerebras.ProviderID = %q, want %q", cerebras.ProviderID, "llama-3-8b")
+		}
+		if cerebras.Task != "conversational" {
+			t.Errorf("cerebras.Task = %q, want %q", cerebras.Task, "conversational")
+		}
+	})
+
+	t.Run("empty providers", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(map[string]any{
+				"id":                       "some/model",
+				"inference":                "",
+				"inferenceProviderMapping": map[string]any{},
+			})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		providers, err := p.GetModelProviders(context.Background(), "some/model")
+
+		if err != nil {
+			t.Fatalf("GetModelProviders() error = %v", err)
+		}
+		if len(providers) != 0 {
+			t.Errorf("providers count = %d, want 0", len(providers))
+		}
+	})
+
+	t.Run("error response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]string{
+					"message": "Invalid token",
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("bad-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		_, err := p.GetModelProviders(context.Background(), "some/model")
+
+		if !errors.Is(err, core.ErrUnauthorized) {
+			t.Error("err should wrap core.ErrUnauthorized")
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		p := New("test-key", WithBaseURL("http://localhost:0"), WithHubAPIBaseURL("http://localhost:0/api"))
+		_, err := p.GetModelProviders(context.Background(), "some/model")
+
+		if !errors.Is(err, core.ErrNetwork) {
+			t.Error("err should wrap core.ErrNetwork")
+		}
+	})
+
+	t.Run("invalid JSON response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`not json`))
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		_, err := p.GetModelProviders(context.Background(), "some/model")
+
+		if !errors.Is(err, core.ErrDecode) {
+			t.Error("err should wrap core.ErrDecode")
+		}
+	})
+}
+
+func TestListModels(t *testing.T) {
+	t.Run("basic list", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				t.Errorf("Method = %q, want GET", r.Method)
+			}
+			if r.URL.Path != "/api/models" {
+				t.Errorf("Path = %q, want /api/models", r.URL.Path)
+			}
+
+			json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"id":           "meta-llama/Llama-3-8B-Instruct",
+					"pipeline_tag": "text-generation",
+					"inference":    "warm",
+				},
+				{
+					"id":           "google/gemma-2-2b-it",
+					"pipeline_tag": "text-generation",
+					"inference":    "warm",
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		models, err := p.ListModels(context.Background(), ListModelsOptions{})
+
+		if err != nil {
+			t.Fatalf("ListModels() error = %v", err)
+		}
+		if len(models) != 2 {
+			t.Fatalf("models count = %d, want 2", len(models))
+		}
+		if models[0].ID != "meta-llama/Llama-3-8B-Instruct" {
+			t.Errorf("models[0].ID = %q, want %q", models[0].ID, "meta-llama/Llama-3-8B-Instruct")
+		}
+		if models[0].PipelineTag != "text-generation" {
+			t.Errorf("models[0].PipelineTag = %q, want %q", models[0].PipelineTag, "text-generation")
+		}
+		if models[0].Inference != "warm" {
+			t.Errorf("models[0].Inference = %q, want %q", models[0].Inference, "warm")
+		}
+	})
+
+	t.Run("with provider filter", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("inference_provider") != "cerebras" {
+				t.Errorf("inference_provider param = %q, want cerebras", r.URL.Query().Get("inference_provider"))
+			}
+			json.NewEncoder(w).Encode([]map[string]any{})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		_, err := p.ListModels(context.Background(), ListModelsOptions{
+			Provider: "cerebras",
+		})
+
+		if err != nil {
+			t.Fatalf("ListModels() error = %v", err)
+		}
+	})
+
+	t.Run("with pipeline tag filter", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("pipeline_tag") != "text-generation" {
+				t.Errorf("pipeline_tag param = %q, want text-generation", r.URL.Query().Get("pipeline_tag"))
+			}
+			json.NewEncoder(w).Encode([]map[string]any{})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		_, err := p.ListModels(context.Background(), ListModelsOptions{
+			PipelineTag: "text-generation",
+		})
+
+		if err != nil {
+			t.Fatalf("ListModels() error = %v", err)
+		}
+	})
+
+	t.Run("with limit", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Query().Get("limit") != "10" {
+				t.Errorf("limit param = %q, want 10", r.URL.Query().Get("limit"))
+			}
+			json.NewEncoder(w).Encode([]map[string]any{})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		_, err := p.ListModels(context.Background(), ListModelsOptions{
+			Limit: 10,
+		})
+
+		if err != nil {
+			t.Fatalf("ListModels() error = %v", err)
+		}
+	})
+
+	t.Run("with all options", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			query := r.URL.Query()
+			if query.Get("inference_provider") != "all" {
+				t.Errorf("inference_provider = %q, want all", query.Get("inference_provider"))
+			}
+			if query.Get("pipeline_tag") != "text-generation" {
+				t.Errorf("pipeline_tag = %q, want text-generation", query.Get("pipeline_tag"))
+			}
+			if query.Get("limit") != "50" {
+				t.Errorf("limit = %q, want 50", query.Get("limit"))
+			}
+			json.NewEncoder(w).Encode([]map[string]any{})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		_, err := p.ListModels(context.Background(), ListModelsOptions{
+			Provider:    "all",
+			PipelineTag: "text-generation",
+			Limit:       50,
+		})
+
+		if err != nil {
+			t.Fatalf("ListModels() error = %v", err)
+		}
+	})
+
+	t.Run("error response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]string{
+					"message": "Internal error",
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		_, err := p.ListModels(context.Background(), ListModelsOptions{})
+
+		if !errors.Is(err, core.ErrServer) {
+			t.Error("err should wrap core.ErrServer")
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		p := New("test-key", WithBaseURL("http://localhost:0"), WithHubAPIBaseURL("http://localhost:0/api"))
+		_, err := p.ListModels(context.Background(), ListModelsOptions{})
+
+		if !errors.Is(err, core.ErrNetwork) {
+			t.Error("err should wrap core.ErrNetwork")
+		}
+	})
+
+	t.Run("invalid JSON response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{not valid`))
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL), WithHubAPIBaseURL(server.URL+"/api"))
+		_, err := p.ListModels(context.Background(), ListModelsOptions{})
+
+		if !errors.Is(err, core.ErrDecode) {
+			t.Error("err should wrap core.ErrDecode")
+		}
+	})
+}
+
+func TestModelStatusString(t *testing.T) {
+	tests := []struct {
+		status ModelStatus
+		want   string
+	}{
+		{ModelStatusWarm, "warm"},
+		{ModelStatusUnknown, "unknown"},
+		{ModelStatus(""), "unknown"},
+		{ModelStatus("other"), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.status), func(t *testing.T) {
+			if got := tt.status.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInferenceProviderString(t *testing.T) {
+	p := InferenceProvider{
+		Name:       "cerebras",
+		Status:     "live",
+		Task:       "conversational",
+		ProviderID: "llama-3-8b",
+	}
+
+	expected := "cerebras (live, conversational)"
+	if got := p.String(); got != expected {
+		t.Errorf("String() = %q, want %q", got, expected)
+	}
+}
+
+func TestInferenceProviderIsLive(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		want   bool
+	}{
+		{"live lowercase", "live", true},
+		{"live uppercase", "LIVE", true},
+		{"live mixed", "Live", true},
+		{"staging", "staging", false},
+		{"empty", "", false},
+		{"other", "other", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := InferenceProvider{Status: tt.status}
+			if got := p.IsLive(); got != tt.want {
+				t.Errorf("IsLive() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHubAPIURL(t *testing.T) {
+	p := New("test-key")
+
+	expected := HubAPIBaseURL + "/models/test"
+	if got := p.hubAPIURL("/models/test"); got != expected {
+		t.Errorf("hubAPIURL() = %q, want %q", got, expected)
+	}
+
+	// Test with custom Hub API URL
+	customURL := "https://custom.huggingface.co/api"
+	p2 := New("test-key", WithHubAPIBaseURL(customURL))
+	expected2 := customURL + "/models/test"
+	if got := p2.hubAPIURL("/models/test"); got != expected2 {
+		t.Errorf("hubAPIURL() with custom = %q, want %q", got, expected2)
+	}
+}

--- a/providers/huggingface/errors_test.go
+++ b/providers/huggingface/errors_test.go
@@ -1,0 +1,188 @@
+package huggingface
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestNormalizeError(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       int
+		body         []byte
+		requestID    string
+		wantCode     string
+		wantMsg      string
+		wantSentinel error
+	}{
+		{
+			name:         "bad request",
+			status:       http.StatusBadRequest,
+			body:         []byte(`{"error":{"message":"Invalid model","type":"invalid_request_error","code":"invalid_model"}}`),
+			requestID:    "req-123",
+			wantCode:     "invalid_model",
+			wantMsg:      "Invalid model",
+			wantSentinel: core.ErrBadRequest,
+		},
+		{
+			name:         "unauthorized",
+			status:       http.StatusUnauthorized,
+			body:         []byte(`{"error":{"message":"Invalid API key","type":"authentication_error"}}`),
+			requestID:    "req-456",
+			wantCode:     "authentication_error",
+			wantMsg:      "Invalid API key",
+			wantSentinel: core.ErrUnauthorized,
+		},
+		{
+			name:         "forbidden",
+			status:       http.StatusForbidden,
+			body:         []byte(`{"error":{"message":"Access denied","type":"permission_error"}}`),
+			requestID:    "",
+			wantCode:     "permission_error",
+			wantMsg:      "Access denied",
+			wantSentinel: core.ErrUnauthorized,
+		},
+		{
+			name:         "rate limited",
+			status:       http.StatusTooManyRequests,
+			body:         []byte(`{"error":{"message":"Rate limit exceeded","type":"rate_limit_error","code":"rate_limit"}}`),
+			requestID:    "req-789",
+			wantCode:     "rate_limit",
+			wantMsg:      "Rate limit exceeded",
+			wantSentinel: core.ErrRateLimited,
+		},
+		{
+			name:         "server error",
+			status:       http.StatusInternalServerError,
+			body:         []byte(`{"error":{"message":"Internal error","type":"server_error"}}`),
+			requestID:    "req-abc",
+			wantCode:     "server_error",
+			wantMsg:      "Internal error",
+			wantSentinel: core.ErrServer,
+		},
+		{
+			name:         "bad gateway",
+			status:       http.StatusBadGateway,
+			body:         []byte(`{}`),
+			requestID:    "",
+			wantCode:     "",
+			wantMsg:      "Bad Gateway",
+			wantSentinel: core.ErrServer,
+		},
+		{
+			name:         "invalid JSON body",
+			status:       http.StatusBadRequest,
+			body:         []byte(`not json`),
+			requestID:    "req-def",
+			wantCode:     "",
+			wantMsg:      "Bad Request",
+			wantSentinel: core.ErrBadRequest,
+		},
+		{
+			name:         "empty body",
+			status:       http.StatusServiceUnavailable,
+			body:         nil,
+			requestID:    "",
+			wantCode:     "",
+			wantMsg:      "Service Unavailable",
+			wantSentinel: core.ErrServer,
+		},
+		{
+			name:         "unknown 4xx status",
+			status:       418, // I'm a teapot
+			body:         []byte(`{}`),
+			requestID:    "",
+			wantCode:     "",
+			wantMsg:      "I'm a teapot",
+			wantSentinel: core.ErrServer,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := normalizeError(tt.status, tt.body, tt.requestID)
+
+			var provErr *core.ProviderError
+			if !errors.As(err, &provErr) {
+				t.Fatal("normalizeError() should return *core.ProviderError")
+			}
+
+			if provErr.Provider != "huggingface" {
+				t.Errorf("Provider = %q, want %q", provErr.Provider, "huggingface")
+			}
+
+			if provErr.Status != tt.status {
+				t.Errorf("Status = %d, want %d", provErr.Status, tt.status)
+			}
+
+			if provErr.RequestID != tt.requestID {
+				t.Errorf("RequestID = %q, want %q", provErr.RequestID, tt.requestID)
+			}
+
+			if provErr.Code != tt.wantCode {
+				t.Errorf("Code = %q, want %q", provErr.Code, tt.wantCode)
+			}
+
+			if provErr.Message != tt.wantMsg {
+				t.Errorf("Message = %q, want %q", provErr.Message, tt.wantMsg)
+			}
+
+			if !errors.Is(err, tt.wantSentinel) {
+				t.Errorf("err should wrap %v", tt.wantSentinel)
+			}
+		})
+	}
+}
+
+func TestNewNetworkError(t *testing.T) {
+	originalErr := errors.New("connection refused")
+	err := newNetworkError(originalErr)
+
+	var provErr *core.ProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatal("newNetworkError() should return *core.ProviderError")
+	}
+
+	if provErr.Provider != "huggingface" {
+		t.Errorf("Provider = %q, want %q", provErr.Provider, "huggingface")
+	}
+
+	if provErr.Message != "connection refused" {
+		t.Errorf("Message = %q, want %q", provErr.Message, "connection refused")
+	}
+
+	if !errors.Is(err, core.ErrNetwork) {
+		t.Error("err should wrap core.ErrNetwork")
+	}
+}
+
+func TestNewDecodeError(t *testing.T) {
+	originalErr := errors.New("unexpected EOF")
+	err := newDecodeError(originalErr)
+
+	var provErr *core.ProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatal("newDecodeError() should return *core.ProviderError")
+	}
+
+	if provErr.Provider != "huggingface" {
+		t.Errorf("Provider = %q, want %q", provErr.Provider, "huggingface")
+	}
+
+	if provErr.Message != "unexpected EOF" {
+		t.Errorf("Message = %q, want %q", provErr.Message, "unexpected EOF")
+	}
+
+	if !errors.Is(err, core.ErrDecode) {
+		t.Error("err should wrap core.ErrDecode")
+	}
+}
+
+func TestErrToolArgsInvalidJSON(t *testing.T) {
+	if ErrToolArgsInvalidJSON.Error() != "tool args invalid json" {
+		t.Errorf("ErrToolArgsInvalidJSON = %q, want %q", ErrToolArgsInvalidJSON.Error(), "tool args invalid json")
+	}
+}

--- a/providers/huggingface/mapping_test.go
+++ b/providers/huggingface/mapping_test.go
@@ -1,0 +1,376 @@
+package huggingface
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/tools"
+)
+
+func TestMapMessages(t *testing.T) {
+	msgs := []core.Message{
+		{Role: core.RoleSystem, Content: "You are a helpful assistant."},
+		{Role: core.RoleUser, Content: "Hello"},
+		{Role: core.RoleAssistant, Content: "Hi there!"},
+	}
+
+	result := mapMessages(msgs)
+
+	if len(result) != 3 {
+		t.Fatalf("mapMessages() returned %d messages, want 3", len(result))
+	}
+
+	tests := []struct {
+		index   int
+		role    string
+		content string
+	}{
+		{0, "system", "You are a helpful assistant."},
+		{1, "user", "Hello"},
+		{2, "assistant", "Hi there!"},
+	}
+
+	for _, tt := range tests {
+		if result[tt.index].Role != tt.role {
+			t.Errorf("result[%d].Role = %q, want %q", tt.index, result[tt.index].Role, tt.role)
+		}
+		if result[tt.index].Content != tt.content {
+			t.Errorf("result[%d].Content = %q, want %q", tt.index, result[tt.index].Content, tt.content)
+		}
+	}
+}
+
+func TestMapTools(t *testing.T) {
+	t.Run("empty tools", func(t *testing.T) {
+		result := mapTools(nil)
+		if result != nil {
+			t.Errorf("mapTools(nil) = %v, want nil", result)
+		}
+
+		result = mapTools([]core.Tool{})
+		if result != nil {
+			t.Errorf("mapTools([]) = %v, want nil", result)
+		}
+	})
+
+	t.Run("with tools", func(t *testing.T) {
+		toolsList := []core.Tool{
+			&mockTool{name: "get_weather", description: "Get weather for a city"},
+			&mockTool{name: "search", description: "Search the web"},
+		}
+
+		result := mapTools(toolsList)
+
+		if len(result) != 2 {
+			t.Fatalf("mapTools() returned %d tools, want 2", len(result))
+		}
+
+		if result[0].Type != "function" {
+			t.Errorf("result[0].Type = %q, want %q", result[0].Type, "function")
+		}
+		if result[0].Function.Name != "get_weather" {
+			t.Errorf("result[0].Function.Name = %q, want %q", result[0].Function.Name, "get_weather")
+		}
+		if result[0].Function.Description != "Get weather for a city" {
+			t.Errorf("result[0].Function.Description = %q, want %q", result[0].Function.Description, "Get weather for a city")
+		}
+
+		if result[1].Function.Name != "search" {
+			t.Errorf("result[1].Function.Name = %q, want %q", result[1].Function.Name, "search")
+		}
+	})
+
+	t.Run("with schema provider", func(t *testing.T) {
+		schema := json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`)
+		toolsList := []core.Tool{
+			&mockToolWithSchema{
+				name:        "get_weather",
+				description: "Get weather",
+				schema:      tools.ToolSchema{JSONSchema: schema},
+			},
+		}
+
+		result := mapTools(toolsList)
+
+		if len(result) != 1 {
+			t.Fatalf("mapTools() returned %d tools, want 1", len(result))
+		}
+
+		if string(result[0].Function.Parameters) != string(schema) {
+			t.Errorf("Parameters = %s, want %s", result[0].Function.Parameters, schema)
+		}
+	})
+}
+
+func TestBuildRequest(t *testing.T) {
+	t.Run("basic request", func(t *testing.T) {
+		req := &core.ChatRequest{
+			Model: "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{
+				{Role: core.RoleUser, Content: "Hello"},
+			},
+		}
+
+		result := buildRequest(req, "meta-llama/Llama-3-8B-Instruct", false)
+
+		if result.Model != "meta-llama/Llama-3-8B-Instruct" {
+			t.Errorf("Model = %q, want %q", result.Model, "meta-llama/Llama-3-8B-Instruct")
+		}
+		if result.Stream {
+			t.Error("Stream should be false")
+		}
+		if len(result.Messages) != 1 {
+			t.Fatalf("Messages count = %d, want 1", len(result.Messages))
+		}
+	})
+
+	t.Run("with stream", func(t *testing.T) {
+		req := &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hello"}},
+		}
+
+		result := buildRequest(req, "meta-llama/Llama-3-8B-Instruct", true)
+
+		if !result.Stream {
+			t.Error("Stream should be true")
+		}
+	})
+
+	t.Run("with temperature and max tokens", func(t *testing.T) {
+		temp := float32(0.7)
+		maxTokens := 100
+
+		req := &core.ChatRequest{
+			Model:       "meta-llama/Llama-3-8B-Instruct",
+			Messages:    []core.Message{{Role: core.RoleUser, Content: "Hello"}},
+			Temperature: &temp,
+			MaxTokens:   &maxTokens,
+		}
+
+		result := buildRequest(req, "meta-llama/Llama-3-8B-Instruct", false)
+
+		if result.Temperature == nil || *result.Temperature != 0.7 {
+			t.Errorf("Temperature = %v, want 0.7", result.Temperature)
+		}
+		if result.MaxTokens == nil || *result.MaxTokens != 100 {
+			t.Errorf("MaxTokens = %v, want 100", result.MaxTokens)
+		}
+	})
+
+	t.Run("with tools", func(t *testing.T) {
+		req := &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hello"}},
+			Tools: []core.Tool{
+				&mockTool{name: "test_tool", description: "A test tool"},
+			},
+		}
+
+		result := buildRequest(req, "meta-llama/Llama-3-8B-Instruct", false)
+
+		if len(result.Tools) != 1 {
+			t.Fatalf("Tools count = %d, want 1", len(result.Tools))
+		}
+		if result.ToolChoice != "auto" {
+			t.Errorf("ToolChoice = %q, want %q", result.ToolChoice, "auto")
+		}
+	})
+}
+
+func TestMapResponse(t *testing.T) {
+	t.Run("basic response", func(t *testing.T) {
+		resp := &hfResponse{
+			ID:    "resp-123",
+			Model: "meta-llama/Llama-3-8B-Instruct",
+			Choices: []hfChoice{
+				{
+					Index: 0,
+					Message: hfRespMsg{
+						Role:    "assistant",
+						Content: "Hello! How can I help you?",
+					},
+					FinishReason: "stop",
+				},
+			},
+			Usage: hfUsage{
+				PromptTokens:     10,
+				CompletionTokens: 20,
+				TotalTokens:      30,
+			},
+		}
+
+		result, err := mapResponse(resp)
+		if err != nil {
+			t.Fatalf("mapResponse() error = %v", err)
+		}
+
+		if result.ID != "resp-123" {
+			t.Errorf("ID = %q, want %q", result.ID, "resp-123")
+		}
+		if result.Model != "meta-llama/Llama-3-8B-Instruct" {
+			t.Errorf("Model = %q, want %q", result.Model, "meta-llama/Llama-3-8B-Instruct")
+		}
+		if result.Output != "Hello! How can I help you?" {
+			t.Errorf("Output = %q, want %q", result.Output, "Hello! How can I help you?")
+		}
+		if result.Usage.PromptTokens != 10 {
+			t.Errorf("PromptTokens = %d, want 10", result.Usage.PromptTokens)
+		}
+		if result.Usage.CompletionTokens != 20 {
+			t.Errorf("CompletionTokens = %d, want 20", result.Usage.CompletionTokens)
+		}
+		if result.Usage.TotalTokens != 30 {
+			t.Errorf("TotalTokens = %d, want 30", result.Usage.TotalTokens)
+		}
+	})
+
+	t.Run("with tool calls", func(t *testing.T) {
+		resp := &hfResponse{
+			ID:    "resp-456",
+			Model: "meta-llama/Llama-3-8B-Instruct",
+			Choices: []hfChoice{
+				{
+					Index: 0,
+					Message: hfRespMsg{
+						Role:    "assistant",
+						Content: "",
+						ToolCalls: []hfToolCall{
+							{
+								ID:   "call_1",
+								Type: "function",
+								Function: hfFunctionCall{
+									Name:      "get_weather",
+									Arguments: `{"city": "Tokyo"}`,
+								},
+							},
+						},
+					},
+					FinishReason: "tool_calls",
+				},
+			},
+		}
+
+		result, err := mapResponse(resp)
+		if err != nil {
+			t.Fatalf("mapResponse() error = %v", err)
+		}
+
+		if len(result.ToolCalls) != 1 {
+			t.Fatalf("ToolCalls count = %d, want 1", len(result.ToolCalls))
+		}
+		if result.ToolCalls[0].ID != "call_1" {
+			t.Errorf("ToolCall.ID = %q, want %q", result.ToolCalls[0].ID, "call_1")
+		}
+		if result.ToolCalls[0].Name != "get_weather" {
+			t.Errorf("ToolCall.Name = %q, want %q", result.ToolCalls[0].Name, "get_weather")
+		}
+	})
+
+	t.Run("empty choices", func(t *testing.T) {
+		resp := &hfResponse{
+			ID:      "resp-789",
+			Model:   "meta-llama/Llama-3-8B-Instruct",
+			Choices: []hfChoice{},
+		}
+
+		result, err := mapResponse(resp)
+		if err != nil {
+			t.Fatalf("mapResponse() error = %v", err)
+		}
+
+		if result.Output != "" {
+			t.Errorf("Output should be empty, got %q", result.Output)
+		}
+	})
+}
+
+func TestMapToolCalls(t *testing.T) {
+	t.Run("valid tool calls", func(t *testing.T) {
+		calls := []hfToolCall{
+			{
+				ID:   "call_1",
+				Type: "function",
+				Function: hfFunctionCall{
+					Name:      "get_weather",
+					Arguments: `{"city": "NYC"}`,
+				},
+			},
+			{
+				ID:   "call_2",
+				Type: "function",
+				Function: hfFunctionCall{
+					Name:      "search",
+					Arguments: `{"query": "news"}`,
+				},
+			},
+		}
+
+		result, err := mapToolCalls(calls)
+		if err != nil {
+			t.Fatalf("mapToolCalls() error = %v", err)
+		}
+
+		if len(result) != 2 {
+			t.Fatalf("Result length = %d, want 2", len(result))
+		}
+
+		if result[0].ID != "call_1" {
+			t.Errorf("result[0].ID = %q, want %q", result[0].ID, "call_1")
+		}
+		if result[0].Name != "get_weather" {
+			t.Errorf("result[0].Name = %q, want %q", result[0].Name, "get_weather")
+		}
+
+		// Verify arguments are valid JSON
+		var args map[string]string
+		if err := json.Unmarshal(result[0].Arguments, &args); err != nil {
+			t.Errorf("Failed to unmarshal arguments: %v", err)
+		}
+		if args["city"] != "NYC" {
+			t.Errorf("args[city] = %q, want %q", args["city"], "NYC")
+		}
+	})
+
+	t.Run("invalid JSON arguments", func(t *testing.T) {
+		calls := []hfToolCall{
+			{
+				ID:   "call_1",
+				Type: "function",
+				Function: hfFunctionCall{
+					Name:      "test",
+					Arguments: `{invalid json}`,
+				},
+			},
+		}
+
+		_, err := mapToolCalls(calls)
+		if err == nil {
+			t.Fatal("mapToolCalls() should return error for invalid JSON")
+		}
+		if err != ErrToolArgsInvalidJSON {
+			t.Errorf("err = %v, want ErrToolArgsInvalidJSON", err)
+		}
+	})
+}
+
+// mockTool is a simple tool implementation for testing.
+type mockTool struct {
+	name        string
+	description string
+}
+
+func (t *mockTool) Name() string        { return t.name }
+func (t *mockTool) Description() string { return t.description }
+
+// mockToolWithSchema is a tool that provides a schema.
+type mockToolWithSchema struct {
+	name        string
+	description string
+	schema      tools.ToolSchema
+}
+
+func (t *mockToolWithSchema) Name() string             { return t.name }
+func (t *mockToolWithSchema) Description() string      { return t.description }
+func (t *mockToolWithSchema) Schema() tools.ToolSchema { return t.schema }

--- a/providers/huggingface/options.go
+++ b/providers/huggingface/options.go
@@ -36,6 +36,10 @@ type Config struct {
 	// Defaults to https://router.huggingface.co
 	BaseURL string
 
+	// HubAPIBaseURL is the Hub API base URL for model discovery.
+	// Defaults to https://huggingface.co/api
+	HubAPIBaseURL string
+
 	// HTTPClient is the HTTP client to use. Defaults to http.DefaultClient.
 	HTTPClient *http.Client
 
@@ -93,5 +97,13 @@ func WithTimeout(d time.Duration) Option {
 func WithProviderPolicy(policy string) Option {
 	return func(c *Config) {
 		c.ProviderPolicy = policy
+	}
+}
+
+// WithHubAPIBaseURL sets the Hub API base URL for model discovery.
+// This is primarily useful for testing.
+func WithHubAPIBaseURL(url string) Option {
+	return func(c *Config) {
+		c.HubAPIBaseURL = url
 	}
 }

--- a/providers/huggingface/provider.go
+++ b/providers/huggingface/provider.go
@@ -49,9 +49,10 @@ type HuggingFace struct {
 // The API key should be a Hugging Face token with "Make calls to Inference Providers" permission.
 func New(apiKey string, opts ...Option) *HuggingFace {
 	cfg := Config{
-		APIKey:     core.NewSecret(apiKey),
-		BaseURL:    DefaultBaseURL,
-		HTTPClient: http.DefaultClient,
+		APIKey:        core.NewSecret(apiKey),
+		BaseURL:       DefaultBaseURL,
+		HubAPIBaseURL: HubAPIBaseURL,
+		HTTPClient:    http.DefaultClient,
 	}
 
 	for _, opt := range opts {

--- a/providers/huggingface/provider_test.go
+++ b/providers/huggingface/provider_test.go
@@ -1,0 +1,270 @@
+package huggingface
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestHuggingFaceImplementsProvider(t *testing.T) {
+	p := New("test-key")
+	var _ core.Provider = p
+}
+
+func TestNew(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		p := New("test-key")
+
+		if p.config.APIKey.Expose() != "test-key" {
+			t.Errorf("APIKey = %q, want %q", p.config.APIKey.Expose(), "test-key")
+		}
+		if p.config.BaseURL != DefaultBaseURL {
+			t.Errorf("BaseURL = %q, want %q", p.config.BaseURL, DefaultBaseURL)
+		}
+		if p.config.HTTPClient != http.DefaultClient {
+			t.Error("HTTPClient should be http.DefaultClient")
+		}
+	})
+
+	t.Run("with options", func(t *testing.T) {
+		client := &http.Client{Timeout: 30 * time.Second}
+
+		p := New("test-key",
+			WithBaseURL("https://custom.api.huggingface.co"),
+			WithHTTPClient(client),
+			WithHeader("X-Custom", "value"),
+			WithTimeout(60*time.Second),
+			WithProviderPolicy(PolicyFastest),
+		)
+
+		if p.config.BaseURL != "https://custom.api.huggingface.co" {
+			t.Errorf("BaseURL = %q, want %q", p.config.BaseURL, "https://custom.api.huggingface.co")
+		}
+		if p.config.HTTPClient != client {
+			t.Error("HTTPClient not set correctly")
+		}
+		if p.config.Headers.Get("X-Custom") != "value" {
+			t.Errorf("Headers[X-Custom] = %q, want %q", p.config.Headers.Get("X-Custom"), "value")
+		}
+		if p.config.Timeout != 60*time.Second {
+			t.Errorf("Timeout = %v, want %v", p.config.Timeout, 60*time.Second)
+		}
+		if p.config.ProviderPolicy != PolicyFastest {
+			t.Errorf("ProviderPolicy = %q, want %q", p.config.ProviderPolicy, PolicyFastest)
+		}
+	})
+}
+
+func TestID(t *testing.T) {
+	p := New("test-key")
+
+	if p.ID() != "huggingface" {
+		t.Errorf("ID() = %q, want %q", p.ID(), "huggingface")
+	}
+}
+
+func TestModels(t *testing.T) {
+	p := New("test-key")
+	models := p.Models()
+
+	// HuggingFace returns empty list since models are dynamic
+	if len(models) != 0 {
+		t.Errorf("Models() returned %d models, want 0 (dynamic models)", len(models))
+	}
+}
+
+func TestSupports(t *testing.T) {
+	p := New("test-key")
+
+	tests := []struct {
+		feature core.Feature
+		want    bool
+	}{
+		{core.FeatureChat, true},
+		{core.FeatureChatStreaming, true},
+		{core.FeatureToolCalling, true},
+		{core.FeatureReasoning, false},
+		{core.FeatureImageGeneration, false},
+		{core.FeatureEmbeddings, false},
+		{core.Feature("unknown"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.feature), func(t *testing.T) {
+			if got := p.Supports(tt.feature); got != tt.want {
+				t.Errorf("Supports(%q) = %v, want %v", tt.feature, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildHeaders(t *testing.T) {
+	t.Run("required headers", func(t *testing.T) {
+		p := New("hf-test-key-123")
+		headers := p.buildHeaders()
+
+		auth := headers.Get("Authorization")
+		if auth != "Bearer hf-test-key-123" {
+			t.Errorf("Authorization = %q, want %q", auth, "Bearer hf-test-key-123")
+		}
+
+		contentType := headers.Get("Content-Type")
+		if contentType != "application/json" {
+			t.Errorf("Content-Type = %q, want %q", contentType, "application/json")
+		}
+	})
+
+	t.Run("with custom headers", func(t *testing.T) {
+		p := New("test-key",
+			WithHeader("X-Custom-One", "value1"),
+			WithHeader("X-Custom-Two", "value2"),
+		)
+		headers := p.buildHeaders()
+
+		if headers.Get("X-Custom-One") != "value1" {
+			t.Errorf("X-Custom-One = %q, want %q", headers.Get("X-Custom-One"), "value1")
+		}
+
+		if headers.Get("X-Custom-Two") != "value2" {
+			t.Errorf("X-Custom-Two = %q, want %q", headers.Get("X-Custom-Two"), "value2")
+		}
+	})
+}
+
+func TestNewFromEnvSuccess(t *testing.T) {
+	// Test with HF_TOKEN
+	t.Run("HF_TOKEN", func(t *testing.T) {
+		originalHF := os.Getenv(HFTokenEnvVar)
+		originalHuggingFace := os.Getenv(HuggingFaceTokenEnvVar)
+		os.Setenv(HFTokenEnvVar, "hf-test-from-env-123")
+		os.Unsetenv(HuggingFaceTokenEnvVar)
+		defer func() {
+			if originalHF != "" {
+				os.Setenv(HFTokenEnvVar, originalHF)
+			} else {
+				os.Unsetenv(HFTokenEnvVar)
+			}
+			if originalHuggingFace != "" {
+				os.Setenv(HuggingFaceTokenEnvVar, originalHuggingFace)
+			}
+		}()
+
+		p, err := NewFromEnv()
+		if err != nil {
+			t.Fatalf("NewFromEnv() error = %v", err)
+		}
+
+		if p == nil {
+			t.Fatal("NewFromEnv() returned nil provider")
+		}
+
+		headers := p.buildHeaders()
+		auth := headers.Get("Authorization")
+		if auth != "Bearer hf-test-from-env-123" {
+			t.Errorf("Authorization = %q, want %q", auth, "Bearer hf-test-from-env-123")
+		}
+	})
+
+	// Test with HUGGINGFACE_TOKEN fallback
+	t.Run("HUGGINGFACE_TOKEN fallback", func(t *testing.T) {
+		originalHF := os.Getenv(HFTokenEnvVar)
+		originalHuggingFace := os.Getenv(HuggingFaceTokenEnvVar)
+		os.Unsetenv(HFTokenEnvVar)
+		os.Setenv(HuggingFaceTokenEnvVar, "hf-fallback-token")
+		defer func() {
+			if originalHF != "" {
+				os.Setenv(HFTokenEnvVar, originalHF)
+			}
+			if originalHuggingFace != "" {
+				os.Setenv(HuggingFaceTokenEnvVar, originalHuggingFace)
+			} else {
+				os.Unsetenv(HuggingFaceTokenEnvVar)
+			}
+		}()
+
+		p, err := NewFromEnv()
+		if err != nil {
+			t.Fatalf("NewFromEnv() error = %v", err)
+		}
+
+		headers := p.buildHeaders()
+		auth := headers.Get("Authorization")
+		if auth != "Bearer hf-fallback-token" {
+			t.Errorf("Authorization = %q, want %q", auth, "Bearer hf-fallback-token")
+		}
+	})
+}
+
+func TestNewFromEnvMissingKey(t *testing.T) {
+	originalHF := os.Getenv(HFTokenEnvVar)
+	originalHuggingFace := os.Getenv(HuggingFaceTokenEnvVar)
+	os.Unsetenv(HFTokenEnvVar)
+	os.Unsetenv(HuggingFaceTokenEnvVar)
+	defer func() {
+		if originalHF != "" {
+			os.Setenv(HFTokenEnvVar, originalHF)
+		}
+		if originalHuggingFace != "" {
+			os.Setenv(HuggingFaceTokenEnvVar, originalHuggingFace)
+		}
+	}()
+
+	_, err := NewFromEnv()
+	if err == nil {
+		t.Fatal("NewFromEnv() should return error when env var is not set")
+	}
+
+	if !errors.Is(err, ErrAPIKeyNotFound) {
+		t.Errorf("err = %v, want ErrAPIKeyNotFound", err)
+	}
+}
+
+func TestNewFromEnvWithOptions(t *testing.T) {
+	originalHF := os.Getenv(HFTokenEnvVar)
+	os.Setenv(HFTokenEnvVar, "hf-test-from-env-456")
+	defer func() {
+		if originalHF != "" {
+			os.Setenv(HFTokenEnvVar, originalHF)
+		} else {
+			os.Unsetenv(HFTokenEnvVar)
+		}
+	}()
+
+	customURL := "https://custom.huggingface.co"
+	p, err := NewFromEnv(WithBaseURL(customURL))
+	if err != nil {
+		t.Fatalf("NewFromEnv() error = %v", err)
+	}
+
+	if p.config.BaseURL != customURL {
+		t.Errorf("BaseURL = %q, want %q", p.config.BaseURL, customURL)
+	}
+}
+
+func TestProviderPolicyConstants(t *testing.T) {
+	if PolicyAuto != "auto" {
+		t.Errorf("PolicyAuto = %q, want %q", PolicyAuto, "auto")
+	}
+	if PolicyFastest != "fastest" {
+		t.Errorf("PolicyFastest = %q, want %q", PolicyFastest, "fastest")
+	}
+	if PolicyCheapest != "cheapest" {
+		t.Errorf("PolicyCheapest = %q, want %q", PolicyCheapest, "cheapest")
+	}
+}
+
+func TestDefaultBaseURL(t *testing.T) {
+	if DefaultBaseURL != "https://router.huggingface.co" {
+		t.Errorf("DefaultBaseURL = %q, want %q", DefaultBaseURL, "https://router.huggingface.co")
+	}
+}
+
+func TestHubAPIBaseURL(t *testing.T) {
+	if HubAPIBaseURL != "https://huggingface.co/api" {
+		t.Errorf("HubAPIBaseURL = %q, want %q", HubAPIBaseURL, "https://huggingface.co/api")
+	}
+}

--- a/providers/huggingface/streaming_test.go
+++ b/providers/huggingface/streaming_test.go
@@ -1,0 +1,446 @@
+package huggingface
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestToolCallAssembler(t *testing.T) {
+	t.Run("single tool call", func(t *testing.T) {
+		asm := newToolCallAssembler()
+
+		// Simulate streaming fragments
+		asm.addFragment(hfStreamToolCall{
+			Index: 0,
+			ID:    "call_1",
+			Function: hfStreamFunction{
+				Name: "get_weather",
+			},
+		})
+		asm.addFragment(hfStreamToolCall{
+			Index: 0,
+			Function: hfStreamFunction{
+				Arguments: `{"city":`,
+			},
+		})
+		asm.addFragment(hfStreamToolCall{
+			Index: 0,
+			Function: hfStreamFunction{
+				Arguments: `"Tokyo"}`,
+			},
+		})
+
+		calls, err := asm.finalize()
+		if err != nil {
+			t.Fatalf("finalize() error = %v", err)
+		}
+
+		if len(calls) != 1 {
+			t.Fatalf("calls count = %d, want 1", len(calls))
+		}
+
+		if calls[0].ID != "call_1" {
+			t.Errorf("ID = %q, want %q", calls[0].ID, "call_1")
+		}
+		if calls[0].Name != "get_weather" {
+			t.Errorf("Name = %q, want %q", calls[0].Name, "get_weather")
+		}
+
+		var args map[string]string
+		if err := json.Unmarshal(calls[0].Arguments, &args); err != nil {
+			t.Fatalf("Failed to unmarshal arguments: %v", err)
+		}
+		if args["city"] != "Tokyo" {
+			t.Errorf("args[city] = %q, want %q", args["city"], "Tokyo")
+		}
+	})
+
+	t.Run("multiple tool calls", func(t *testing.T) {
+		asm := newToolCallAssembler()
+
+		// Tool call 0
+		asm.addFragment(hfStreamToolCall{
+			Index: 0,
+			ID:    "call_1",
+			Function: hfStreamFunction{
+				Name:      "get_weather",
+				Arguments: `{"city":"NYC"}`,
+			},
+		})
+
+		// Tool call 1
+		asm.addFragment(hfStreamToolCall{
+			Index: 1,
+			ID:    "call_2",
+			Function: hfStreamFunction{
+				Name:      "search",
+				Arguments: `{"query":"news"}`,
+			},
+		})
+
+		calls, err := asm.finalize()
+		if err != nil {
+			t.Fatalf("finalize() error = %v", err)
+		}
+
+		if len(calls) != 2 {
+			t.Fatalf("calls count = %d, want 2", len(calls))
+		}
+
+		if calls[0].Name != "get_weather" {
+			t.Errorf("calls[0].Name = %q, want %q", calls[0].Name, "get_weather")
+		}
+		if calls[1].Name != "search" {
+			t.Errorf("calls[1].Name = %q, want %q", calls[1].Name, "search")
+		}
+	})
+
+	t.Run("empty assembler", func(t *testing.T) {
+		asm := newToolCallAssembler()
+		calls, err := asm.finalize()
+
+		if err != nil {
+			t.Fatalf("finalize() error = %v", err)
+		}
+		if calls != nil {
+			t.Errorf("calls should be nil, got %v", calls)
+		}
+	})
+
+	t.Run("invalid JSON arguments", func(t *testing.T) {
+		asm := newToolCallAssembler()
+
+		asm.addFragment(hfStreamToolCall{
+			Index: 0,
+			ID:    "call_1",
+			Function: hfStreamFunction{
+				Name:      "test",
+				Arguments: `{invalid`,
+			},
+		})
+
+		_, err := asm.finalize()
+		if err != ErrToolArgsInvalidJSON {
+			t.Errorf("finalize() error = %v, want ErrToolArgsInvalidJSON", err)
+		}
+	})
+
+	t.Run("sparse indices", func(t *testing.T) {
+		asm := newToolCallAssembler()
+
+		// Only index 0 and 2, no 1
+		asm.addFragment(hfStreamToolCall{
+			Index: 0,
+			ID:    "call_0",
+			Function: hfStreamFunction{
+				Name:      "func0",
+				Arguments: `{}`,
+			},
+		})
+		asm.addFragment(hfStreamToolCall{
+			Index: 2,
+			ID:    "call_2",
+			Function: hfStreamFunction{
+				Name:      "func2",
+				Arguments: `{}`,
+			},
+		})
+
+		calls, err := asm.finalize()
+		if err != nil {
+			t.Fatalf("finalize() error = %v", err)
+		}
+
+		if len(calls) != 2 {
+			t.Fatalf("calls count = %d, want 2", len(calls))
+		}
+	})
+}
+
+func TestDoStreamChat(t *testing.T) {
+	t.Run("successful stream", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("x-request-id", "stream-req-123")
+
+			// Send SSE events
+			chunks := []string{
+				`data: {"id":"resp-1","model":"meta-llama/Llama-3-8B-Instruct","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}]}`,
+				`data: {"id":"resp-1","model":"meta-llama/Llama-3-8B-Instruct","choices":[{"index":0,"delta":{"content":" world!"}}]}`,
+				`data: {"id":"resp-1","model":"meta-llama/Llama-3-8B-Instruct","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+				`data: [DONE]`,
+			}
+
+			for _, chunk := range chunks {
+				fmt.Fprintln(w, chunk)
+				fmt.Fprintln(w, "")
+			}
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL))
+		stream, err := p.doStreamChat(context.Background(), &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if err != nil {
+			t.Fatalf("doStreamChat() error = %v", err)
+		}
+
+		// Collect chunks
+		var content string
+		for chunk := range stream.Ch {
+			content += chunk.Delta
+		}
+
+		if content != "Hello world!" {
+			t.Errorf("content = %q, want %q", content, "Hello world!")
+		}
+
+		// Check final response
+		finalResp := <-stream.Final
+		if finalResp == nil {
+			t.Fatal("Final response should not be nil")
+		}
+		if finalResp.ID != "resp-1" {
+			t.Errorf("ID = %q, want %q", finalResp.ID, "resp-1")
+		}
+		if finalResp.Usage.TotalTokens != 15 {
+			t.Errorf("TotalTokens = %d, want 15", finalResp.Usage.TotalTokens)
+		}
+
+		// Check no errors
+		select {
+		case err := <-stream.Err:
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		default:
+		}
+	})
+
+	t.Run("stream with tool calls", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+
+			chunks := []string{
+				`data: {"id":"resp-2","model":"meta-llama/Llama-3-8B-Instruct","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather"}}]}}]}`,
+				`data: {"id":"resp-2","model":"meta-llama/Llama-3-8B-Instruct","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":"}}]}}]}`,
+				`data: {"id":"resp-2","model":"meta-llama/Llama-3-8B-Instruct","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"Tokyo\"}"}}]}}]}`,
+				`data: {"id":"resp-2","model":"meta-llama/Llama-3-8B-Instruct","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+				`data: [DONE]`,
+			}
+
+			for _, chunk := range chunks {
+				fmt.Fprintln(w, chunk)
+				fmt.Fprintln(w, "")
+			}
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL))
+		stream, err := p.doStreamChat(context.Background(), &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Weather?"}},
+		})
+
+		if err != nil {
+			t.Fatalf("doStreamChat() error = %v", err)
+		}
+
+		// Drain content channel
+		for range stream.Ch {
+		}
+
+		// Check final response has tool calls
+		finalResp := <-stream.Final
+		if finalResp == nil {
+			t.Fatal("Final response should not be nil")
+		}
+		if len(finalResp.ToolCalls) != 1 {
+			t.Fatalf("ToolCalls count = %d, want 1", len(finalResp.ToolCalls))
+		}
+		if finalResp.ToolCalls[0].Name != "get_weather" {
+			t.Errorf("ToolCall.Name = %q, want %q", finalResp.ToolCalls[0].Name, "get_weather")
+		}
+	})
+
+	t.Run("error response before stream", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("x-request-id", "err-req")
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]string{
+					"message": "Invalid key",
+					"type":    "auth_error",
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("bad-key", WithBaseURL(server.URL))
+		_, err := p.doStreamChat(context.Background(), &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if err == nil {
+			t.Fatal("doStreamChat() should return error")
+		}
+
+		var provErr *core.ProviderError
+		if !errors.As(err, &provErr) {
+			t.Fatal("err should be *core.ProviderError")
+		}
+		if provErr.Status != http.StatusUnauthorized {
+			t.Errorf("Status = %d, want %d", provErr.Status, http.StatusUnauthorized)
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		p := New("test-key", WithBaseURL("http://localhost:0"))
+		_, err := p.doStreamChat(context.Background(), &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if !errors.Is(err, core.ErrNetwork) {
+			t.Error("err should wrap core.ErrNetwork")
+		}
+	})
+
+	t.Run("skip empty lines and comments", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+
+			lines := []string{
+				"",            // empty line
+				":keep-alive", // comment
+				`data: {"id":"resp-3","model":"meta-llama/Llama-3-8B-Instruct","choices":[{"index":0,"delta":{"content":"Hi"}}]}`, // actual data
+				"",
+				`:another comment`,
+				`data: [DONE]`,
+			}
+
+			for _, line := range lines {
+				fmt.Fprintln(w, line)
+			}
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL))
+		stream, err := p.doStreamChat(context.Background(), &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if err != nil {
+			t.Fatalf("doStreamChat() error = %v", err)
+		}
+
+		var content string
+		for chunk := range stream.Ch {
+			content += chunk.Delta
+		}
+
+		if content != "Hi" {
+			t.Errorf("content = %q, want %q", content, "Hi")
+		}
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			<-r.Context().Done()
+		}))
+		defer server.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		p := New("test-key", WithBaseURL(server.URL))
+		_, err := p.doStreamChat(ctx, &core.ChatRequest{
+			Model:    "meta-llama/Llama-3-8B-Instruct",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if err == nil {
+			t.Fatal("doStreamChat() should return error on cancelled context")
+		}
+	})
+}
+
+func TestNewToolCallAssembler(t *testing.T) {
+	asm := newToolCallAssembler()
+	if asm == nil {
+		t.Fatal("newToolCallAssembler() returned nil")
+	}
+	if asm.calls == nil {
+		t.Fatal("newToolCallAssembler().calls should not be nil")
+	}
+}
+
+func TestStreamRequestHasStreamTrue(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req hfRequest
+		json.Unmarshal(body, &req)
+
+		if !req.Stream {
+			t.Error("Stream should be true for streaming request")
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintln(w, `data: [DONE]`)
+	}))
+	defer server.Close()
+
+	p := New("test-key", WithBaseURL(server.URL))
+	stream, _ := p.doStreamChat(context.Background(), &core.ChatRequest{
+		Model:    "meta-llama/Llama-3-8B-Instruct",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+	})
+
+	// Drain channels
+	for range stream.Ch {
+	}
+	<-stream.Final
+}
+
+func TestStreamWithProviderPolicy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req hfRequest
+		json.Unmarshal(body, &req)
+
+		// Model should have :fastest suffix
+		if !strings.HasSuffix(req.Model, ":fastest") {
+			t.Errorf("Model = %q, expected :fastest suffix", req.Model)
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprintln(w, `data: [DONE]`)
+	}))
+	defer server.Close()
+
+	p := New("test-key", WithBaseURL(server.URL), WithProviderPolicy(PolicyFastest))
+	stream, _ := p.doStreamChat(context.Background(), &core.ChatRequest{
+		Model:    "meta-llama/Llama-3-8B-Instruct",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+	})
+
+	// Drain channels
+	for range stream.Ch {
+	}
+	<-stream.Final
+}

--- a/providers/perplexity/client_test.go
+++ b/providers/perplexity/client_test.go
@@ -1,0 +1,254 @@
+package perplexity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestDoChat(t *testing.T) {
+	t.Run("successful response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Verify request
+			if r.Method != http.MethodPost {
+				t.Errorf("Method = %q, want POST", r.Method)
+			}
+			if r.URL.Path != "/chat/completions" {
+				t.Errorf("Path = %q, want /chat/completions", r.URL.Path)
+			}
+			if r.Header.Get("Authorization") != "Bearer test-key" {
+				t.Errorf("Authorization = %q, want Bearer test-key", r.Header.Get("Authorization"))
+			}
+			if r.Header.Get("Content-Type") != "application/json" {
+				t.Errorf("Content-Type = %q, want application/json", r.Header.Get("Content-Type"))
+			}
+
+			// Verify request body
+			body, _ := io.ReadAll(r.Body)
+			var req perplexityRequest
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("Failed to unmarshal request: %v", err)
+			}
+			if req.Model != "sonar" {
+				t.Errorf("Model = %q, want %q", req.Model, "sonar")
+			}
+			if req.Stream {
+				t.Error("Stream should be false")
+			}
+
+			// Write response
+			w.Header().Set("x-request-id", "req-123")
+			json.NewEncoder(w).Encode(perplexityResponse{
+				ID:    "resp-456",
+				Model: "sonar",
+				Choices: []perplexityChoice{
+					{
+						Index:        0,
+						Message:      &perplexityRespMsg{Role: "assistant", Content: "Hello!"},
+						FinishReason: "stop",
+					},
+				},
+				Usage: &perplexityUsage{
+					PromptTokens:     10,
+					CompletionTokens: 5,
+					TotalTokens:      15,
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL))
+		resp, err := p.doChat(context.Background(), &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if err != nil {
+			t.Fatalf("doChat() error = %v", err)
+		}
+
+		if resp.ID != "resp-456" {
+			t.Errorf("ID = %q, want %q", resp.ID, "resp-456")
+		}
+		if resp.Model != "sonar" {
+			t.Errorf("Model = %q, want %q", resp.Model, "sonar")
+		}
+		if resp.Output != "Hello!" {
+			t.Errorf("Output = %q, want %q", resp.Output, "Hello!")
+		}
+		if resp.Usage.TotalTokens != 15 {
+			t.Errorf("TotalTokens = %d, want 15", resp.Usage.TotalTokens)
+		}
+	})
+
+	t.Run("with tool calls", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(perplexityResponse{
+				ID:    "resp-789",
+				Model: "sonar",
+				Choices: []perplexityChoice{
+					{
+						Index: 0,
+						Message: &perplexityRespMsg{
+							Role:    "assistant",
+							Content: "",
+							ToolCalls: []perplexityToolCall{
+								{
+									ID:   "call_1",
+									Type: "function",
+									Function: perplexityFunctionCall{
+										Name:      "get_weather",
+										Arguments: `{"city":"Tokyo"}`,
+									},
+								},
+							},
+						},
+						FinishReason: "tool_calls",
+					},
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL))
+		resp, err := p.doChat(context.Background(), &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "What's the weather?"}},
+		})
+
+		if err != nil {
+			t.Fatalf("doChat() error = %v", err)
+		}
+
+		if len(resp.ToolCalls) != 1 {
+			t.Fatalf("ToolCalls count = %d, want 1", len(resp.ToolCalls))
+		}
+		if resp.ToolCalls[0].Name != "get_weather" {
+			t.Errorf("ToolCall.Name = %q, want %q", resp.ToolCalls[0].Name, "get_weather")
+		}
+	})
+
+	t.Run("error response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("x-request-id", "req-err")
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]string{
+					"message": "Invalid API key",
+					"type":    "authentication_error",
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("bad-key", WithBaseURL(server.URL))
+		_, err := p.doChat(context.Background(), &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if err == nil {
+			t.Fatal("doChat() should return error")
+		}
+
+		var provErr *core.ProviderError
+		if !errors.As(err, &provErr) {
+			t.Fatal("err should be *core.ProviderError")
+		}
+
+		if provErr.Status != http.StatusUnauthorized {
+			t.Errorf("Status = %d, want %d", provErr.Status, http.StatusUnauthorized)
+		}
+		if provErr.RequestID != "req-err" {
+			t.Errorf("RequestID = %q, want %q", provErr.RequestID, "req-err")
+		}
+		if !errors.Is(err, core.ErrUnauthorized) {
+			t.Error("err should wrap core.ErrUnauthorized")
+		}
+	})
+
+	t.Run("rate limited", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTooManyRequests)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]string{
+					"message": "Rate limit exceeded",
+					"type":    "rate_limit_error",
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL))
+		_, err := p.doChat(context.Background(), &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if !errors.Is(err, core.ErrRateLimited) {
+			t.Error("err should wrap core.ErrRateLimited")
+		}
+	})
+
+	t.Run("invalid response JSON", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{invalid json`))
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL))
+		_, err := p.doChat(context.Background(), &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if !errors.Is(err, core.ErrDecode) {
+			t.Error("err should wrap core.ErrDecode")
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		p := New("test-key", WithBaseURL("http://localhost:0"))
+		_, err := p.doChat(context.Background(), &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if !errors.Is(err, core.ErrNetwork) {
+			t.Error("err should wrap core.ErrNetwork")
+		}
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Slow response - but we'll cancel before it completes
+			<-r.Context().Done()
+		}))
+		defer server.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		p := New("test-key", WithBaseURL(server.URL))
+		_, err := p.doChat(ctx, &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if err == nil {
+			t.Fatal("doChat() should return error on cancelled context")
+		}
+	})
+}
+
+func TestChatCompletionsPath(t *testing.T) {
+	if chatCompletionsPath != "/chat/completions" {
+		t.Errorf("chatCompletionsPath = %q, want %q", chatCompletionsPath, "/chat/completions")
+	}
+}

--- a/providers/perplexity/errors_test.go
+++ b/providers/perplexity/errors_test.go
@@ -1,0 +1,188 @@
+package perplexity
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestNormalizeError(t *testing.T) {
+	tests := []struct {
+		name         string
+		status       int
+		body         []byte
+		requestID    string
+		wantCode     string
+		wantMsg      string
+		wantSentinel error
+	}{
+		{
+			name:         "bad request",
+			status:       http.StatusBadRequest,
+			body:         []byte(`{"error":{"message":"Invalid model","type":"invalid_request_error","code":"invalid_model"}}`),
+			requestID:    "req-123",
+			wantCode:     "invalid_model",
+			wantMsg:      "Invalid model",
+			wantSentinel: core.ErrBadRequest,
+		},
+		{
+			name:         "unauthorized",
+			status:       http.StatusUnauthorized,
+			body:         []byte(`{"error":{"message":"Invalid API key","type":"authentication_error"}}`),
+			requestID:    "req-456",
+			wantCode:     "authentication_error",
+			wantMsg:      "Invalid API key",
+			wantSentinel: core.ErrUnauthorized,
+		},
+		{
+			name:         "forbidden",
+			status:       http.StatusForbidden,
+			body:         []byte(`{"error":{"message":"Access denied","type":"permission_error"}}`),
+			requestID:    "",
+			wantCode:     "permission_error",
+			wantMsg:      "Access denied",
+			wantSentinel: core.ErrUnauthorized,
+		},
+		{
+			name:         "rate limited",
+			status:       http.StatusTooManyRequests,
+			body:         []byte(`{"error":{"message":"Rate limit exceeded","type":"rate_limit_error","code":"rate_limit"}}`),
+			requestID:    "req-789",
+			wantCode:     "rate_limit",
+			wantMsg:      "Rate limit exceeded",
+			wantSentinel: core.ErrRateLimited,
+		},
+		{
+			name:         "server error",
+			status:       http.StatusInternalServerError,
+			body:         []byte(`{"error":{"message":"Internal error","type":"server_error"}}`),
+			requestID:    "req-abc",
+			wantCode:     "server_error",
+			wantMsg:      "Internal error",
+			wantSentinel: core.ErrServer,
+		},
+		{
+			name:         "bad gateway",
+			status:       http.StatusBadGateway,
+			body:         []byte(`{}`),
+			requestID:    "",
+			wantCode:     "",
+			wantMsg:      "Bad Gateway",
+			wantSentinel: core.ErrServer,
+		},
+		{
+			name:         "invalid JSON body",
+			status:       http.StatusBadRequest,
+			body:         []byte(`not json`),
+			requestID:    "req-def",
+			wantCode:     "",
+			wantMsg:      "Bad Request",
+			wantSentinel: core.ErrBadRequest,
+		},
+		{
+			name:         "empty body",
+			status:       http.StatusServiceUnavailable,
+			body:         nil,
+			requestID:    "",
+			wantCode:     "",
+			wantMsg:      "Service Unavailable",
+			wantSentinel: core.ErrServer,
+		},
+		{
+			name:         "unknown 4xx status",
+			status:       418, // I'm a teapot
+			body:         []byte(`{}`),
+			requestID:    "",
+			wantCode:     "",
+			wantMsg:      "I'm a teapot",
+			wantSentinel: core.ErrServer,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := normalizeError(tt.status, tt.body, tt.requestID)
+
+			var provErr *core.ProviderError
+			if !errors.As(err, &provErr) {
+				t.Fatal("normalizeError() should return *core.ProviderError")
+			}
+
+			if provErr.Provider != "perplexity" {
+				t.Errorf("Provider = %q, want %q", provErr.Provider, "perplexity")
+			}
+
+			if provErr.Status != tt.status {
+				t.Errorf("Status = %d, want %d", provErr.Status, tt.status)
+			}
+
+			if provErr.RequestID != tt.requestID {
+				t.Errorf("RequestID = %q, want %q", provErr.RequestID, tt.requestID)
+			}
+
+			if provErr.Code != tt.wantCode {
+				t.Errorf("Code = %q, want %q", provErr.Code, tt.wantCode)
+			}
+
+			if provErr.Message != tt.wantMsg {
+				t.Errorf("Message = %q, want %q", provErr.Message, tt.wantMsg)
+			}
+
+			if !errors.Is(err, tt.wantSentinel) {
+				t.Errorf("err should wrap %v", tt.wantSentinel)
+			}
+		})
+	}
+}
+
+func TestNewNetworkError(t *testing.T) {
+	originalErr := errors.New("connection refused")
+	err := newNetworkError(originalErr)
+
+	var provErr *core.ProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatal("newNetworkError() should return *core.ProviderError")
+	}
+
+	if provErr.Provider != "perplexity" {
+		t.Errorf("Provider = %q, want %q", provErr.Provider, "perplexity")
+	}
+
+	if provErr.Message != "connection refused" {
+		t.Errorf("Message = %q, want %q", provErr.Message, "connection refused")
+	}
+
+	if !errors.Is(err, core.ErrNetwork) {
+		t.Error("err should wrap core.ErrNetwork")
+	}
+}
+
+func TestNewDecodeError(t *testing.T) {
+	originalErr := errors.New("unexpected EOF")
+	err := newDecodeError(originalErr)
+
+	var provErr *core.ProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatal("newDecodeError() should return *core.ProviderError")
+	}
+
+	if provErr.Provider != "perplexity" {
+		t.Errorf("Provider = %q, want %q", provErr.Provider, "perplexity")
+	}
+
+	if provErr.Message != "unexpected EOF" {
+		t.Errorf("Message = %q, want %q", provErr.Message, "unexpected EOF")
+	}
+
+	if !errors.Is(err, core.ErrDecode) {
+		t.Error("err should wrap core.ErrDecode")
+	}
+}
+
+func TestErrToolArgsInvalidJSON(t *testing.T) {
+	if ErrToolArgsInvalidJSON.Error() != "tool args invalid json" {
+		t.Errorf("ErrToolArgsInvalidJSON = %q, want %q", ErrToolArgsInvalidJSON.Error(), "tool args invalid json")
+	}
+}

--- a/providers/perplexity/mapping_test.go
+++ b/providers/perplexity/mapping_test.go
@@ -1,0 +1,414 @@
+package perplexity
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestMapMessages(t *testing.T) {
+	msgs := []core.Message{
+		{Role: core.RoleSystem, Content: "You are a helpful assistant."},
+		{Role: core.RoleUser, Content: "Hello"},
+		{Role: core.RoleAssistant, Content: "Hi there!"},
+	}
+
+	result := mapMessages(msgs)
+
+	if len(result) != 3 {
+		t.Fatalf("mapMessages() returned %d messages, want 3", len(result))
+	}
+
+	tests := []struct {
+		index   int
+		role    string
+		content string
+	}{
+		{0, "system", "You are a helpful assistant."},
+		{1, "user", "Hello"},
+		{2, "assistant", "Hi there!"},
+	}
+
+	for _, tt := range tests {
+		if result[tt.index].Role != tt.role {
+			t.Errorf("result[%d].Role = %q, want %q", tt.index, result[tt.index].Role, tt.role)
+		}
+		if result[tt.index].Content != tt.content {
+			t.Errorf("result[%d].Content = %q, want %q", tt.index, result[tt.index].Content, tt.content)
+		}
+	}
+}
+
+func TestMapTools(t *testing.T) {
+	t.Run("empty tools", func(t *testing.T) {
+		result := mapTools(nil)
+		if result != nil {
+			t.Errorf("mapTools(nil) = %v, want nil", result)
+		}
+
+		result = mapTools([]core.Tool{})
+		if result != nil {
+			t.Errorf("mapTools([]) = %v, want nil", result)
+		}
+	})
+
+	t.Run("with tools", func(t *testing.T) {
+		tools := []core.Tool{
+			&mockTool{name: "get_weather", description: "Get weather for a city"},
+			&mockTool{name: "search", description: "Search the web"},
+		}
+
+		result := mapTools(tools)
+
+		if len(result) != 2 {
+			t.Fatalf("mapTools() returned %d tools, want 2", len(result))
+		}
+
+		if result[0].Type != "function" {
+			t.Errorf("result[0].Type = %q, want %q", result[0].Type, "function")
+		}
+		if result[0].Function.Name != "get_weather" {
+			t.Errorf("result[0].Function.Name = %q, want %q", result[0].Function.Name, "get_weather")
+		}
+		if result[0].Function.Description != "Get weather for a city" {
+			t.Errorf("result[0].Function.Description = %q, want %q", result[0].Function.Description, "Get weather for a city")
+		}
+
+		if result[1].Function.Name != "search" {
+			t.Errorf("result[1].Function.Name = %q, want %q", result[1].Function.Name, "search")
+		}
+	})
+}
+
+func TestMapReasoningEffort(t *testing.T) {
+	tests := []struct {
+		effort core.ReasoningEffort
+		want   string
+	}{
+		{core.ReasoningEffortNone, ""},
+		{core.ReasoningEffortLow, "low"},
+		{core.ReasoningEffortMedium, "medium"},
+		{core.ReasoningEffortHigh, "high"},
+		{core.ReasoningEffortXHigh, "high"}, // maps to high
+		{core.ReasoningEffort("unknown"), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.effort), func(t *testing.T) {
+			got := mapReasoningEffort(tt.effort)
+			if got != tt.want {
+				t.Errorf("mapReasoningEffort(%q) = %q, want %q", tt.effort, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildRequest(t *testing.T) {
+	t.Run("basic request", func(t *testing.T) {
+		req := &core.ChatRequest{
+			Model: "sonar",
+			Messages: []core.Message{
+				{Role: core.RoleUser, Content: "Hello"},
+			},
+		}
+
+		result := buildRequest(req, false)
+
+		if result.Model != "sonar" {
+			t.Errorf("Model = %q, want %q", result.Model, "sonar")
+		}
+		if result.Stream {
+			t.Error("Stream should be false")
+		}
+		if len(result.Messages) != 1 {
+			t.Fatalf("Messages count = %d, want 1", len(result.Messages))
+		}
+	})
+
+	t.Run("with stream", func(t *testing.T) {
+		req := &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hello"}},
+		}
+
+		result := buildRequest(req, true)
+
+		if !result.Stream {
+			t.Error("Stream should be true")
+		}
+	})
+
+	t.Run("with temperature and max tokens", func(t *testing.T) {
+		temp := float32(0.7)
+		maxTokens := 100
+
+		req := &core.ChatRequest{
+			Model:       "sonar",
+			Messages:    []core.Message{{Role: core.RoleUser, Content: "Hello"}},
+			Temperature: &temp,
+			MaxTokens:   &maxTokens,
+		}
+
+		result := buildRequest(req, false)
+
+		if result.Temperature == nil || *result.Temperature != 0.7 {
+			t.Errorf("Temperature = %v, want 0.7", result.Temperature)
+		}
+		if result.MaxTokens == nil || *result.MaxTokens != 100 {
+			t.Errorf("MaxTokens = %v, want 100", result.MaxTokens)
+		}
+	})
+
+	t.Run("with tools", func(t *testing.T) {
+		req := &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hello"}},
+			Tools: []core.Tool{
+				&mockTool{name: "test_tool", description: "A test tool"},
+			},
+		}
+
+		result := buildRequest(req, false)
+
+		if len(result.Tools) != 1 {
+			t.Fatalf("Tools count = %d, want 1", len(result.Tools))
+		}
+		if result.ToolChoice != "auto" {
+			t.Errorf("ToolChoice = %q, want %q", result.ToolChoice, "auto")
+		}
+	})
+
+	t.Run("with reasoning effort", func(t *testing.T) {
+		req := &core.ChatRequest{
+			Model:           "sonar-reasoning-pro",
+			Messages:        []core.Message{{Role: core.RoleUser, Content: "Hello"}},
+			ReasoningEffort: core.ReasoningEffortHigh,
+		}
+
+		result := buildRequest(req, false)
+
+		if result.ReasoningEffort != "high" {
+			t.Errorf("ReasoningEffort = %q, want %q", result.ReasoningEffort, "high")
+		}
+	})
+
+	t.Run("reasoning effort none is omitted", func(t *testing.T) {
+		req := &core.ChatRequest{
+			Model:           "sonar",
+			Messages:        []core.Message{{Role: core.RoleUser, Content: "Hello"}},
+			ReasoningEffort: core.ReasoningEffortNone,
+		}
+
+		result := buildRequest(req, false)
+
+		if result.ReasoningEffort != "" {
+			t.Errorf("ReasoningEffort should be empty for None, got %q", result.ReasoningEffort)
+		}
+	})
+}
+
+func TestMapResponse(t *testing.T) {
+	t.Run("basic response", func(t *testing.T) {
+		resp := &perplexityResponse{
+			ID:    "resp-123",
+			Model: "sonar",
+			Choices: []perplexityChoice{
+				{
+					Index: 0,
+					Message: &perplexityRespMsg{
+						Role:    "assistant",
+						Content: "Hello! How can I help you?",
+					},
+					FinishReason: "stop",
+				},
+			},
+			Usage: &perplexityUsage{
+				PromptTokens:     10,
+				CompletionTokens: 20,
+				TotalTokens:      30,
+			},
+		}
+
+		result, err := mapResponse(resp)
+		if err != nil {
+			t.Fatalf("mapResponse() error = %v", err)
+		}
+
+		if result.ID != "resp-123" {
+			t.Errorf("ID = %q, want %q", result.ID, "resp-123")
+		}
+		if result.Model != "sonar" {
+			t.Errorf("Model = %q, want %q", result.Model, "sonar")
+		}
+		if result.Output != "Hello! How can I help you?" {
+			t.Errorf("Output = %q, want %q", result.Output, "Hello! How can I help you?")
+		}
+		if result.Usage.PromptTokens != 10 {
+			t.Errorf("PromptTokens = %d, want 10", result.Usage.PromptTokens)
+		}
+		if result.Usage.CompletionTokens != 20 {
+			t.Errorf("CompletionTokens = %d, want 20", result.Usage.CompletionTokens)
+		}
+		if result.Usage.TotalTokens != 30 {
+			t.Errorf("TotalTokens = %d, want 30", result.Usage.TotalTokens)
+		}
+	})
+
+	t.Run("with tool calls", func(t *testing.T) {
+		resp := &perplexityResponse{
+			ID:    "resp-456",
+			Model: "sonar",
+			Choices: []perplexityChoice{
+				{
+					Index: 0,
+					Message: &perplexityRespMsg{
+						Role:    "assistant",
+						Content: "",
+						ToolCalls: []perplexityToolCall{
+							{
+								ID:   "call_1",
+								Type: "function",
+								Function: perplexityFunctionCall{
+									Name:      "get_weather",
+									Arguments: `{"city": "Tokyo"}`,
+								},
+							},
+						},
+					},
+					FinishReason: "tool_calls",
+				},
+			},
+		}
+
+		result, err := mapResponse(resp)
+		if err != nil {
+			t.Fatalf("mapResponse() error = %v", err)
+		}
+
+		if len(result.ToolCalls) != 1 {
+			t.Fatalf("ToolCalls count = %d, want 1", len(result.ToolCalls))
+		}
+		if result.ToolCalls[0].ID != "call_1" {
+			t.Errorf("ToolCall.ID = %q, want %q", result.ToolCalls[0].ID, "call_1")
+		}
+		if result.ToolCalls[0].Name != "get_weather" {
+			t.Errorf("ToolCall.Name = %q, want %q", result.ToolCalls[0].Name, "get_weather")
+		}
+	})
+
+	t.Run("empty choices", func(t *testing.T) {
+		resp := &perplexityResponse{
+			ID:      "resp-789",
+			Model:   "sonar",
+			Choices: []perplexityChoice{},
+		}
+
+		result, err := mapResponse(resp)
+		if err != nil {
+			t.Fatalf("mapResponse() error = %v", err)
+		}
+
+		if result.Output != "" {
+			t.Errorf("Output should be empty, got %q", result.Output)
+		}
+	})
+
+	t.Run("no usage", func(t *testing.T) {
+		resp := &perplexityResponse{
+			ID:    "resp-abc",
+			Model: "sonar",
+			Choices: []perplexityChoice{
+				{Message: &perplexityRespMsg{Content: "Hi"}},
+			},
+			Usage: nil,
+		}
+
+		result, err := mapResponse(resp)
+		if err != nil {
+			t.Fatalf("mapResponse() error = %v", err)
+		}
+
+		if result.Usage.TotalTokens != 0 {
+			t.Errorf("Usage should be zero, got %+v", result.Usage)
+		}
+	})
+}
+
+func TestMapToolCalls(t *testing.T) {
+	t.Run("valid tool calls", func(t *testing.T) {
+		calls := []perplexityToolCall{
+			{
+				ID:   "call_1",
+				Type: "function",
+				Function: perplexityFunctionCall{
+					Name:      "get_weather",
+					Arguments: `{"city": "NYC"}`,
+				},
+			},
+			{
+				ID:   "call_2",
+				Type: "function",
+				Function: perplexityFunctionCall{
+					Name:      "search",
+					Arguments: `{"query": "news"}`,
+				},
+			},
+		}
+
+		result, err := mapToolCalls(calls)
+		if err != nil {
+			t.Fatalf("mapToolCalls() error = %v", err)
+		}
+
+		if len(result) != 2 {
+			t.Fatalf("Result length = %d, want 2", len(result))
+		}
+
+		if result[0].ID != "call_1" {
+			t.Errorf("result[0].ID = %q, want %q", result[0].ID, "call_1")
+		}
+		if result[0].Name != "get_weather" {
+			t.Errorf("result[0].Name = %q, want %q", result[0].Name, "get_weather")
+		}
+
+		// Verify arguments are valid JSON
+		var args map[string]string
+		if err := json.Unmarshal(result[0].Arguments, &args); err != nil {
+			t.Errorf("Failed to unmarshal arguments: %v", err)
+		}
+		if args["city"] != "NYC" {
+			t.Errorf("args[city] = %q, want %q", args["city"], "NYC")
+		}
+	})
+
+	t.Run("invalid JSON arguments", func(t *testing.T) {
+		calls := []perplexityToolCall{
+			{
+				ID:   "call_1",
+				Type: "function",
+				Function: perplexityFunctionCall{
+					Name:      "test",
+					Arguments: `{invalid json}`,
+				},
+			},
+		}
+
+		_, err := mapToolCalls(calls)
+		if err == nil {
+			t.Fatal("mapToolCalls() should return error for invalid JSON")
+		}
+		if err != ErrToolArgsInvalidJSON {
+			t.Errorf("err = %v, want ErrToolArgsInvalidJSON", err)
+		}
+	})
+}
+
+// mockTool is a simple tool implementation for testing.
+type mockTool struct {
+	name        string
+	description string
+}
+
+func (t *mockTool) Name() string        { return t.name }
+func (t *mockTool) Description() string { return t.description }

--- a/providers/perplexity/provider_test.go
+++ b/providers/perplexity/provider_test.go
@@ -1,0 +1,273 @@
+package perplexity
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestPerplexityImplementsProvider(t *testing.T) {
+	p := New("test-key")
+	var _ core.Provider = p
+}
+
+func TestNew(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		p := New("test-key")
+
+		if p.config.APIKey.Expose() != "test-key" {
+			t.Errorf("APIKey = %q, want %q", p.config.APIKey.Expose(), "test-key")
+		}
+		if p.config.BaseURL != DefaultBaseURL {
+			t.Errorf("BaseURL = %q, want %q", p.config.BaseURL, DefaultBaseURL)
+		}
+		if p.config.HTTPClient != http.DefaultClient {
+			t.Error("HTTPClient should be http.DefaultClient")
+		}
+	})
+
+	t.Run("with options", func(t *testing.T) {
+		client := &http.Client{Timeout: 30 * time.Second}
+
+		p := New("test-key",
+			WithBaseURL("https://custom.api.perplexity.ai"),
+			WithHTTPClient(client),
+			WithHeader("X-Custom", "value"),
+			WithTimeout(60*time.Second),
+		)
+
+		if p.config.BaseURL != "https://custom.api.perplexity.ai" {
+			t.Errorf("BaseURL = %q, want %q", p.config.BaseURL, "https://custom.api.perplexity.ai")
+		}
+		if p.config.HTTPClient != client {
+			t.Error("HTTPClient not set correctly")
+		}
+		if p.config.Headers.Get("X-Custom") != "value" {
+			t.Errorf("Headers[X-Custom] = %q, want %q", p.config.Headers.Get("X-Custom"), "value")
+		}
+		if p.config.Timeout != 60*time.Second {
+			t.Errorf("Timeout = %v, want %v", p.config.Timeout, 60*time.Second)
+		}
+	})
+}
+
+func TestID(t *testing.T) {
+	p := New("test-key")
+
+	if p.ID() != "perplexity" {
+		t.Errorf("ID() = %q, want %q", p.ID(), "perplexity")
+	}
+}
+
+func TestModels(t *testing.T) {
+	p := New("test-key")
+	models := p.Models()
+
+	if len(models) < 2 {
+		t.Errorf("Models() returned %d models, want at least 2", len(models))
+	}
+
+	// Check for required models
+	modelIDs := make(map[core.ModelID]bool)
+	for _, m := range models {
+		modelIDs[m.ID] = true
+	}
+
+	if !modelIDs[ModelSonar] {
+		t.Error("Models() missing sonar")
+	}
+
+	if !modelIDs[ModelSonarPro] {
+		t.Error("Models() missing sonar-pro")
+	}
+}
+
+func TestModelsReturnsCopy(t *testing.T) {
+	p := New("test-key")
+	models1 := p.Models()
+	models2 := p.Models()
+
+	if len(models1) > 0 {
+		models1[0].DisplayName = "modified"
+	}
+
+	if models2[0].DisplayName == "modified" {
+		t.Error("Models() did not return a copy")
+	}
+}
+
+func TestModelsHaveCapabilities(t *testing.T) {
+	p := New("test-key")
+	models := p.Models()
+
+	for _, m := range models {
+		if len(m.Capabilities) == 0 {
+			t.Errorf("Model %s has no capabilities", m.ID)
+		}
+
+		// All models should support chat
+		hasChat := false
+		for _, cap := range m.Capabilities {
+			if cap == core.FeatureChat {
+				hasChat = true
+				break
+			}
+		}
+		if !hasChat {
+			t.Errorf("Model %s missing FeatureChat capability", m.ID)
+		}
+	}
+}
+
+func TestSupports(t *testing.T) {
+	p := New("test-key")
+
+	tests := []struct {
+		feature core.Feature
+		want    bool
+	}{
+		{core.FeatureChat, true},
+		{core.FeatureChatStreaming, true},
+		{core.FeatureToolCalling, true},
+		{core.FeatureReasoning, true},
+		{core.FeatureImageGeneration, false},
+		{core.FeatureEmbeddings, false},
+		{core.Feature("unknown"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.feature), func(t *testing.T) {
+			if got := p.Supports(tt.feature); got != tt.want {
+				t.Errorf("Supports(%q) = %v, want %v", tt.feature, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildHeaders(t *testing.T) {
+	t.Run("required headers", func(t *testing.T) {
+		p := New("sk-test-key-123")
+		headers := p.buildHeaders()
+
+		auth := headers.Get("Authorization")
+		if auth != "Bearer sk-test-key-123" {
+			t.Errorf("Authorization = %q, want %q", auth, "Bearer sk-test-key-123")
+		}
+
+		contentType := headers.Get("Content-Type")
+		if contentType != "application/json" {
+			t.Errorf("Content-Type = %q, want %q", contentType, "application/json")
+		}
+	})
+
+	t.Run("with custom headers", func(t *testing.T) {
+		p := New("test-key",
+			WithHeader("X-Custom-One", "value1"),
+			WithHeader("X-Custom-Two", "value2"),
+		)
+		headers := p.buildHeaders()
+
+		if headers.Get("X-Custom-One") != "value1" {
+			t.Errorf("X-Custom-One = %q, want %q", headers.Get("X-Custom-One"), "value1")
+		}
+
+		if headers.Get("X-Custom-Two") != "value2" {
+			t.Errorf("X-Custom-Two = %q, want %q", headers.Get("X-Custom-Two"), "value2")
+		}
+	})
+}
+
+func TestNewFromEnvSuccess(t *testing.T) {
+	// Set the environment variable
+	originalValue := os.Getenv(DefaultAPIKeyEnvVar)
+	os.Setenv(DefaultAPIKeyEnvVar, "pplx-test-from-env-123")
+	defer func() {
+		if originalValue != "" {
+			os.Setenv(DefaultAPIKeyEnvVar, originalValue)
+		} else {
+			os.Unsetenv(DefaultAPIKeyEnvVar)
+		}
+	}()
+
+	p, err := NewFromEnv()
+	if err != nil {
+		t.Fatalf("NewFromEnv() error = %v", err)
+	}
+
+	if p == nil {
+		t.Fatal("NewFromEnv() returned nil provider")
+	}
+
+	// Verify the API key was set correctly
+	headers := p.buildHeaders()
+	auth := headers.Get("Authorization")
+	if auth != "Bearer pplx-test-from-env-123" {
+		t.Errorf("Authorization = %q, want %q", auth, "Bearer pplx-test-from-env-123")
+	}
+}
+
+func TestNewFromEnvMissingKey(t *testing.T) {
+	// Unset the environment variable
+	originalValue := os.Getenv(DefaultAPIKeyEnvVar)
+	os.Unsetenv(DefaultAPIKeyEnvVar)
+	defer func() {
+		if originalValue != "" {
+			os.Setenv(DefaultAPIKeyEnvVar, originalValue)
+		}
+	}()
+
+	_, err := NewFromEnv()
+	if err == nil {
+		t.Fatal("NewFromEnv() should return error when env var is not set")
+	}
+
+	if !errors.Is(err, ErrAPIKeyNotFound) {
+		t.Errorf("err = %v, want ErrAPIKeyNotFound", err)
+	}
+}
+
+func TestNewFromEnvWithOptions(t *testing.T) {
+	// Set the environment variable
+	originalValue := os.Getenv(DefaultAPIKeyEnvVar)
+	os.Setenv(DefaultAPIKeyEnvVar, "pplx-test-from-env-456")
+	defer func() {
+		if originalValue != "" {
+			os.Setenv(DefaultAPIKeyEnvVar, originalValue)
+		} else {
+			os.Unsetenv(DefaultAPIKeyEnvVar)
+		}
+	}()
+
+	customURL := "https://custom.perplexity.ai"
+	p, err := NewFromEnv(WithBaseURL(customURL))
+	if err != nil {
+		t.Fatalf("NewFromEnv() error = %v", err)
+	}
+
+	if p.config.BaseURL != customURL {
+		t.Errorf("BaseURL = %q, want %q", p.config.BaseURL, customURL)
+	}
+}
+
+func TestGetModelInfo(t *testing.T) {
+	t.Run("existing model", func(t *testing.T) {
+		info := GetModelInfo(ModelSonar)
+		if info == nil {
+			t.Fatal("GetModelInfo(ModelSonar) returned nil")
+		}
+		if info.ID != ModelSonar {
+			t.Errorf("ID = %q, want %q", info.ID, ModelSonar)
+		}
+	})
+
+	t.Run("non-existing model", func(t *testing.T) {
+		info := GetModelInfo("non-existent-model")
+		if info != nil {
+			t.Errorf("GetModelInfo(non-existent) = %v, want nil", info)
+		}
+	})
+}

--- a/providers/perplexity/streaming_test.go
+++ b/providers/perplexity/streaming_test.go
@@ -1,0 +1,414 @@
+package perplexity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestToolCallAssembler(t *testing.T) {
+	t.Run("single tool call", func(t *testing.T) {
+		asm := newToolCallAssembler()
+
+		// Simulate streaming fragments
+		asm.addFragment(perplexityStreamToolCall{
+			Index: 0,
+			ID:    "call_1",
+			Function: struct {
+				Name      string `json:"name,omitempty"`
+				Arguments string `json:"arguments,omitempty"`
+			}{
+				Name: "get_weather",
+			},
+		})
+		asm.addFragment(perplexityStreamToolCall{
+			Index: 0,
+			Function: struct {
+				Name      string `json:"name,omitempty"`
+				Arguments string `json:"arguments,omitempty"`
+			}{
+				Arguments: `{"city":`,
+			},
+		})
+		asm.addFragment(perplexityStreamToolCall{
+			Index: 0,
+			Function: struct {
+				Name      string `json:"name,omitempty"`
+				Arguments string `json:"arguments,omitempty"`
+			}{
+				Arguments: `"Tokyo"}`,
+			},
+		})
+
+		calls, err := asm.finalize()
+		if err != nil {
+			t.Fatalf("finalize() error = %v", err)
+		}
+
+		if len(calls) != 1 {
+			t.Fatalf("calls count = %d, want 1", len(calls))
+		}
+
+		if calls[0].ID != "call_1" {
+			t.Errorf("ID = %q, want %q", calls[0].ID, "call_1")
+		}
+		if calls[0].Name != "get_weather" {
+			t.Errorf("Name = %q, want %q", calls[0].Name, "get_weather")
+		}
+
+		var args map[string]string
+		if err := json.Unmarshal(calls[0].Arguments, &args); err != nil {
+			t.Fatalf("Failed to unmarshal arguments: %v", err)
+		}
+		if args["city"] != "Tokyo" {
+			t.Errorf("args[city] = %q, want %q", args["city"], "Tokyo")
+		}
+	})
+
+	t.Run("multiple tool calls", func(t *testing.T) {
+		asm := newToolCallAssembler()
+
+		// Tool call 0
+		asm.addFragment(perplexityStreamToolCall{
+			Index: 0,
+			ID:    "call_1",
+			Function: struct {
+				Name      string `json:"name,omitempty"`
+				Arguments string `json:"arguments,omitempty"`
+			}{
+				Name:      "get_weather",
+				Arguments: `{"city":"NYC"}`,
+			},
+		})
+
+		// Tool call 1
+		asm.addFragment(perplexityStreamToolCall{
+			Index: 1,
+			ID:    "call_2",
+			Function: struct {
+				Name      string `json:"name,omitempty"`
+				Arguments string `json:"arguments,omitempty"`
+			}{
+				Name:      "search",
+				Arguments: `{"query":"news"}`,
+			},
+		})
+
+		calls, err := asm.finalize()
+		if err != nil {
+			t.Fatalf("finalize() error = %v", err)
+		}
+
+		if len(calls) != 2 {
+			t.Fatalf("calls count = %d, want 2", len(calls))
+		}
+
+		if calls[0].Name != "get_weather" {
+			t.Errorf("calls[0].Name = %q, want %q", calls[0].Name, "get_weather")
+		}
+		if calls[1].Name != "search" {
+			t.Errorf("calls[1].Name = %q, want %q", calls[1].Name, "search")
+		}
+	})
+
+	t.Run("empty assembler", func(t *testing.T) {
+		asm := newToolCallAssembler()
+		calls, err := asm.finalize()
+
+		if err != nil {
+			t.Fatalf("finalize() error = %v", err)
+		}
+		if calls != nil {
+			t.Errorf("calls should be nil, got %v", calls)
+		}
+	})
+
+	t.Run("invalid JSON arguments", func(t *testing.T) {
+		asm := newToolCallAssembler()
+
+		asm.addFragment(perplexityStreamToolCall{
+			Index: 0,
+			ID:    "call_1",
+			Function: struct {
+				Name      string `json:"name,omitempty"`
+				Arguments string `json:"arguments,omitempty"`
+			}{
+				Name:      "test",
+				Arguments: `{invalid`,
+			},
+		})
+
+		_, err := asm.finalize()
+		if err != ErrToolArgsInvalidJSON {
+			t.Errorf("finalize() error = %v, want ErrToolArgsInvalidJSON", err)
+		}
+	})
+
+	t.Run("sparse indices", func(t *testing.T) {
+		asm := newToolCallAssembler()
+
+		// Only index 0 and 2, no 1
+		asm.addFragment(perplexityStreamToolCall{
+			Index: 0,
+			ID:    "call_0",
+			Function: struct {
+				Name      string `json:"name,omitempty"`
+				Arguments string `json:"arguments,omitempty"`
+			}{
+				Name:      "func0",
+				Arguments: `{}`,
+			},
+		})
+		asm.addFragment(perplexityStreamToolCall{
+			Index: 2,
+			ID:    "call_2",
+			Function: struct {
+				Name      string `json:"name,omitempty"`
+				Arguments string `json:"arguments,omitempty"`
+			}{
+				Name:      "func2",
+				Arguments: `{}`,
+			},
+		})
+
+		calls, err := asm.finalize()
+		if err != nil {
+			t.Fatalf("finalize() error = %v", err)
+		}
+
+		if len(calls) != 2 {
+			t.Fatalf("calls count = %d, want 2", len(calls))
+		}
+	})
+}
+
+func TestDoStreamChat(t *testing.T) {
+	t.Run("successful stream", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("x-request-id", "stream-req-123")
+
+			// Send SSE events
+			chunks := []string{
+				`data: {"id":"resp-1","model":"sonar","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello"}}]}`,
+				`data: {"id":"resp-1","model":"sonar","choices":[{"index":0,"delta":{"content":" world!"}}]}`,
+				`data: {"id":"resp-1","model":"sonar","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+				`data: [DONE]`,
+			}
+
+			for _, chunk := range chunks {
+				fmt.Fprintln(w, chunk)
+				fmt.Fprintln(w, "")
+			}
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL))
+		stream, err := p.doStreamChat(context.Background(), &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if err != nil {
+			t.Fatalf("doStreamChat() error = %v", err)
+		}
+
+		// Collect chunks
+		var content string
+		for chunk := range stream.Ch {
+			content += chunk.Delta
+		}
+
+		if content != "Hello world!" {
+			t.Errorf("content = %q, want %q", content, "Hello world!")
+		}
+
+		// Check final response
+		finalResp := <-stream.Final
+		if finalResp == nil {
+			t.Fatal("Final response should not be nil")
+		}
+		if finalResp.ID != "resp-1" {
+			t.Errorf("ID = %q, want %q", finalResp.ID, "resp-1")
+		}
+		if finalResp.Usage.TotalTokens != 15 {
+			t.Errorf("TotalTokens = %d, want 15", finalResp.Usage.TotalTokens)
+		}
+
+		// Check no errors
+		select {
+		case err := <-stream.Err:
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		default:
+		}
+	})
+
+	t.Run("stream with tool calls", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+
+			chunks := []string{
+				`data: {"id":"resp-2","model":"sonar","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather"}}]}}]}`,
+				`data: {"id":"resp-2","model":"sonar","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":"}}]}}]}`,
+				`data: {"id":"resp-2","model":"sonar","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"Tokyo\"}"}}]}}]}`,
+				`data: {"id":"resp-2","model":"sonar","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+				`data: [DONE]`,
+			}
+
+			for _, chunk := range chunks {
+				fmt.Fprintln(w, chunk)
+				fmt.Fprintln(w, "")
+			}
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL))
+		stream, err := p.doStreamChat(context.Background(), &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Weather?"}},
+		})
+
+		if err != nil {
+			t.Fatalf("doStreamChat() error = %v", err)
+		}
+
+		// Drain content channel
+		for range stream.Ch {
+		}
+
+		// Check final response has tool calls
+		finalResp := <-stream.Final
+		if finalResp == nil {
+			t.Fatal("Final response should not be nil")
+		}
+		if len(finalResp.ToolCalls) != 1 {
+			t.Fatalf("ToolCalls count = %d, want 1", len(finalResp.ToolCalls))
+		}
+		if finalResp.ToolCalls[0].Name != "get_weather" {
+			t.Errorf("ToolCall.Name = %q, want %q", finalResp.ToolCalls[0].Name, "get_weather")
+		}
+	})
+
+	t.Run("error response before stream", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("x-request-id", "err-req")
+			w.WriteHeader(http.StatusUnauthorized)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]string{
+					"message": "Invalid key",
+					"type":    "auth_error",
+				},
+			})
+		}))
+		defer server.Close()
+
+		p := New("bad-key", WithBaseURL(server.URL))
+		_, err := p.doStreamChat(context.Background(), &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if err == nil {
+			t.Fatal("doStreamChat() should return error")
+		}
+
+		var provErr *core.ProviderError
+		if !errors.As(err, &provErr) {
+			t.Fatal("err should be *core.ProviderError")
+		}
+		if provErr.Status != http.StatusUnauthorized {
+			t.Errorf("Status = %d, want %d", provErr.Status, http.StatusUnauthorized)
+		}
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		p := New("test-key", WithBaseURL("http://localhost:0"))
+		_, err := p.doStreamChat(context.Background(), &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if !errors.Is(err, core.ErrNetwork) {
+			t.Error("err should wrap core.ErrNetwork")
+		}
+	})
+
+	t.Run("skip empty lines and comments", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+
+			lines := []string{
+				"",            // empty line
+				":keep-alive", // comment
+				`data: {"id":"resp-3","model":"sonar","choices":[{"index":0,"delta":{"content":"Hi"}}]}`, // actual data
+				"",
+				`:another comment`,
+				`data: [DONE]`,
+			}
+
+			for _, line := range lines {
+				fmt.Fprintln(w, line)
+			}
+		}))
+		defer server.Close()
+
+		p := New("test-key", WithBaseURL(server.URL))
+		stream, err := p.doStreamChat(context.Background(), &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if err != nil {
+			t.Fatalf("doStreamChat() error = %v", err)
+		}
+
+		var content string
+		for chunk := range stream.Ch {
+			content += chunk.Delta
+		}
+
+		if content != "Hi" {
+			t.Errorf("content = %q, want %q", content, "Hi")
+		}
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			// Block until context is cancelled
+			<-r.Context().Done()
+		}))
+		defer server.Close()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		p := New("test-key", WithBaseURL(server.URL))
+		_, err := p.doStreamChat(ctx, &core.ChatRequest{
+			Model:    "sonar",
+			Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+		})
+
+		if err == nil {
+			t.Fatal("doStreamChat() should return error on cancelled context")
+		}
+	})
+}
+
+func TestNewToolCallAssembler(t *testing.T) {
+	asm := newToolCallAssembler()
+	if asm == nil {
+		t.Fatal("newToolCallAssembler() returned nil")
+	}
+	if asm.calls == nil {
+		t.Fatal("newToolCallAssembler().calls should not be nil")
+	}
+}

--- a/tests/integration/ollama_test.go
+++ b/tests/integration/ollama_test.go
@@ -1,0 +1,279 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/ollama"
+)
+
+// TestOllama_ChatCompletion tests basic chat completion with local Ollama.
+// Requires: ollama running locally with gemma3 model pulled.
+func TestOllama_ChatCompletion(t *testing.T) {
+	skipIfNoOllama(t)
+
+	provider := ollama.NewLocal()
+	client := core.NewClient(provider)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, err := client.Chat("gemma3").
+		User("Say 'hello' and nothing else.").
+		GetResponse(ctx)
+
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if resp.Output == "" {
+		t.Error("Response output is empty")
+	}
+
+	t.Logf("Response: %s", resp.Output)
+	t.Logf("Usage: %d prompt + %d completion = %d total",
+		resp.Usage.PromptTokens,
+		resp.Usage.CompletionTokens,
+		resp.Usage.TotalTokens)
+}
+
+// TestOllama_ChatCompletion_Streaming tests streaming chat completion.
+// Requires: ollama running locally with gemma3 model pulled.
+func TestOllama_ChatCompletion_Streaming(t *testing.T) {
+	skipIfNoOllama(t)
+
+	provider := ollama.NewLocal()
+	client := core.NewClient(provider)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	stream, err := client.Chat("gemma3").
+		User("Count from 1 to 5, each number on a new line.").
+		Stream(ctx)
+
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+
+	// Collect deltas
+	var chunks []string
+	for chunk := range stream.Ch {
+		chunks = append(chunks, chunk.Delta)
+	}
+
+	// Check for errors
+	select {
+	case err := <-stream.Err:
+		if err != nil {
+			t.Fatalf("Stream error: %v", err)
+		}
+	default:
+	}
+
+	// Wait for final response
+	var finalResp *core.ChatResponse
+	select {
+	case resp := <-stream.Final:
+		finalResp = resp
+	case <-time.After(5 * time.Second):
+		t.Log("No final response received (may be expected for Ollama)")
+	}
+
+	if len(chunks) == 0 {
+		t.Error("No chunks received")
+	}
+
+	combined := strings.Join(chunks, "")
+	if combined == "" {
+		t.Error("Combined output is empty")
+	}
+
+	t.Logf("Received %d chunks", len(chunks))
+	t.Logf("Combined output: %s", combined)
+
+	if finalResp != nil {
+		t.Logf("Final response model: %s", finalResp.Model)
+	}
+}
+
+// TestOllama_ChatCompletion_SystemMessage tests chat with a system message.
+// Requires: ollama running locally with gemma3 model pulled.
+func TestOllama_ChatCompletion_SystemMessage(t *testing.T) {
+	skipIfNoOllama(t)
+
+	provider := ollama.NewLocal()
+	client := core.NewClient(provider)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, err := client.Chat("gemma3").
+		System("You are a pirate. Always respond in pirate speak.").
+		User("Say hello.").
+		GetResponse(ctx)
+
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if resp.Output == "" {
+		t.Error("Response output is empty")
+	}
+
+	// The output should contain pirate-like language
+	output := strings.ToLower(resp.Output)
+	pirateWords := []string{"ahoy", "matey", "arr", "aye", "ye", "ship", "sail", "sea", "yo ho"}
+
+	hasPirateWord := false
+	for _, word := range pirateWords {
+		if strings.Contains(output, word) {
+			hasPirateWord = true
+			break
+		}
+	}
+
+	if !hasPirateWord {
+		t.Logf("Note: Response may not be in pirate speak: %s", resp.Output)
+	}
+
+	t.Logf("Response: %s", resp.Output)
+}
+
+// TestOllama_ChatCompletion_Temperature tests chat with temperature parameter.
+// Requires: ollama running locally with gemma3 model pulled.
+func TestOllama_ChatCompletion_Temperature(t *testing.T) {
+	skipIfNoOllama(t)
+
+	provider := ollama.NewLocal()
+	client := core.NewClient(provider)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Low temperature should give more deterministic output
+	resp, err := client.Chat("gemma3").
+		User("What is 2+2? Reply with just the number.").
+		Temperature(0).
+		GetResponse(ctx)
+
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if resp.Output == "" {
+		t.Error("Response output is empty")
+	}
+
+	// Should contain "4"
+	if !strings.Contains(resp.Output, "4") {
+		t.Errorf("Expected response to contain '4', got: %s", resp.Output)
+	}
+
+	t.Logf("Response: %s", resp.Output)
+}
+
+// TestOllama_ChatCompletion_MultiTurn tests multi-turn conversation.
+// Requires: ollama running locally with gemma3 model pulled.
+func TestOllama_ChatCompletion_MultiTurn(t *testing.T) {
+	skipIfNoOllama(t)
+
+	provider := ollama.NewLocal()
+	client := core.NewClient(provider)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// First turn: set context
+	resp1, err := client.Chat("gemma3").
+		User("My name is Alice. Remember this.").
+		GetResponse(ctx)
+
+	if err != nil {
+		t.Fatalf("First turn error = %v", err)
+	}
+
+	t.Logf("First response: %s", resp1.Output)
+
+	// Second turn: recall context
+	resp2, err := client.Chat("gemma3").
+		User("My name is Alice. Remember this.").
+		Assistant(resp1.Output).
+		User("What is my name?").
+		GetResponse(ctx)
+
+	if err != nil {
+		t.Fatalf("Second turn error = %v", err)
+	}
+
+	// Response should mention "Alice"
+	if !strings.Contains(strings.ToLower(resp2.Output), "alice") {
+		t.Logf("Note: Response may not have remembered the name: %s", resp2.Output)
+	}
+
+	t.Logf("Second response: %s", resp2.Output)
+}
+
+// TestOllama_NewLocalWithOptions tests provider creation with options.
+func TestOllama_NewLocalWithOptions(t *testing.T) {
+	skipIfNoOllama(t)
+
+	// Test that we can create with custom timeout option
+	provider := ollama.NewLocal(
+		ollama.WithTimeout(60*time.Second),
+	)
+
+	if provider.ID() != "ollama" {
+		t.Errorf("ID() = %q, want %q", provider.ID(), "ollama")
+	}
+
+	// Verify provider works
+	client := core.NewClient(provider)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, err := client.Chat("gemma3").
+		User("Say 'test' and nothing else.").
+		GetResponse(ctx)
+
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if resp.Output == "" {
+		t.Error("Response output is empty")
+	}
+
+	t.Logf("Response: %s", resp.Output)
+}
+
+// TestOllama_SupportsFeatures tests provider feature support.
+func TestOllama_SupportsFeatures(t *testing.T) {
+	provider := ollama.NewLocal()
+
+	tests := []struct {
+		feature core.Feature
+		want    bool
+	}{
+		{core.FeatureChat, true},
+		{core.FeatureChatStreaming, true},
+		{core.FeatureToolCalling, true},
+		{core.FeatureReasoning, true},
+		{core.FeatureEmbeddings, false},       // Not supported
+		{core.FeatureImageGeneration, false},  // Not supported
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.feature), func(t *testing.T) {
+			if got := provider.Supports(tt.feature); got != tt.want {
+				t.Errorf("Supports(%q) = %v, want %v", tt.feature, got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/integration/ollama_test.go
+++ b/tests/integration/ollama_test.go
@@ -225,7 +225,7 @@ func TestOllama_NewLocalWithOptions(t *testing.T) {
 
 	// Test that we can create with custom timeout option
 	provider := ollama.NewLocal(
-		ollama.WithTimeout(60*time.Second),
+		ollama.WithTimeout(60 * time.Second),
 	)
 
 	if provider.ID() != "ollama" {
@@ -265,8 +265,8 @@ func TestOllama_SupportsFeatures(t *testing.T) {
 		{core.FeatureChatStreaming, true},
 		{core.FeatureToolCalling, true},
 		{core.FeatureReasoning, true},
-		{core.FeatureEmbeddings, false},       // Not supported
-		{core.FeatureImageGeneration, false},  // Not supported
+		{core.FeatureEmbeddings, false},      // Not supported
+		{core.FeatureImageGeneration, false}, // Not supported
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Add huggingface provider tests (91.9% coverage, from 0%)
- Add perplexity provider tests (90.6% coverage, from 0%)
- Add ollama integration tests with gemma3 model
- Add helper functions for ollama integration testing
- Add chat command tests for CLI
- Add configurable HubAPIBaseURL for testability

## Test Coverage Improvements

| Provider | Before | After |
|----------|--------|-------|
| huggingface | 0% | 91.9% |
| perplexity | 0% | 90.6% |

## New Test Files

### HuggingFace (6 files, ~1800 lines)
- `provider_test.go` - New, NewFromEnv, ID, Models, Supports, buildHeaders
- `errors_test.go` - normalizeError, newNetworkError, newDecodeError
- `mapping_test.go` - mapMessages, mapTools, buildRequest, mapResponse
- `client_test.go` - doChat, buildModelString, chatURL
- `streaming_test.go` - toolCallAssembler, doStreamChat
- `discovery_test.go` - GetModelStatus, GetModelProviders, ListModels

### Perplexity (5 files, ~1200 lines)
- `provider_test.go`, `errors_test.go`, `mapping_test.go`
- `client_test.go`, `streaming_test.go`

### Integration Tests
- `tests/integration/ollama_test.go` - 7 integration tests for local ollama

## Test Plan

- [x] All unit tests pass
- [x] Linting passes with no issues
- [x] Coverage targets met (>90%)