### PR TITLE
fix(test): remove outdated agents expectation from CLI init test

### DIFF
--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -121,7 +121,6 @@ func TestCLI_Init(t *testing.T) {
 	files := []string{
 		"main.go",
 		"iris.yaml",
-		"agents/.gitkeep",
 		"tools/.gitkeep",
 	}
 


### PR DESCRIPTION
## Summary
- Removed `agents/.gitkeep` from expected files in `TestCLI_Init` integration test
- Agents were removed from Iris when PetalFlow was created, but the test was not updated

## Test plan
- [x] `go test -v -tags=integration -run TestCLI_Init ./tests/integration/...` passes
- [x] `go test -v ./cli/commands/... -run Init` passes