### PR TITLE
ci: add Codecov integration for test coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,20 @@ jobs:
         run: go build ./...
 
       - name: Test
+        if: matrix.os != 'ubuntu-latest'
         run: go test ./...
+
+      - name: Test with coverage
+        if: matrix.os == 'ubuntu-latest'
+        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.out
+          fail_ci_if_error: false
+          verbose: true
 
       - name: Vet
         run: go vet ./...

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Iris SDK Makefile
 
-.PHONY: all build test lint fmt vet clean install-hooks help
+.PHONY: all build test lint fmt vet clean install-hooks help coverage
 
 # Version information
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -25,9 +25,19 @@ test:
 test-v:
 	go test -v ./...
 
-# Run tests with coverage
+# Run tests with coverage summary
 test-cover:
 	go test -cover ./...
+
+# Generate coverage profile for CI/Codecov
+coverage:
+	go test -race -coverprofile=coverage.out -covermode=atomic ./...
+	@echo "Coverage report generated: coverage.out"
+
+# Generate and view HTML coverage report
+coverage-html: coverage
+	go tool cover -html=coverage.out -o coverage.html
+	@echo "HTML report generated: coverage.html"
 
 # Lint: format check and vet
 lint: fmt-check vet
@@ -84,7 +94,9 @@ help:
 	@echo "  build          Build all packages"
 	@echo "  test           Run all tests"
 	@echo "  test-v         Run tests with verbose output"
-	@echo "  test-cover     Run tests with coverage"
+	@echo "  test-cover     Run tests with coverage summary"
+	@echo "  coverage       Generate coverage.out profile for Codecov"
+	@echo "  coverage-html  Generate HTML coverage report"
 	@echo "  lint           Run fmt-check and vet"
 	@echo "  fmt-check      Check if files are formatted"
 	@echo "  fmt            Format all Go files"


### PR DESCRIPTION
## Summary
- Add coverage generation step to CI workflow (ubuntu-latest only)
- Upload coverage reports to Codecov using codecov-action v5
- Add `make coverage` and `make coverage-html` targets for local development

## Test plan
- [ ] Verify CI workflow runs successfully on all platforms
- [ ] Confirm coverage report uploads to Codecov after merge
- [ ] Test `make coverage` generates coverage.out locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)