### PR TITLE
[codex] migrate remaining providers to shared error normalization

### DIFF
--- a/providers/internal/normalize/errors_test.go
+++ b/providers/internal/normalize/errors_test.go
@@ -113,3 +113,27 @@ func TestDecodeError(t *testing.T) {
 		t.Error("error should wrap core.ErrDecode")
 	}
 }
+
+func TestProviderErrorDefaults(t *testing.T) {
+	err := ProviderError("test-provider", http.StatusBadGateway, "req-1", "", "", nil)
+
+	var provErr *core.ProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatal("expected *core.ProviderError")
+	}
+	if provErr.Message != "Bad Gateway" {
+		t.Errorf("Message = %q, want Bad Gateway", provErr.Message)
+	}
+	if !errors.Is(err, core.ErrServer) {
+		t.Error("error should wrap core.ErrServer")
+	}
+}
+
+func TestSentinelForStatusWithOverrides(t *testing.T) {
+	sentinel := SentinelForStatusWithOverrides(http.StatusNotFound, map[int]error{
+		http.StatusNotFound: core.ErrNotFound,
+	})
+	if !errors.Is(sentinel, core.ErrNotFound) {
+		t.Errorf("sentinel = %v, want ErrNotFound", sentinel)
+	}
+}

--- a/providers/openai/errors.go
+++ b/providers/openai/errors.go
@@ -1,17 +1,16 @@
 package openai
 
 import (
-	"encoding/json"
 	"errors"
-	"net/http"
 
-	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
 )
 
 // ErrToolArgsInvalidJSON is returned when tool call arguments contain invalid JSON.
 var ErrToolArgsInvalidJSON = errors.New("tool args invalid json")
 
-// openAIErrorResponse represents an error response from the OpenAI API.
+// openAIErrorResponse represents an OpenAI API error response.
+// It is retained for test fixtures.
 type openAIErrorResponse struct {
 	Error struct {
 		Message string `json:"message"`
@@ -22,59 +21,15 @@ type openAIErrorResponse struct {
 
 // normalizeError converts an HTTP error response to a ProviderError with the appropriate sentinel.
 func normalizeError(status int, body []byte, requestID string) error {
-	// Parse error response if possible
-	var errResp openAIErrorResponse
-	_ = json.Unmarshal(body, &errResp)
-
-	message := errResp.Error.Message
-	if message == "" {
-		message = http.StatusText(status)
-	}
-
-	code := errResp.Error.Code
-	if code == "" {
-		code = errResp.Error.Type
-	}
-
-	// Determine sentinel error based on status
-	var sentinel error
-	switch {
-	case status == http.StatusBadRequest:
-		sentinel = core.ErrBadRequest
-	case status == http.StatusUnauthorized || status == http.StatusForbidden:
-		sentinel = core.ErrUnauthorized
-	case status == http.StatusTooManyRequests:
-		sentinel = core.ErrRateLimited
-	case status >= 500:
-		sentinel = core.ErrServer
-	default:
-		sentinel = core.ErrServer
-	}
-
-	return &core.ProviderError{
-		Provider:  "openai",
-		Status:    status,
-		RequestID: requestID,
-		Code:      code,
-		Message:   message,
-		Err:       sentinel,
-	}
+	return normalize.OpenAIStyleProviderError("openai", status, body, requestID)
 }
 
 // newNetworkError creates a ProviderError for network-related failures.
 func newNetworkError(err error) error {
-	return &core.ProviderError{
-		Provider: "openai",
-		Message:  err.Error(),
-		Err:      core.ErrNetwork,
-	}
+	return normalize.NetworkError("openai", err)
 }
 
 // newDecodeError creates a ProviderError for JSON decode failures.
 func newDecodeError(err error) error {
-	return &core.ProviderError{
-		Provider: "openai",
-		Message:  err.Error(),
-		Err:      core.ErrDecode,
-	}
+	return normalize.DecodeError("openai", err)
 }

--- a/providers/xai/errors.go
+++ b/providers/xai/errors.go
@@ -1,80 +1,25 @@
 package xai
 
 import (
-	"encoding/json"
 	"errors"
-	"net/http"
 
-	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
 )
 
 // ErrToolArgsInvalidJSON is returned when tool call arguments contain invalid JSON.
 var ErrToolArgsInvalidJSON = errors.New("tool args invalid json")
 
-// xaiErrorResponse represents an error response from the xAI API.
-type xaiErrorResponse struct {
-	Error struct {
-		Message string `json:"message"`
-		Type    string `json:"type"`
-		Code    string `json:"code"`
-	} `json:"error"`
-}
-
 // normalizeError converts an HTTP error response to a ProviderError with the appropriate sentinel.
 func normalizeError(status int, body []byte, requestID string) error {
-	// Parse error response if possible
-	var errResp xaiErrorResponse
-	_ = json.Unmarshal(body, &errResp)
-
-	message := errResp.Error.Message
-	if message == "" {
-		message = http.StatusText(status)
-	}
-
-	code := errResp.Error.Code
-	if code == "" {
-		code = errResp.Error.Type
-	}
-
-	// Determine sentinel error based on status
-	var sentinel error
-	switch {
-	case status == http.StatusBadRequest:
-		sentinel = core.ErrBadRequest
-	case status == http.StatusUnauthorized || status == http.StatusForbidden:
-		sentinel = core.ErrUnauthorized
-	case status == http.StatusTooManyRequests:
-		sentinel = core.ErrRateLimited
-	case status >= 500:
-		sentinel = core.ErrServer
-	default:
-		sentinel = core.ErrServer
-	}
-
-	return &core.ProviderError{
-		Provider:  "xai",
-		Status:    status,
-		RequestID: requestID,
-		Code:      code,
-		Message:   message,
-		Err:       sentinel,
-	}
+	return normalize.OpenAIStyleProviderError("xai", status, body, requestID)
 }
 
 // newNetworkError creates a ProviderError for network-related failures.
 func newNetworkError(err error) error {
-	return &core.ProviderError{
-		Provider: "xai",
-		Message:  err.Error(),
-		Err:      core.ErrNetwork,
-	}
+	return normalize.NetworkError("xai", err)
 }
 
 // newDecodeError creates a ProviderError for JSON decode failures.
 func newDecodeError(err error) error {
-	return &core.ProviderError{
-		Provider: "xai",
-		Message:  err.Error(),
-		Err:      core.ErrDecode,
-	}
+	return normalize.DecodeError("xai", err)
 }


### PR DESCRIPTION
## Summary
This PR migrates all remaining providers to use the shared provider error normalization helper in `providers/internal/normalize`.

It completes the staged P1 normalization work that started with Perplexity and Hugging Face by removing duplicated normalization/network/decode scaffolding across the rest of the provider set.

## Problem and User Impact
Several provider packages still reimplemented near-identical logic for:
- parsing provider error envelopes,
- mapping HTTP status codes to Iris sentinel errors,
- wrapping network and decode failures.

This duplication increases maintenance risk: behavior drift can occur between providers over time, and fixes to normalization behavior require repetitive edits in multiple packages.

## Root Cause
Error normalization was historically implemented provider-by-provider, even when providers shared the same OpenAI-style envelope and status mapping model.

## Fix
### Shared helper enhancements
- Extended `providers/internal/normalize/errors.go` with reusable building blocks:
  - `ProviderError(...)`
  - `SentinelForStatus(...)`
  - `SentinelForStatusWithOverrides(...)`
- Kept existing helper entrypoints (`OpenAIStyleProviderError`, `NetworkError`, `DecodeError`) and added tests for new helper behavior in `providers/internal/normalize/errors_test.go`.

### Provider migrations
Migrated remaining providers to use shared helper paths:
- `providers/openai/errors.go`
- `providers/anthropic/errors.go`
- `providers/gemini/errors.go`
- `providers/xai/errors.go`
- `providers/zai/errors.go`
- `providers/voyageai/errors.go`
- `providers/ollama/errors.go` (uses shared sentinel mapping while keeping Ollama-specific error code strings)

Previously migrated providers already on shared helper:
- `providers/perplexity/errors.go`
- `providers/huggingface/errors.go`

## Behavioral Compatibility
Provider-specific semantics were preserved where they intentionally differ from default mapping:
- Anthropic `404` remains `core.ErrNotFound`.
- Gemini and Z.ai `404` remain `core.ErrBadRequest`.
- Ollama keeps its existing provider-specific `Code` strings and now uses shared sentinel mapping with `404 -> core.ErrBadRequest` override.

## Validation
Ran locally on this branch:
- `make lint`
- `go test ./...`
- targeted provider checks during migration:
  - `go test ./providers/internal/normalize ./providers/openai ./providers/anthropic ./providers/gemini ./providers/xai ./providers/zai ./providers/voyageai ./providers/ollama`

All passed.
