### PR TITLE
[codex] harden P0 warning handling and contributor DX

### DIFF
--- a/.github/workflows/integration-smoke.yml
+++ b/.github/workflows/integration-smoke.yml
@@ -1,0 +1,39 @@
+name: PR Integration Smoke
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.x"
+          cache: true
+
+      - name: Check OpenAI secret
+        id: keycheck
+        env:
+          HAS_OPENAI: ${{ secrets.OPENAI_API_KEY != '' }}
+        run: |
+          if [ "$HAS_OPENAI" = "true" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "OPENAI_API_KEY is not configured for this run; skipping smoke test."
+          fi
+
+      - name: Run OpenAI integration smoke test
+        if: steps.keycheck.outputs.available == 'true'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: go test -tags=integration ./tests/integration/... -run '^TestOpenAI_ChatCompletion$' -count=1 -v

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing to Iris
+
+Thanks for contributing to Iris.
+
+## Prerequisites
+
+- Go 1.24+
+- Make (optional, but recommended)
+- Git
+
+## Local Setup
+
+```bash
+git clone https://github.com/petal-labs/iris.git
+cd iris
+make install-hooks
+```
+
+## Development Workflow
+
+1. Create a branch from `main`.
+2. Keep changes focused and small.
+3. Run the appropriate test tier locally.
+4. Open a pull request with a clear summary and test notes.
+
+## Test Tiers
+
+Use the lightest tier that provides confidence for your change:
+
+### Fast (iteration while coding)
+
+```bash
+go test ./core/... ./tools/... ./cli/...
+```
+
+### Standard (required before opening PR)
+
+```bash
+make lint
+make test
+make build
+```
+
+### Full (networked integration coverage)
+
+```bash
+make test-integration
+```
+
+Integration tests use real provider APIs and require credentials. See the next section for required environment variables.
+
+## Integration Test Keys
+
+Set provider keys as needed for the tests you run:
+
+```bash
+export OPENAI_API_KEY=...
+export ANTHROPIC_API_KEY=...   # optional unless running Anthropic tests
+export GEMINI_API_KEY=...      # optional unless running Gemini tests
+export XAI_API_KEY=...         # optional unless running xAI tests
+export ZAI_API_KEY=...         # optional unless running Z.ai tests
+export PERPLEXITY_API_KEY=...  # optional unless running Perplexity tests
+export VOYAGEAI_API_KEY=...    # optional unless running VoyageAI tests
+export HF_TOKEN=...            # optional unless running Hugging Face tests
+```
+
+Run a focused OpenAI smoke test:
+
+```bash
+go test -tags=integration ./tests/integration/... -run '^TestOpenAI_ChatCompletion$' -count=1 -v
+```
+
+In CI, integration tests fail on missing required keys unless `IRIS_SKIP_INTEGRATION=1` is set.
+
+## Code Style and Quality
+
+- Format with `gofmt` (`make fmt`).
+- Keep `go vet` clean (`make vet`).
+- Prefer small, composable functions over large control blocks.
+- Add tests for behavior changes and regressions.
+
+## Pull Request Checklist
+
+- [ ] Scope is focused and described clearly.
+- [ ] `make lint`, `make test`, and `make build` pass locally.
+- [ ] Integration tests were run when relevant, or explicitly noted as not run.
+- [ ] New behavior is covered by tests.
+- [ ] User-facing docs are updated when behavior or APIs change.

--- a/README.md
+++ b/README.md
@@ -909,4 +909,4 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit issues and pull requests.
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, test tiers, and PR expectations.

--- a/core/doc.go
+++ b/core/doc.go
@@ -13,6 +13,7 @@
 //	client := core.NewClient(provider,
 //	    core.WithTelemetry(myTelemetryHook),
 //	    core.WithRetryPolicy(core.DefaultRetryPolicy()),
+//	    core.WithWarningHandler(func(msg string) { log.Printf("iris warning: %s", msg) }),
 //	)
 //
 // # ChatBuilder
@@ -130,6 +131,11 @@
 //
 // The default policy retries transient errors (rate limits, server errors) with
 // exponential backoff.
+//
+// # Warnings
+//
+// Non-fatal SDK warnings (for example, mismatched tool result IDs) can be routed
+// through [WithWarningHandler]. The default warning handler is a no-op.
 //
 // # Multimodal Messages
 //


### PR DESCRIPTION
## Summary
This PR implements the P0 hardening items from `/Users/erikhoward/src/github/petal-labs/iris/.spec/2026-02-15-codebase-organization-audit.md`.

The changes focus on reducing noisy library behavior, clarifying contributor workflow, and adding low-cost integration signal on pull requests.

## Problem and User Impact
The SDK emitted non-fatal warnings using direct `println` calls in core library code. That made warnings hard to route, suppress, or test in applications using Iris as a dependency.

Contributor expectations (setup, test tiers, and PR validation) were also spread across README sections, which increases onboarding friction and inconsistent local validation.

Finally, integration coverage only ran on schedule/manual dispatch, so pull requests lacked an early integration smoke signal.

## Root Cause
- Warning output was hardcoded in `core/client.go` with `println`.
- There was no dedicated `CONTRIBUTING.md` contributor contract.
- CI had full integration workflow, but no PR-triggered lightweight integration job.

## Fix
- Added a configurable warning hook in `core.Client`:
  - `type WarningHandler func(message string)`
  - `WithWarningHandler(...)` client option
  - Default no-op handler for backward-safe behavior
  - Replaced `println` warning sites in `ToolResults` with the new handler
- Added tests covering warning handler wiring and tool-result warning emission.
- Updated core package docs with warning handler guidance.
- Added `CONTRIBUTING.md` with prerequisites, workflow, test tiers, integration key setup, and PR checklist.
- Updated README contributing section to point to `CONTRIBUTING.md`.
- Added `.github/workflows/integration-smoke.yml`:
  - Runs on pull requests and manual dispatch
  - Executes a single OpenAI integration smoke test
  - Gracefully skips when `OPENAI_API_KEY` is unavailable

## Validation
I ran the following locally on this branch:
- `make lint`
- `make test`
- `make build`
- `go test -tags=integration ./tests/integration/... -run '^TestOpenAI_ChatCompletion$' -count=1`

All commands passed.
