### PR TITLE
docs: expand package documentation and add architecture guides

### DIFF
--- a/core/doc.go
+++ b/core/doc.go
@@ -1,2 +1,157 @@
 // Package core provides the Iris SDK client and types for interacting with AI providers.
+//
+// Iris is a Go-native framework for building, orchestrating, and deploying AI agents
+// and multimodal workflows. The core package defines the fundamental abstractions
+// that all providers implement.
+//
+// # Client and Provider
+//
+// The primary entry point is [Client], which wraps a [Provider] and adds telemetry,
+// retry logic, and a fluent builder API:
+//
+//	provider := openai.New(os.Getenv("OPENAI_API_KEY"))
+//	client := core.NewClient(provider,
+//	    core.WithTelemetry(myTelemetryHook),
+//	    core.WithRetryPolicy(core.DefaultRetryPolicy()),
+//	)
+//
+// # ChatBuilder
+//
+// The [ChatBuilder] provides a fluent API for constructing chat requests:
+//
+//	resp, err := client.Chat("gpt-4o").
+//	    System("You are a helpful assistant.").
+//	    User("Hello!").
+//	    Temperature(0.7).
+//	    GetResponse(ctx)
+//
+// ChatBuilder is NOT thread-safe. Each goroutine should create its own builder
+// instance. Use [ChatBuilder.Clone] to create independent copies from a base
+// configuration:
+//
+//	base := client.Chat(model).System("You are helpful.").Temperature(0.7)
+//	go func() { resp1, _ := base.Clone().User("Q1").GetResponse(ctx) }()
+//	go func() { resp2, _ := base.Clone().User("Q2").GetResponse(ctx) }()
+//
+// # Streaming
+//
+// Iris treats streaming as a first-class primitive. Use [ChatBuilder.Stream] for
+// streaming responses:
+//
+//	stream, err := client.Chat(model).User("Tell me a story.").Stream(ctx)
+//	if err != nil {
+//	    return err
+//	}
+//	for chunk := range stream.Ch {
+//	    fmt.Print(chunk.Delta)
+//	}
+//
+// The [ChatStream] type provides three channels:
+//   - Ch: Emits text deltas in order
+//   - Err: Emits at most one error
+//   - Final: Emits the complete response with usage and tool calls
+//
+// Use [DrainStream] as a convenience to accumulate all chunks into a final response.
+//
+// # Provider Interface
+//
+// All providers implement the [Provider] interface:
+//
+//	type Provider interface {
+//	    ID() string
+//	    Models() []ModelInfo
+//	    Supports(feature Feature) bool
+//	    Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error)
+//	    StreamChat(ctx context.Context, req *ChatRequest) (*ChatStream, error)
+//	}
+//
+// Providers SHOULD be safe for concurrent use. Use [Provider.Supports] to check
+// capabilities before making requests:
+//
+//	if provider.Supports(core.FeatureToolCalling) {
+//	    // Safe to use tools
+//	}
+//
+// # Features
+//
+// Providers declare their capabilities through [Feature] constants:
+//   - [FeatureChat]: Basic chat completion
+//   - [FeatureChatStreaming]: Streaming chat completion
+//   - [FeatureToolCalling]: Function/tool calling support
+//   - [FeatureReasoning]: Extended reasoning capabilities
+//   - [FeatureBuiltInTools]: Web search, file search, code interpreter
+//   - [FeatureResponseChain]: Multi-turn response chaining
+//   - [FeatureEmbeddings]: Text embedding generation
+//   - [FeatureContextualizedEmbeddings]: Document-aware embeddings
+//   - [FeatureReranking]: Search result reranking
+//
+// # Error Handling
+//
+// The package defines sentinel errors for common failure modes:
+//   - [ErrUnauthorized]: Invalid or missing API key
+//   - [ErrRateLimited]: Provider rate limit exceeded
+//   - [ErrBadRequest]: Invalid request parameters
+//   - [ErrServer]: Provider server error (5xx)
+//   - [ErrNetwork]: Network connectivity issues
+//   - [ErrDecode]: Response parsing failed
+//   - [ErrModelRequired]: Model ID not specified
+//   - [ErrNoMessages]: No messages in request
+//
+// Use errors.Is to check error types:
+//
+//	if errors.Is(err, core.ErrRateLimited) {
+//	    // Handle rate limiting
+//	}
+//
+// # Telemetry
+//
+// Implement [TelemetryHook] to observe request lifecycle:
+//
+//	type MyTelemetry struct{}
+//
+//	func (t MyTelemetry) OnRequestStart(e RequestStartEvent) {
+//	    log.Printf("Starting %s request to %s", e.Model, e.Provider)
+//	}
+//
+//	func (t MyTelemetry) OnRequestEnd(e RequestEndEvent) {
+//	    log.Printf("Completed in %v, tokens: %d", e.End.Sub(e.Start), e.Usage.TotalTokens)
+//	}
+//
+// # Retry Policy
+//
+// Configure retry behavior with [RetryPolicy]:
+//
+//	policy := &core.ExponentialBackoff{
+//	    MaxRetries:  3,
+//	    BaseDelay:   time.Second,
+//	    MaxDelay:    30 * time.Second,
+//	}
+//	client := core.NewClient(provider, core.WithRetryPolicy(policy))
+//
+// The default policy retries transient errors (rate limits, server errors) with
+// exponential backoff.
+//
+// # Multimodal Messages
+//
+// For vision and document analysis, use [MessageBuilder]:
+//
+//	resp, err := client.Chat(model).
+//	    UserMultimodal().
+//	        Text("What's in this image?").
+//	        ImageURL("https://example.com/image.jpg").
+//	        Done().
+//	    GetResponse(ctx)
+//
+// Convenience methods are also available:
+//
+//	resp, err := client.Chat(model).
+//	    UserWithImageURL("Describe this:", "https://example.com/image.jpg").
+//	    GetResponse(ctx)
+//
+// # Thread Safety
+//
+// [Client] is safe for concurrent use across goroutines.
+// [ChatBuilder] and [MessageBuilder] are NOT thread-safe.
+// [ChatStream] channels may be read by one goroutine at a time.
+// Providers SHOULD be safe for concurrent calls (check provider documentation).
 package core

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,318 @@
+# Architecture Design Decisions
+
+This document explains the key architectural decisions in the Iris SDK and the rationale behind them.
+
+## Why Streaming Is First-Class
+
+### Decision
+Streaming is not an afterthought in Iris. The `ChatStream` type with its three-channel design (Ch, Err, Final) is a core primitive, and all providers must implement `StreamChat`.
+
+### Rationale
+
+**User Experience**: LLM responses can take seconds to generate. Users expect to see tokens as they're generated, not wait for the entire response. Streaming provides immediate feedback and perceived performance improvement.
+
+**Memory Efficiency**: Streaming avoids buffering entire responses in memory before returning. For long responses, this significantly reduces memory pressure.
+
+**Cancellation Support**: Users may want to stop generation early. Streaming with context cancellation allows graceful termination without wasting API calls or compute.
+
+**Tool Call Handling**: Modern LLMs interleave text output with tool calls. Streaming surfaces tool calls as they occur, enabling faster agentic workflows.
+
+### Design Details
+
+```go
+type ChatStream struct {
+    Ch    <-chan ChatChunk   // Text deltas in order
+    Err   <-chan error       // At most one error
+    Final <-chan *ChatResponse // Complete response with usage/tool calls
+}
+```
+
+**Why Three Channels?**
+
+- `Ch`: Separating content from errors allows clean iteration (`for chunk := range stream.Ch`)
+- `Err`: A dedicated error channel prevents mixing error handling with content reading
+- `Final`: Provides the complete response with usage statistics and tool calls, which aren't available until stream completion
+
+**Provider Contract**: Providers MUST:
+- Close all three channels when finished
+- Terminate promptly on context cancellation
+- Send at most one error on Err
+- Send exactly one response on Final (or zero on setup failure)
+
+### Alternatives Considered
+
+**Single Channel with Union Type**: Could return `StreamEvent` with either content, error, or final. Rejected because it complicates the common case of just reading text deltas.
+
+**Callback-Based API**: Pass functions for each event type. Rejected because it's harder to compose and doesn't leverage Go's channel-based concurrency.
+
+---
+
+## Why Provider Is an Interface, Not a Struct
+
+### Decision
+`Provider` is defined as an interface that all implementations must satisfy, rather than a concrete struct with provider-specific logic.
+
+### Rationale
+
+**Pluggability**: New providers can be added without modifying core code. Third parties can implement custom providers without forking the SDK.
+
+**Testability**: Tests can use mock providers that implement the interface. No need to make real API calls in unit tests.
+
+**Provider Isolation**: Each provider's implementation details (authentication, request formats, error mapping) are encapsulated. Core code never imports provider packages.
+
+**Go Idiom**: Go favors small interfaces. The five-method Provider interface is minimal yet complete for chat functionality.
+
+### Interface Design
+
+```go
+type Provider interface {
+    ID() string
+    Models() []ModelInfo
+    Supports(feature Feature) bool
+    Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error)
+    StreamChat(ctx context.Context, req *ChatRequest) (*ChatStream, error)
+}
+```
+
+**Why These Five Methods?**
+
+- `ID()`: Identifies the provider for telemetry and debugging
+- `Models()`: Enables discovery of available models and their capabilities
+- `Supports(feature)`: Runtime feature detection without reflection
+- `Chat()`: Synchronous request for simple use cases
+- `StreamChat()`: Streaming request for real-time output
+
+### Optional Interfaces
+
+Additional capabilities use separate interfaces:
+
+```go
+type ImageGenerator interface {
+    GenerateImage(ctx context.Context, req *ImageGenerateRequest) (*ImageResponse, error)
+    EditImage(ctx context.Context, req *ImageEditRequest) (*ImageResponse, error)
+    StreamImage(ctx context.Context, req *ImageGenerateRequest) (*ImageStream, error)
+}
+```
+
+This allows providers to opt into capabilities without polluting the core interface.
+
+### Alternatives Considered
+
+**Single Struct with Provider Field**: A monolithic struct with a `providerType` field and switch statements. Rejected because it would require modifying core code for each new provider.
+
+**Configuration-Based Providers**: Pass a configuration struct to a generic provider. Rejected because providers have fundamentally different APIs, authentication mechanisms, and response formats.
+
+---
+
+## Why ChatBuilder Is Not Thread-Safe
+
+### Decision
+`ChatBuilder` explicitly documents that it is NOT thread-safe and should not be shared across goroutines.
+
+### Rationale
+
+**Performance**: Synchronization (mutexes, atomic operations) has overhead. Since builders are typically used for a single request, this overhead provides no benefit.
+
+**Go Idiom**: Go prefers explicit sharing over implicit synchronization. The pattern of "create, configure, execute" doesn't require concurrent access to the builder.
+
+**Simplicity**: Thread-safe builders would need careful handling of slice appends, pointer assignments, and the timeout field. This complexity would obscure the simple builder pattern.
+
+**Copy Semantics**: The `Clone()` method provides explicit copying for concurrent use cases. This is more efficient than synchronization when parallelism is actually needed.
+
+### Safe Usage Pattern
+
+```go
+// Thread-safe: Clone before goroutine
+base := client.Chat(model).System("You are helpful").Temperature(0.7)
+
+go func() {
+    resp1, _ := base.Clone().User("Question 1").GetResponse(ctx)
+}()
+
+go func() {
+    resp2, _ := base.Clone().User("Question 2").GetResponse(ctx)
+}()
+```
+
+### What Is Thread-Safe?
+
+- `Client`: Safe for concurrent use (immutable after creation)
+- `Provider`: SHOULD be safe (documented per-provider)
+- `ChatStream`: Channels safe to read from one goroutine
+
+### Alternatives Considered
+
+**Always Thread-Safe**: Add mutex protection to ChatBuilder. Rejected due to performance overhead and complexity for the common single-threaded case.
+
+**Builder Pool**: Pool and reuse builders with synchronization. Rejected because builders are cheap to allocate and the pooling logic adds complexity.
+
+---
+
+## Why Tools Use json.RawMessage
+
+### Decision
+Tool arguments and schemas use `json.RawMessage` instead of parsed Go types.
+
+```go
+type ToolCall struct {
+    ID        string          `json:"id"`
+    Name      string          `json:"name"`
+    Arguments json.RawMessage `json:"arguments"`
+}
+
+type ToolSchema struct {
+    JSONSchema json.RawMessage `json:"json_schema"`
+}
+```
+
+### Rationale
+
+**Preserves Raw JSON**: Different providers may return semantically equivalent but syntactically different JSON. `json.RawMessage` preserves the exact bytes the model returned, avoiding reformatting issues.
+
+**Deferred Parsing**: The core SDK doesn't need to understand tool argument structure. Parsing is deferred to the tool implementation, which knows its expected schema.
+
+**Flexibility**: Users can define any JSON schema. Using `map[string]any` or struct types would limit expressiveness or require reflection.
+
+**Round-Trip Safety**: When passing tool results back to the model, the exact JSON is preserved. Some models are sensitive to whitespace or key ordering changes.
+
+### Usage Pattern
+
+```go
+// In tool implementation
+func (t *WeatherTool) Call(ctx context.Context, args json.RawMessage) (any, error) {
+    var params struct {
+        Location string `json:"location"`
+        Units    string `json:"units"`
+    }
+    if err := json.Unmarshal(args, &params); err != nil {
+        return nil, err
+    }
+    return t.getWeather(params.Location, params.Units)
+}
+```
+
+### Alternatives Considered
+
+**map[string]any**: Loses type information and requires type assertions everywhere.
+
+**Struct per Tool**: Would require code generation or reflection to handle arbitrary schemas.
+
+**Generic Type Parameter**: `ToolCall[T any]` would complicate the ChatResponse type and require users to know types at compile time.
+
+---
+
+## Why Sentinel Errors with ProviderError
+
+### Decision
+The SDK defines sentinel errors (`ErrRateLimited`, `ErrUnauthorized`, etc.) AND a `ProviderError` struct with full context.
+
+```go
+var ErrRateLimited = errors.New("rate limited")
+
+type ProviderError struct {
+    Provider  string
+    Status    int
+    RequestID string
+    Code      string
+    Message   string
+    Err       error // Wraps sentinel error
+}
+```
+
+### Rationale
+
+**Classification**: Sentinel errors enable simple classification with `errors.Is()`:
+```go
+if errors.Is(err, core.ErrRateLimited) {
+    // Handle rate limiting
+}
+```
+
+**Full Context**: `ProviderError` provides debugging information (request ID, status code, provider-specific error codes) without forcing callers to parse error messages.
+
+**Error Chaining**: `ProviderError.Unwrap()` returns the sentinel, supporting both classification and context extraction:
+```go
+var pe *core.ProviderError
+if errors.As(err, &pe) {
+    log.Printf("Provider %s returned %d: %s", pe.Provider, pe.Status, pe.Message)
+}
+```
+
+### Retry Integration
+
+The retry policy uses sentinel errors to determine retryability:
+
+```go
+func isRetryable(err error) bool {
+    if errors.Is(err, ErrUnauthorized) { return false }  // Don't retry auth errors
+    if errors.Is(err, ErrRateLimited) { return true }    // Retry rate limits
+    if errors.Is(err, ErrServer) { return true }         // Retry server errors
+    // ...
+}
+```
+
+---
+
+## Why Exponential Backoff with Jitter
+
+### Decision
+The default retry policy uses exponential backoff with configurable jitter.
+
+### Rationale
+
+**Thundering Herd Prevention**: Without jitter, all clients retry at the same time after a rate limit, causing another spike. Jitter spreads retries over time.
+
+**Backoff Growth**: Exponential growth (1s, 2s, 4s, 8s...) quickly reaches meaningful delays while starting with fast initial retries.
+
+**Configurability**: The `RetryConfig` allows tuning for different use cases:
+```go
+type RetryConfig struct {
+    MaxRetries int           // Maximum retry attempts
+    BaseDelay  time.Duration // Initial delay
+    MaxDelay   time.Duration // Delay cap
+    Jitter     float64       // Randomization factor (0.0-1.0)
+}
+```
+
+### Formula
+
+```
+delay = baseDelay * 2^attempt * (1 + random(-jitter, +jitter))
+delay = min(delay, maxDelay)
+```
+
+---
+
+## Why Features Are Explicit, Not Implicit
+
+### Decision
+Providers explicitly declare capabilities via `Supports(feature Feature)` rather than using reflection or interface assertions.
+
+### Rationale
+
+**Model-Level Granularity**: Within a single provider, different models may support different features. `Supports()` can check model-specific capabilities at runtime.
+
+**No Reflection**: Reflection is slow and opaque. Explicit feature flags are fast and debuggable.
+
+**Discovery**: Users can query capabilities before making requests:
+```go
+for _, model := range provider.Models() {
+    if model.HasCapability(core.FeatureReasoning) {
+        fmt.Printf("%s supports reasoning\n", model.ID)
+    }
+}
+```
+
+**Documentation**: Feature constants serve as documentation. New capabilities are added as new constants, making API evolution explicit.
+
+---
+
+## Summary of Design Principles
+
+1. **Strong Typing Over Reflection**: Prefer explicit Go types and interfaces
+2. **Provider Isolation**: All provider-specific logic stays in provider packages
+3. **Streaming-First**: Streaming is a core primitive, not an afterthought
+4. **Concurrency Safety**: Clear documentation of what's safe to share
+5. **Minimal Magic**: No global singletons, no hidden goroutines
+6. **Pluggability**: Interfaces enable extension without modification
+7. **Error Context**: Rich errors with classification and debugging info

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -1,0 +1,382 @@
+# Provider Comparison
+
+This document provides a comprehensive comparison of the AI providers supported by Iris.
+
+## Feature Support Matrix
+
+| Provider | Chat | Streaming | Tool Calling | Reasoning | Built-in Tools | Response Chain | Embeddings | Reranking |
+|----------|------|-----------|--------------|-----------|----------------|----------------|------------|-----------|
+| OpenAI | Yes | Yes | Yes | Yes* | Yes* | Yes* | No | No |
+| Anthropic | Yes | Yes | Yes | No | No | No | No | No |
+| Gemini | Yes | Yes | Yes | Yes | No | No | No | No |
+| xAI (Grok) | Yes | Yes | Yes | Yes* | No | No | No | No |
+| Perplexity | Yes | Yes | Yes* | Yes* | No | No | No | No |
+| Z.ai (GLM) | Yes | Yes | Yes | Yes* | No | No | No | No |
+| Ollama | Yes | Yes | Yes* | Yes* | No | No | No | No |
+| HuggingFace | Yes | Yes | Yes | No | No | No | No | No |
+| VoyageAI | No | No | No | No | No | No | Yes | Yes |
+
+*Feature availability varies by model. See model-specific tables below.
+
+## Provider Details
+
+### OpenAI
+
+**API Endpoint**: `https://api.openai.com/v1`
+
+**Authentication**: API key via `OPENAI_API_KEY` environment variable
+
+**API Types**:
+- Chat Completions API (GPT-4o, GPT-4, GPT-3.5 series)
+- Responses API (GPT-5.x, GPT-4.1, o-series models)
+
+**Models**:
+
+| Model | Display Name | Reasoning | Built-in Tools | Notes |
+|-------|--------------|-----------|----------------|-------|
+| gpt-5.2 | GPT-5.2 | Yes | Yes | Latest flagship |
+| gpt-5.2-pro | GPT-5.2 Pro | Yes | Yes | Enhanced capabilities |
+| gpt-5.2-codex | GPT-5.2 Codex | Yes | Yes | Code specialized |
+| gpt-5.1 | GPT-5.1 | Yes | Yes | |
+| gpt-5.1-codex | GPT-5.1 Codex | Yes | Yes | Code specialized |
+| gpt-5 | GPT-5 | Yes | Yes | |
+| gpt-5-mini | GPT-5 Mini | Yes | Yes | Smaller, faster |
+| gpt-5-nano | GPT-5 Nano | No | Yes | Lightweight |
+| gpt-4.1 | GPT-4.1 | No | Yes | |
+| gpt-4o | GPT-4o | No | No | Multimodal |
+| gpt-4o-mini | GPT-4o Mini | No | No | Cost-effective |
+| o4-mini | o4-mini | Yes | Yes | Reasoning focused |
+| o3 | o3 | Yes | Yes | Reasoning focused |
+| o1 | o1 | Yes | No | Reasoning focused |
+
+**Image Generation Models**: gpt-image-1.5, gpt-image-1, dall-e-3, dall-e-2
+
+**Usage Example**:
+```go
+provider := openai.New(os.Getenv("OPENAI_API_KEY"))
+client := core.NewClient(provider)
+
+resp, err := client.Chat(openai.ModelGPT4o).
+    User("Hello!").
+    GetResponse(ctx)
+```
+
+---
+
+### Anthropic
+
+**API Endpoint**: `https://api.anthropic.com/v1`
+
+**Authentication**: API key via `ANTHROPIC_API_KEY` environment variable
+
+**Models**:
+
+| Model | Display Name | Notes |
+|-------|--------------|-------|
+| claude-sonnet-4-5 | Claude Sonnet 4.5 | Balanced performance |
+| claude-haiku-4-5 | Claude Haiku 4.5 | Fast, cost-effective |
+| claude-opus-4-5 | Claude Opus 4.5 | Most capable |
+
+**Special Features**:
+- Extended context windows
+- Strong instruction following
+- Built-in safety guardrails
+
+**Usage Example**:
+```go
+provider := anthropic.New(os.Getenv("ANTHROPIC_API_KEY"))
+client := core.NewClient(provider)
+
+resp, err := client.Chat(anthropic.ModelClaudeSonnet45).
+    System("You are a helpful assistant.").
+    User("Explain quantum computing.").
+    GetResponse(ctx)
+```
+
+---
+
+### Google Gemini
+
+**API Endpoint**: `https://generativelanguage.googleapis.com/v1beta`
+
+**Authentication**: API key via `GEMINI_API_KEY` environment variable
+
+**Models**:
+
+| Model | Display Name | Reasoning | Notes |
+|-------|--------------|-----------|-------|
+| gemini-3-pro-preview | Gemini 3 Pro Preview | Yes | Latest preview |
+| gemini-3-flash-preview | Gemini 3 Flash Preview | Yes | Fast preview |
+| gemini-2.5-pro | Gemini 2.5 Pro | Yes | Production ready |
+| gemini-2.5-flash | Gemini 2.5 Flash | Yes | Fast, efficient |
+| gemini-2.5-flash-lite | Gemini 2.5 Flash Lite | Yes | Lightweight |
+
+**Image Generation Models**: gemini-2.5-flash-image, gemini-3-pro-image-preview (Nano Banana)
+
+**Special Features**:
+- Native multimodal support
+- Long context windows
+- Grounding with Google Search
+
+**Usage Example**:
+```go
+provider := gemini.New(os.Getenv("GEMINI_API_KEY"))
+client := core.NewClient(provider)
+
+resp, err := client.Chat(gemini.ModelGemini25Flash).
+    User("Summarize this document.").
+    GetResponse(ctx)
+```
+
+---
+
+### xAI (Grok)
+
+**API Endpoint**: `https://api.x.ai/v1`
+
+**Authentication**: API key via `XAI_API_KEY` environment variable
+
+**Models**:
+
+| Model | Display Name | Reasoning | Notes |
+|-------|--------------|-----------|-------|
+| grok-4 | Grok 4 | Yes | Latest flagship |
+| grok-4-fast-reasoning | Grok 4 Fast (Reasoning) | Yes | Fast with reasoning |
+| grok-4-fast-non-reasoning | Grok 4 Fast (Non-Reasoning) | No | Fast without reasoning |
+| grok-4-1-fast-reasoning | Grok 4.1 Fast (Reasoning) | Yes | Newest fast model |
+| grok-3 | Grok 3 | Yes | Previous generation |
+| grok-3-mini | Grok 3 Mini | Yes | Smaller model |
+| grok-code-fast | Grok Code Fast | No | Code specialized |
+
+**Special Features**:
+- Real-time information access
+- Distinct reasoning modes
+
+**Usage Example**:
+```go
+provider := xai.New(os.Getenv("XAI_API_KEY"))
+client := core.NewClient(provider)
+
+resp, err := client.Chat(xai.ModelGrok4).
+    User("What's happening in tech today?").
+    GetResponse(ctx)
+```
+
+---
+
+### Perplexity
+
+**API Endpoint**: `https://api.perplexity.ai`
+
+**Authentication**: API key via `PERPLEXITY_API_KEY` environment variable
+
+**Models**:
+
+| Model | Display Name | Reasoning | Tool Calling | Notes |
+|-------|--------------|-----------|--------------|-------|
+| sonar | Sonar | No | Yes | Fast search |
+| sonar-pro | Sonar Pro | No | Yes | Enhanced search |
+| sonar-reasoning-pro | Sonar Reasoning Pro | Yes | Yes | Chain of thought |
+| sonar-deep-research | Sonar Deep Research | Yes | No | Comprehensive research |
+
+**Special Features**:
+- Built-in web search and grounding
+- Citation support
+- Research report generation
+
+**Usage Example**:
+```go
+provider := perplexity.New(os.Getenv("PERPLEXITY_API_KEY"))
+client := core.NewClient(provider)
+
+resp, err := client.Chat(perplexity.ModelSonarPro).
+    User("What are the latest developments in AI?").
+    GetResponse(ctx)
+```
+
+---
+
+### Z.ai (GLM)
+
+**API Endpoint**: `https://open.bigmodel.cn/api/paas/v4`
+
+**Authentication**: API key via `ZAI_API_KEY` environment variable
+
+**Models**:
+
+| Model | Display Name | Reasoning | Vision | Notes |
+|-------|--------------|-----------|--------|-------|
+| glm-4.7 | GLM-4.7 | Yes | No | Latest flagship |
+| glm-4.7-flash | GLM-4.7 Flash | No | No | Fast |
+| glm-4.6 | GLM-4.6 | Yes | No | |
+| glm-4.6v | GLM-4.6V | Yes | Yes | Vision capable |
+| glm-4.5 | GLM-4.5 | Yes | No | |
+| glm-4.5v | GLM-4.5V | Yes | Yes | Vision capable |
+| glm-4-32b-0414-128k | GLM-4 32B | No | No | Large context |
+
+**Special Features**:
+- Vision models for image understanding
+- Chinese language optimization
+- Large context windows
+
+**Usage Example**:
+```go
+provider := zai.New(os.Getenv("ZAI_API_KEY"))
+client := core.NewClient(provider)
+
+resp, err := client.Chat(zai.ModelGLM47).
+    User("Explain machine learning.").
+    GetResponse(ctx)
+```
+
+---
+
+### Ollama
+
+**API Endpoint**: `http://localhost:11434` (default local) or `https://ollama.com` (cloud)
+
+**Authentication**: No key required for local; API key for Ollama Cloud
+
+**Models**: Dynamic - any model pulled locally. Common models:
+- llama3.2, llama3.2:70b
+- mistral, mixtral
+- qwen3
+- gemma3
+- deepseek-coder
+
+**Special Features**:
+- Local-first operation
+- No API costs for local usage
+- Custom model support
+- Thinking/reasoning mode for supported models
+
+**Usage Example**:
+```go
+// Local usage (no API key)
+provider := ollama.New()
+
+// Remote instance
+provider := ollama.New(ollama.WithBaseURL("http://remote:11434"))
+
+// Ollama Cloud
+provider := ollama.New(
+    ollama.WithCloud(),
+    ollama.WithAPIKey(os.Getenv("OLLAMA_API_KEY")),
+)
+
+client := core.NewClient(provider)
+resp, err := client.Chat("llama3.2").
+    User("Hello!").
+    GetResponse(ctx)
+```
+
+---
+
+### HuggingFace
+
+**API Endpoint**: `https://router.huggingface.co/v1`
+
+**Authentication**: HuggingFace token with Inference Providers permission
+
+**Models**: Access to thousands of models across multiple inference providers.
+
+**Provider Routing**:
+- `:fastest` - Routes to highest throughput provider
+- `:cheapest` - Routes to lowest cost provider
+- `:provider-name` - Routes to specific provider (cerebras, together, etc.)
+
+**Special Features**:
+- Multi-provider routing
+- Model discovery API
+- Provider status checking
+
+**Usage Example**:
+```go
+provider := huggingface.New(os.Getenv("HF_TOKEN"),
+    huggingface.WithProviderPolicy("fastest"),
+)
+client := core.NewClient(provider)
+
+resp, err := client.Chat("meta-llama/Llama-3-8B-Instruct").
+    User("Hello!").
+    GetResponse(ctx)
+```
+
+---
+
+### VoyageAI
+
+**API Endpoint**: `https://api.voyageai.com/v1`
+
+**Authentication**: API key via `VOYAGE_API_KEY` environment variable
+
+**Note**: VoyageAI is an embeddings and reranking provider. It does not support chat completions.
+
+**Embedding Models**:
+
+| Model | Display Name | Notes |
+|-------|--------------|-------|
+| voyage-4-large | Voyage 4 Large | Highest quality |
+| voyage-4 | Voyage 4 | Balanced |
+| voyage-4-lite | Voyage 4 Lite | Lightweight |
+| voyage-3.5 | Voyage 3.5 | |
+| voyage-3-large | Voyage 3 Large | |
+| voyage-code-3 | Voyage Code 3 | Code specialized |
+| voyage-finance-2 | Voyage Finance 2 | Finance domain |
+| voyage-law-2 | Voyage Law 2 | Legal domain |
+| voyage-context-3 | Voyage Context 3 | Contextualized embeddings |
+
+**Reranker Models**:
+
+| Model | Display Name |
+|-------|--------------|
+| rerank-2.5 | Rerank 2.5 |
+| rerank-2.5-lite | Rerank 2.5 Lite |
+| rerank-2 | Rerank 2 |
+| rerank-2-lite | Rerank 2 Lite |
+
+**Usage Example**:
+```go
+provider := voyageai.New(os.Getenv("VOYAGE_API_KEY"))
+
+// Generate embeddings
+embeddings, err := provider.Embed(ctx, &core.EmbeddingRequest{
+    Model: voyageai.ModelVoyage4,
+    Input: []string{"Hello, world!"},
+})
+
+// Rerank results
+results, err := provider.Rerank(ctx, &core.RerankRequest{
+    Model:     voyageai.ModelRerank25,
+    Query:     "machine learning",
+    Documents: []string{"doc1", "doc2", "doc3"},
+})
+```
+
+## Choosing a Provider
+
+| Use Case | Recommended Provider(s) |
+|----------|------------------------|
+| General chat and coding | OpenAI (GPT-4o, GPT-5), Anthropic (Claude) |
+| Complex reasoning | OpenAI (o-series), Gemini 3, xAI Grok 4 |
+| Web search integration | Perplexity |
+| Local/private deployment | Ollama |
+| Cost-sensitive applications | HuggingFace (routing), Ollama (local) |
+| Embeddings and RAG | VoyageAI |
+| Code generation | OpenAI (Codex models), Anthropic |
+| Multimodal (vision) | OpenAI (GPT-4o), Gemini, Z.ai (GLM-V) |
+| Image generation | OpenAI (DALL-E, GPT-Image), Gemini (Nano Banana) |
+
+## Rate Limits and Pricing
+
+Rate limits and pricing vary by provider and subscription tier. Consult each provider's documentation for current information:
+
+- **OpenAI**: https://platform.openai.com/docs/guides/rate-limits
+- **Anthropic**: https://docs.anthropic.com/en/api/rate-limits
+- **Google Gemini**: https://ai.google.dev/pricing
+- **xAI**: https://docs.x.ai/docs
+- **Perplexity**: https://docs.perplexity.ai/guides/rate-limits
+- **Z.ai**: https://open.bigmodel.cn/pricing
+- **Ollama**: No rate limits for local usage
+- **HuggingFace**: https://huggingface.co/docs/api-inference/rate-limits
+- **VoyageAI**: https://docs.voyageai.com/docs/rate-limits

--- a/docs/docs_test.go
+++ b/docs/docs_test.go
@@ -1,0 +1,181 @@
+package docs_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestProvidersDocExists verifies PROVIDERS.md exists and contains required sections.
+func TestProvidersDocExists(t *testing.T) {
+	content := readDocFile(t, "PROVIDERS.md")
+
+	requiredSections := []string{
+		"# Provider Comparison",
+		"## Feature Support Matrix",
+		"## Provider Details",
+		"### OpenAI",
+		"### Anthropic",
+		"### Google Gemini",
+		"### xAI (Grok)",
+		"### Perplexity",
+		"### Z.ai (GLM)",
+		"### Ollama",
+		"### HuggingFace",
+		"### VoyageAI",
+		"## Choosing a Provider",
+		"## Rate Limits and Pricing",
+	}
+
+	for _, section := range requiredSections {
+		if !strings.Contains(content, section) {
+			t.Errorf("PROVIDERS.md missing required section: %q", section)
+		}
+	}
+
+	// Verify feature matrix table exists
+	if !strings.Contains(content, "| Provider |") {
+		t.Error("PROVIDERS.md missing feature support matrix table")
+	}
+
+	// Verify code examples exist for major providers
+	providers := []string{"openai", "anthropic", "gemini", "ollama"}
+	for _, p := range providers {
+		if !strings.Contains(strings.ToLower(content), "```go") {
+			t.Errorf("PROVIDERS.md missing Go code examples")
+			break
+		}
+		if !strings.Contains(strings.ToLower(content), p+".new") {
+			t.Errorf("PROVIDERS.md missing usage example for %s provider", p)
+		}
+	}
+}
+
+// TestArchitectureDocExists verifies ARCHITECTURE.md exists and contains required sections.
+func TestArchitectureDocExists(t *testing.T) {
+	content := readDocFile(t, "ARCHITECTURE.md")
+
+	requiredSections := []string{
+		"# Architecture Design Decisions",
+		"## Why Streaming Is First-Class",
+		"## Why Provider Is an Interface",
+		"## Why ChatBuilder Is Not Thread-Safe",
+		"## Why Tools Use json.RawMessage",
+		"## Why Sentinel Errors",
+		"## Why Exponential Backoff",
+		"## Why Features Are Explicit",
+		"## Summary of Design Principles",
+	}
+
+	for _, section := range requiredSections {
+		if !strings.Contains(content, section) {
+			t.Errorf("ARCHITECTURE.md missing required section: %q", section)
+		}
+	}
+
+	// Verify each section has rationale
+	if strings.Count(content, "### Rationale") < 5 {
+		t.Error("ARCHITECTURE.md should have Rationale subsections for design decisions")
+	}
+
+	// Verify alternatives considered are documented
+	if strings.Count(content, "### Alternatives Considered") < 3 {
+		t.Error("ARCHITECTURE.md should document alternatives considered for major decisions")
+	}
+
+	// Verify code examples are included
+	if !strings.Contains(content, "```go") {
+		t.Error("ARCHITECTURE.md should include Go code examples")
+	}
+}
+
+// TestCoreDocGoExists verifies core/doc.go has comprehensive package documentation.
+func TestCoreDocGoExists(t *testing.T) {
+	content := readCoreDocFile(t)
+
+	requiredSections := []string{
+		"Package core provides",
+		"# Client and Provider",
+		"# ChatBuilder",
+		"# Streaming",
+		"# Provider Interface",
+		"# Features",
+		"# Error Handling",
+		"# Telemetry",
+		"# Retry Policy",
+		"# Thread Safety",
+	}
+
+	for _, section := range requiredSections {
+		if !strings.Contains(content, section) {
+			t.Errorf("core/doc.go missing required section: %q", section)
+		}
+	}
+
+	// Verify examples are included
+	if !strings.Contains(content, "provider :=") {
+		t.Error("core/doc.go should include provider creation example")
+	}
+	if !strings.Contains(content, "client.Chat(") {
+		t.Error("core/doc.go should include Chat usage example")
+	}
+
+	// Verify feature constants are documented
+	features := []string{
+		"FeatureChat",
+		"FeatureChatStreaming",
+		"FeatureToolCalling",
+		"FeatureReasoning",
+	}
+	for _, f := range features {
+		if !strings.Contains(content, f) {
+			t.Errorf("core/doc.go should document %s feature", f)
+		}
+	}
+
+	// Verify error constants are documented
+	errors := []string{
+		"ErrUnauthorized",
+		"ErrRateLimited",
+		"ErrBadRequest",
+		"ErrModelRequired",
+	}
+	for _, e := range errors {
+		if !strings.Contains(content, e) {
+			t.Errorf("core/doc.go should document %s error", e)
+		}
+	}
+}
+
+// readDocFile reads a file from the docs directory.
+func readDocFile(t *testing.T, filename string) string {
+	t.Helper()
+
+	// Get the directory of the test file
+	_, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+
+	path := filepath.Join(filename)
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read %s: %v", filename, err)
+	}
+
+	return string(content)
+}
+
+// readCoreDocFile reads the core/doc.go file.
+func readCoreDocFile(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join("..", "core", "doc.go")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read core/doc.go: %v", err)
+	}
+
+	return string(content)
+}


### PR DESCRIPTION
## Summary

- Expand `core/doc.go` with comprehensive package documentation covering Client, ChatBuilder, streaming, Provider interface, features, error handling, telemetry, and thread safety
- Add `docs/PROVIDERS.md` with feature comparison matrix, model tables, and usage examples for all 9 providers
- Add `docs/ARCHITECTURE.md` explaining key design decisions (streaming first-class, Provider as interface, ChatBuilder thread safety, json.RawMessage for tools)
- Add `docs/docs_test.go` with unit tests verifying documentation completeness

## Test plan

- [x] All documentation tests pass (`go test ./docs/...`)
- [x] All existing tests continue to pass (`go test ./...`)
- [x] Code passes gofmt and golangci-lint checks
- [ ] Review documentation content for accuracy and clarity