### PR TITLE
feat(core): add tool result injection for multi-turn tool use

### DIFF
--- a/core/types.go
+++ b/core/types.go
@@ -119,8 +119,8 @@ type ToolCall struct {
 // ToolResult represents the outcome of executing a tool.
 // Use this for untyped tool results where the Content can be any JSON-serializable value.
 type ToolResult struct {
-	CallID  string `json:"call_id"` // Must match ToolCall.ID from the response
-	Content any    `json:"content"` // Result data (will be JSON marshaled)
+	CallID  string `json:"call_id"`  // Must match ToolCall.ID from the response
+	Content any    `json:"content"`  // Result data (will be JSON marshaled)
 	IsError bool   `json:"is_error"` // True if this represents an error
 }
 

--- a/providers/anthropic/types_anthropic.go
+++ b/providers/anthropic/types_anthropic.go
@@ -24,9 +24,14 @@ type anthropicMessage struct {
 type anthropicContentBlock struct {
 	Type string `json:"type"`
 	Text string `json:"text,omitempty"`
-	// For tool_result blocks
+	// For tool_use blocks (assistant requesting tool)
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+	// For tool_result blocks (user providing result)
 	ToolUseID string `json:"tool_use_id,omitempty"`
 	Content   string `json:"content,omitempty"`
+	IsError   bool   `json:"is_error,omitempty"`
 }
 
 // anthropicTool represents a tool definition in the Anthropic format.

--- a/providers/openai/types_openai.go
+++ b/providers/openai/types_openai.go
@@ -17,7 +17,7 @@ type openAIRequest struct {
 type openAIMessage struct {
 	Role       string           `json:"role"`
 	Content    string           `json:"content,omitempty"`
-	ToolCalls  []openAIToolCall `json:"tool_calls,omitempty"`  // For assistant messages requesting tools
+	ToolCalls  []openAIToolCall `json:"tool_calls,omitempty"`   // For assistant messages requesting tools
 	ToolCallID string           `json:"tool_call_id,omitempty"` // For tool result messages
 }
 

--- a/providers/openai/types_openai.go
+++ b/providers/openai/types_openai.go
@@ -15,8 +15,10 @@ type openAIRequest struct {
 
 // openAIMessage represents a message in the OpenAI format.
 type openAIMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role       string           `json:"role"`
+	Content    string           `json:"content,omitempty"`
+	ToolCalls  []openAIToolCall `json:"tool_calls,omitempty"`  // For assistant messages requesting tools
+	ToolCallID string           `json:"tool_call_id,omitempty"` // For tool result messages
 }
 
 // openAITool represents a tool definition in the OpenAI format.


### PR DESCRIPTION
## Summary

- Add provider-agnostic API for injecting tool execution results into chat conversations
- Enable multi-turn tool use workflows with immutable builder pattern
- Support OpenAI, Anthropic, and Ollama provider mappings

## Changes

**Core Types (`core/types.go`):**
- `RoleTool` constant for tool result messages
- `ToolResult` struct with `CallID`, `Content`, and `IsError` fields
- `TypedToolResult[T]` generic struct for type-safe results
- `ToolResultBuilder` and `TypedToolResultBuilder[T]` for fluent construction

**ChatBuilder (`core/client.go`):**
- `ToolResults()` - adds assistant message with tool calls + tool results message
- `ToolResult()` - convenience for single successful result
- `ToolError()` - convenience for single error result
- `Clone()` - now deep copies `ToolCalls` and `ToolResults`

**Provider Mappings:**
- OpenAI: maps `RoleTool` to individual `tool` messages with `tool_call_id`
- Anthropic: maps `RoleTool` to `user` message with `tool_result` content blocks
- Ollama: maps `RoleTool` to `tool` messages

## Test plan

- [x] Unit tests for `ToolResult`, `TypedToolResult[T]`, and builders
- [x] Unit tests for `ToolResults()`, `ToolResult()`, `ToolError()` methods
- [x] Tests for immutability (original builder unchanged after `ToolResults()`)
- [x] Tests for `Clone()` with tool calls and results
- [x] All existing tests continue to pass