### PR TITLE
fix(ci): add missing PERPLEXITY_API_KEY to integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,5 +37,6 @@ jobs:
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
           ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
           VOYAGEAI_API_KEY: ${{ secrets.VOYAGEAI_API_KEY }}
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: go test -tags=integration ./tests/integration/... -count=1 -v


### PR DESCRIPTION
## Summary

- Added `PERPLEXITY_API_KEY` to the environment variables in the integration test workflow
- The secret existed in GitHub but was not being mapped to the test environment

## Root Cause

The integration workflow at `.github/workflows/integration.yml` explicitly maps secrets to environment variables for each test step. `PERPLEXITY_API_KEY` was missing from this mapping, causing tests to fail with "PERPLEXITY_API_KEY not set" even though the secret was configured in GitHub.

## Test plan

- [x] Trigger a manual workflow run of the integration tests
- [ ] Verify Perplexity-related tests no longer fail due to missing API key

🤖 Generated with [Claude Code](https://claude.ai/code)