### PR TITLE
[codex] fix perplexity tools integration test model

### DIFF
--- a/tests/integration/perplexity_test.go
+++ b/tests/integration/perplexity_test.go
@@ -121,7 +121,7 @@ func TestPerplexity_ChatCompletion_WithTools(t *testing.T) {
 
 	tool := createTestTool()
 
-	resp, err := client.Chat(perplexity.ModelSonar).
+	resp, err := client.Chat(perplexity.ModelSonarPro).
 		User("What's the weather like in San Francisco?").
 		Tools(tool).
 		GetResponse(ctx)


### PR DESCRIPTION
## Summary
A Perplexity integration test began failing because it attempted tool-calling with a model that no longer supports tools in practice. This made the integration suite fail even though the provider implementation itself was healthy.

## User Impact
When running integration tests, the suite failed in `TestPerplexity_ChatCompletion_WithTools` with a provider error (`Tool calling is not supported for this model`). This blocked CI confidence for integration coverage and introduced noise for contributors.

## Root Cause
The test used `perplexity.ModelSonar` for tool-calling. Current provider behavior rejects tool-calling for that model, so the request fails before the test can assert tool/text behavior.

## Fix
Updated the test to use `perplexity.ModelSonarPro` in `TestPerplexity_ChatCompletion_WithTools`, which supports the test scenario.

- File changed:
  - `tests/integration/perplexity_test.go`

## Validation
Executed and passed:

- `go test -tags=integration ./tests/integration -run '^TestPerplexity_ChatCompletion_WithTools$' -v -count=1 -timeout=3m`
- `go test -tags=integration ./tests/integration -run '^TestPerplexity' -v -count=1 -timeout=6m`
- `go test -tags=integration ./tests/integration -count=1 -timeout=15m`
