### PR TITLE
[codex] Refactor P2 foundations for providers, tools, and integration tests

### DIFF
--- a/providers/huggingface/streaming.go
+++ b/providers/huggingface/streaming.go
@@ -5,83 +5,46 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/toolcalls"
 )
 
 // toolCallAssembler accumulates streaming tool call fragments.
 type toolCallAssembler struct {
-	calls map[int]*assemblingToolCall
-}
-
-type assemblingToolCall struct {
-	ID        string
-	Name      string
-	Arguments strings.Builder
+	asm *toolcalls.Assembler
 }
 
 func newToolCallAssembler() *toolCallAssembler {
 	return &toolCallAssembler{
-		calls: make(map[int]*assemblingToolCall),
+		asm: toolcalls.NewAssembler(toolcalls.Config{}),
 	}
 }
 
 // addFragment processes a streaming tool call fragment.
 func (a *toolCallAssembler) addFragment(tc hfStreamToolCall) {
-	call, exists := a.calls[tc.Index]
-	if !exists {
-		call = &assemblingToolCall{}
-		a.calls[tc.Index] = call
-	}
-
-	if tc.ID != "" {
-		call.ID = tc.ID
-	}
-	if tc.Function.Name != "" {
-		call.Name = tc.Function.Name
-	}
-	if tc.Function.Arguments != "" {
-		call.Arguments.WriteString(tc.Function.Arguments)
-	}
+	a.asm.AddFragment(toolcalls.Fragment{
+		Index:     tc.Index,
+		ID:        tc.ID,
+		Name:      tc.Function.Name,
+		Arguments: tc.Function.Arguments,
+	})
 }
 
 // finalize validates and returns the assembled tool calls.
 func (a *toolCallAssembler) finalize() ([]core.ToolCall, error) {
-	if len(a.calls) == 0 {
-		return nil, nil
-	}
-
-	// Find max index to determine slice size
-	maxIndex := 0
-	for idx := range a.calls {
-		if idx > maxIndex {
-			maxIndex = idx
-		}
-	}
-
-	result := make([]core.ToolCall, 0, len(a.calls))
-	for i := 0; i <= maxIndex; i++ {
-		call, exists := a.calls[i]
-		if !exists {
-			continue
-		}
-
-		args := call.Arguments.String()
-		if !json.Valid([]byte(args)) {
+	calls, err := a.asm.Finalize()
+	if err != nil {
+		if errors.Is(err, toolcalls.ErrInvalidJSON) {
 			return nil, ErrToolArgsInvalidJSON
 		}
-
-		result = append(result, core.ToolCall{
-			ID:        call.ID,
-			Name:      call.Name,
-			Arguments: json.RawMessage(args),
-		})
+		return nil, err
 	}
-
-	return result, nil
+	return calls, nil
 }
 
 // doStreamChat performs a streaming chat completion request.

--- a/providers/huggingface/streaming_test.go
+++ b/providers/huggingface/streaming_test.go
@@ -385,8 +385,8 @@ func TestNewToolCallAssembler(t *testing.T) {
 	if asm == nil {
 		t.Fatal("newToolCallAssembler() returned nil")
 	}
-	if asm.calls == nil {
-		t.Fatal("newToolCallAssembler().calls should not be nil")
+	if asm.asm == nil {
+		t.Fatal("newToolCallAssembler().asm should not be nil")
 	}
 }
 

--- a/providers/internal/toolcalls/assembler.go
+++ b/providers/internal/toolcalls/assembler.go
@@ -1,0 +1,123 @@
+// Package toolcalls provides shared streaming tool-call assembly utilities.
+package toolcalls
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/petal-labs/iris/core"
+)
+
+// ErrInvalidJSON is returned when assembled tool arguments are not valid JSON.
+var ErrInvalidJSON = errors.New("tool args invalid json")
+
+// Config controls assembler behavior.
+type Config struct {
+	// EmptyArgumentsJSON, when set, is used as arguments when a tool call has no
+	// accumulated argument fragments.
+	EmptyArgumentsJSON string
+}
+
+// Fragment represents one streaming tool-call delta fragment.
+type Fragment struct {
+	Index     int
+	ID        string
+	Name      string
+	Arguments string
+}
+
+type assemblingCall struct {
+	ID        string
+	Name      string
+	Arguments strings.Builder
+}
+
+// Assembler accumulates fragmented tool calls and emits canonical tool calls.
+type Assembler struct {
+	calls map[int]*assemblingCall
+	cfg   Config
+}
+
+// NewAssembler creates a tool-call assembler.
+func NewAssembler(cfg Config) *Assembler {
+	return &Assembler{
+		calls: make(map[int]*assemblingCall),
+		cfg:   cfg,
+	}
+}
+
+// AddFragment applies a streaming fragment, creating a call entry if needed.
+func (a *Assembler) AddFragment(f Fragment) {
+	call, exists := a.calls[f.Index]
+	if !exists {
+		call = &assemblingCall{}
+		a.calls[f.Index] = call
+	}
+
+	if f.ID != "" {
+		call.ID = f.ID
+	}
+	if f.Name != "" {
+		call.Name = f.Name
+	}
+	if f.Arguments != "" {
+		call.Arguments.WriteString(f.Arguments)
+	}
+}
+
+// StartCall initializes a tool call by index.
+func (a *Assembler) StartCall(index int, id, name string) {
+	a.calls[index] = &assemblingCall{
+		ID:   id,
+		Name: name,
+	}
+}
+
+// AddArguments appends argument fragments for an existing call.
+// If the call index has not been initialized, this is a no-op.
+func (a *Assembler) AddArguments(index int, chunk string) {
+	call, exists := a.calls[index]
+	if !exists || chunk == "" {
+		return
+	}
+	call.Arguments.WriteString(chunk)
+}
+
+// Finalize validates and returns assembled tool calls in index order.
+func (a *Assembler) Finalize() ([]core.ToolCall, error) {
+	if len(a.calls) == 0 {
+		return nil, nil
+	}
+
+	maxIndex := 0
+	for idx := range a.calls {
+		if idx > maxIndex {
+			maxIndex = idx
+		}
+	}
+
+	result := make([]core.ToolCall, 0, len(a.calls))
+	for i := 0; i <= maxIndex; i++ {
+		call, exists := a.calls[i]
+		if !exists {
+			continue
+		}
+
+		args := call.Arguments.String()
+		if args == "" && a.cfg.EmptyArgumentsJSON != "" {
+			args = a.cfg.EmptyArgumentsJSON
+		}
+		if !json.Valid([]byte(args)) {
+			return nil, ErrInvalidJSON
+		}
+
+		result = append(result, core.ToolCall{
+			ID:        call.ID,
+			Name:      call.Name,
+			Arguments: json.RawMessage(args),
+		})
+	}
+
+	return result, nil
+}

--- a/providers/internal/toolcalls/assembler_test.go
+++ b/providers/internal/toolcalls/assembler_test.go
@@ -1,0 +1,80 @@
+package toolcalls
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAssemblerFinalizeEmpty(t *testing.T) {
+	a := NewAssembler(Config{})
+	calls, err := a.Finalize()
+	if err != nil {
+		t.Fatalf("Finalize() error = %v", err)
+	}
+	if calls != nil {
+		t.Errorf("Finalize() = %v, want nil", calls)
+	}
+}
+
+func TestAssemblerFragmentsAndOrder(t *testing.T) {
+	a := NewAssembler(Config{})
+
+	a.AddFragment(Fragment{Index: 1, ID: "call_2", Name: "time", Arguments: `{"tz":"UTC"}`})
+	a.AddFragment(Fragment{Index: 0, ID: "call_1", Name: "weather"})
+	a.AddFragment(Fragment{Index: 0, Arguments: `{"city":`})
+	a.AddFragment(Fragment{Index: 0, Arguments: `"NYC"}`})
+
+	calls, err := a.Finalize()
+	if err != nil {
+		t.Fatalf("Finalize() error = %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("len(calls) = %d, want 2", len(calls))
+	}
+	if calls[0].ID != "call_1" || calls[0].Name != "weather" || string(calls[0].Arguments) != `{"city":"NYC"}` {
+		t.Errorf("calls[0] = %+v", calls[0])
+	}
+	if calls[1].ID != "call_2" || calls[1].Name != "time" || string(calls[1].Arguments) != `{"tz":"UTC"}` {
+		t.Errorf("calls[1] = %+v", calls[1])
+	}
+}
+
+func TestAssemblerInvalidJSON(t *testing.T) {
+	a := NewAssembler(Config{})
+	a.AddFragment(Fragment{Index: 0, ID: "bad", Name: "broken", Arguments: `{invalid`})
+
+	_, err := a.Finalize()
+	if !errors.Is(err, ErrInvalidJSON) {
+		t.Errorf("err = %v, want ErrInvalidJSON", err)
+	}
+}
+
+func TestAssemblerStartCallAndEmptyArgs(t *testing.T) {
+	a := NewAssembler(Config{EmptyArgumentsJSON: "{}"})
+	a.StartCall(0, "call_1", "no_args")
+	a.AddArguments(0, "")
+
+	calls, err := a.Finalize()
+	if err != nil {
+		t.Fatalf("Finalize() error = %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("len(calls) = %d, want 1", len(calls))
+	}
+	if string(calls[0].Arguments) != "{}" {
+		t.Errorf("Arguments = %s, want {}", calls[0].Arguments)
+	}
+}
+
+func TestAssemblerAddArgumentsWithoutStartIsNoop(t *testing.T) {
+	a := NewAssembler(Config{})
+	a.AddArguments(0, `{"x":1}`)
+
+	calls, err := a.Finalize()
+	if err != nil {
+		t.Fatalf("Finalize() error = %v", err)
+	}
+	if calls != nil {
+		t.Errorf("calls = %v, want nil", calls)
+	}
+}

--- a/providers/openai/streaming.go
+++ b/providers/openai/streaming.go
@@ -5,11 +5,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/toolcalls"
 )
 
 // Streaming response types for OpenAI SSE protocol.
@@ -47,74 +49,35 @@ type openAIStreamFunction struct {
 
 // toolCallAssembler accumulates streaming tool call fragments.
 type toolCallAssembler struct {
-	calls map[int]*assemblingToolCall
-}
-
-type assemblingToolCall struct {
-	ID        string
-	Name      string
-	Arguments strings.Builder
+	asm *toolcalls.Assembler
 }
 
 func newToolCallAssembler() *toolCallAssembler {
 	return &toolCallAssembler{
-		calls: make(map[int]*assemblingToolCall),
+		asm: toolcalls.NewAssembler(toolcalls.Config{}),
 	}
 }
 
 // addFragment processes a streaming tool call fragment.
 func (a *toolCallAssembler) addFragment(tc openAIStreamToolCall) {
-	call, exists := a.calls[tc.Index]
-	if !exists {
-		call = &assemblingToolCall{}
-		a.calls[tc.Index] = call
-	}
-
-	if tc.ID != "" {
-		call.ID = tc.ID
-	}
-	if tc.Function.Name != "" {
-		call.Name = tc.Function.Name
-	}
-	if tc.Function.Arguments != "" {
-		call.Arguments.WriteString(tc.Function.Arguments)
-	}
+	a.asm.AddFragment(toolcalls.Fragment{
+		Index:     tc.Index,
+		ID:        tc.ID,
+		Name:      tc.Function.Name,
+		Arguments: tc.Function.Arguments,
+	})
 }
 
 // finalize validates and returns the assembled tool calls.
 func (a *toolCallAssembler) finalize() ([]core.ToolCall, error) {
-	if len(a.calls) == 0 {
-		return nil, nil
-	}
-
-	// Find max index to determine slice size
-	maxIndex := 0
-	for idx := range a.calls {
-		if idx > maxIndex {
-			maxIndex = idx
-		}
-	}
-
-	result := make([]core.ToolCall, 0, len(a.calls))
-	for i := 0; i <= maxIndex; i++ {
-		call, exists := a.calls[i]
-		if !exists {
-			continue
-		}
-
-		args := call.Arguments.String()
-		if !json.Valid([]byte(args)) {
+	calls, err := a.asm.Finalize()
+	if err != nil {
+		if errors.Is(err, toolcalls.ErrInvalidJSON) {
 			return nil, ErrToolArgsInvalidJSON
 		}
-
-		result = append(result, core.ToolCall{
-			ID:        call.ID,
-			Name:      call.Name,
-			Arguments: json.RawMessage(args),
-		})
+		return nil, err
 	}
-
-	return result, nil
+	return calls, nil
 }
 
 // doStreamChat performs a streaming chat completion request.

--- a/providers/perplexity/streaming.go
+++ b/providers/perplexity/streaming.go
@@ -5,83 +5,46 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/toolcalls"
 )
 
 // toolCallAssembler accumulates streaming tool call fragments.
 type toolCallAssembler struct {
-	calls map[int]*assemblingToolCall
-}
-
-type assemblingToolCall struct {
-	ID        string
-	Name      string
-	Arguments strings.Builder
+	asm *toolcalls.Assembler
 }
 
 func newToolCallAssembler() *toolCallAssembler {
 	return &toolCallAssembler{
-		calls: make(map[int]*assemblingToolCall),
+		asm: toolcalls.NewAssembler(toolcalls.Config{}),
 	}
 }
 
 // addFragment processes a streaming tool call fragment.
 func (a *toolCallAssembler) addFragment(tc perplexityStreamToolCall) {
-	call, exists := a.calls[tc.Index]
-	if !exists {
-		call = &assemblingToolCall{}
-		a.calls[tc.Index] = call
-	}
-
-	if tc.ID != "" {
-		call.ID = tc.ID
-	}
-	if tc.Function.Name != "" {
-		call.Name = tc.Function.Name
-	}
-	if tc.Function.Arguments != "" {
-		call.Arguments.WriteString(tc.Function.Arguments)
-	}
+	a.asm.AddFragment(toolcalls.Fragment{
+		Index:     tc.Index,
+		ID:        tc.ID,
+		Name:      tc.Function.Name,
+		Arguments: tc.Function.Arguments,
+	})
 }
 
 // finalize validates and returns the assembled tool calls.
 func (a *toolCallAssembler) finalize() ([]core.ToolCall, error) {
-	if len(a.calls) == 0 {
-		return nil, nil
-	}
-
-	// Find max index to determine slice size
-	maxIndex := 0
-	for idx := range a.calls {
-		if idx > maxIndex {
-			maxIndex = idx
-		}
-	}
-
-	result := make([]core.ToolCall, 0, len(a.calls))
-	for i := 0; i <= maxIndex; i++ {
-		call, exists := a.calls[i]
-		if !exists {
-			continue
-		}
-
-		args := call.Arguments.String()
-		if !json.Valid([]byte(args)) {
+	calls, err := a.asm.Finalize()
+	if err != nil {
+		if errors.Is(err, toolcalls.ErrInvalidJSON) {
 			return nil, ErrToolArgsInvalidJSON
 		}
-
-		result = append(result, core.ToolCall{
-			ID:        call.ID,
-			Name:      call.Name,
-			Arguments: json.RawMessage(args),
-		})
+		return nil, err
 	}
-
-	return result, nil
+	return calls, nil
 }
 
 // doStreamChat performs a streaming chat completion request.

--- a/providers/perplexity/streaming_test.go
+++ b/providers/perplexity/streaming_test.go
@@ -408,7 +408,7 @@ func TestNewToolCallAssembler(t *testing.T) {
 	if asm == nil {
 		t.Fatal("newToolCallAssembler() returned nil")
 	}
-	if asm.calls == nil {
-		t.Fatal("newToolCallAssembler().calls should not be nil")
+	if asm.asm == nil {
+		t.Fatal("newToolCallAssembler().asm should not be nil")
 	}
 }

--- a/providers/xai/streaming.go
+++ b/providers/xai/streaming.go
@@ -5,83 +5,46 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/toolcalls"
 )
 
 // toolCallAssembler accumulates streaming tool call fragments.
 type toolCallAssembler struct {
-	calls map[int]*assemblingToolCall
-}
-
-type assemblingToolCall struct {
-	ID        string
-	Name      string
-	Arguments strings.Builder
+	asm *toolcalls.Assembler
 }
 
 func newToolCallAssembler() *toolCallAssembler {
 	return &toolCallAssembler{
-		calls: make(map[int]*assemblingToolCall),
+		asm: toolcalls.NewAssembler(toolcalls.Config{}),
 	}
 }
 
 // addFragment processes a streaming tool call fragment.
 func (a *toolCallAssembler) addFragment(tc xaiStreamToolCall) {
-	call, exists := a.calls[tc.Index]
-	if !exists {
-		call = &assemblingToolCall{}
-		a.calls[tc.Index] = call
-	}
-
-	if tc.ID != "" {
-		call.ID = tc.ID
-	}
-	if tc.Function.Name != "" {
-		call.Name = tc.Function.Name
-	}
-	if tc.Function.Arguments != "" {
-		call.Arguments.WriteString(tc.Function.Arguments)
-	}
+	a.asm.AddFragment(toolcalls.Fragment{
+		Index:     tc.Index,
+		ID:        tc.ID,
+		Name:      tc.Function.Name,
+		Arguments: tc.Function.Arguments,
+	})
 }
 
 // finalize validates and returns the assembled tool calls.
 func (a *toolCallAssembler) finalize() ([]core.ToolCall, error) {
-	if len(a.calls) == 0 {
-		return nil, nil
-	}
-
-	// Find max index to determine slice size
-	maxIndex := 0
-	for idx := range a.calls {
-		if idx > maxIndex {
-			maxIndex = idx
-		}
-	}
-
-	result := make([]core.ToolCall, 0, len(a.calls))
-	for i := 0; i <= maxIndex; i++ {
-		call, exists := a.calls[i]
-		if !exists {
-			continue
-		}
-
-		args := call.Arguments.String()
-		if !json.Valid([]byte(args)) {
+	calls, err := a.asm.Finalize()
+	if err != nil {
+		if errors.Is(err, toolcalls.ErrInvalidJSON) {
 			return nil, ErrToolArgsInvalidJSON
 		}
-
-		result = append(result, core.ToolCall{
-			ID:        call.ID,
-			Name:      call.Name,
-			Arguments: json.RawMessage(args),
-		})
+		return nil, err
 	}
-
-	return result, nil
+	return calls, nil
 }
 
 // doStreamChat performs a streaming chat completion request.

--- a/providers/zai/streaming.go
+++ b/providers/zai/streaming.go
@@ -5,83 +5,46 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/toolcalls"
 )
 
 // toolCallAssembler accumulates streaming tool call fragments.
 type toolCallAssembler struct {
-	calls map[int]*assemblingToolCall
-}
-
-type assemblingToolCall struct {
-	ID        string
-	Name      string
-	Arguments strings.Builder
+	asm *toolcalls.Assembler
 }
 
 func newToolCallAssembler() *toolCallAssembler {
 	return &toolCallAssembler{
-		calls: make(map[int]*assemblingToolCall),
+		asm: toolcalls.NewAssembler(toolcalls.Config{}),
 	}
 }
 
 // addFragment processes a streaming tool call fragment.
 func (a *toolCallAssembler) addFragment(tc zaiStreamToolCall) {
-	call, exists := a.calls[tc.Index]
-	if !exists {
-		call = &assemblingToolCall{}
-		a.calls[tc.Index] = call
-	}
-
-	if tc.ID != "" {
-		call.ID = tc.ID
-	}
-	if tc.Function.Name != "" {
-		call.Name = tc.Function.Name
-	}
-	if tc.Function.Arguments != "" {
-		call.Arguments.WriteString(tc.Function.Arguments)
-	}
+	a.asm.AddFragment(toolcalls.Fragment{
+		Index:     tc.Index,
+		ID:        tc.ID,
+		Name:      tc.Function.Name,
+		Arguments: tc.Function.Arguments,
+	})
 }
 
 // finalize validates and returns the assembled tool calls.
 func (a *toolCallAssembler) finalize() ([]core.ToolCall, error) {
-	if len(a.calls) == 0 {
-		return nil, nil
-	}
-
-	// Find max index to determine slice size
-	maxIndex := 0
-	for idx := range a.calls {
-		if idx > maxIndex {
-			maxIndex = idx
-		}
-	}
-
-	result := make([]core.ToolCall, 0, len(a.calls))
-	for i := 0; i <= maxIndex; i++ {
-		call, exists := a.calls[i]
-		if !exists {
-			continue
-		}
-
-		args := call.Arguments.String()
-		if !json.Valid([]byte(args)) {
+	calls, err := a.asm.Finalize()
+	if err != nil {
+		if errors.Is(err, toolcalls.ErrInvalidJSON) {
 			return nil, ErrToolArgsInvalidJSON
 		}
-
-		result = append(result, core.ToolCall{
-			ID:        call.ID,
-			Name:      call.Name,
-			Arguments: json.RawMessage(args),
-		})
+		return nil, err
 	}
-
-	return result, nil
+	return calls, nil
 }
 
 // doStreamChat performs a streaming chat completion request.

--- a/tests/integration/anthropic_test.go
+++ b/tests/integration/anthropic_test.go
@@ -13,279 +13,31 @@ import (
 )
 
 func TestAnthropic_ChatCompletion(t *testing.T) {
-	skipIfNoAnthropicKey(t)
-
-	apiKey := getAnthropicKey(t)
-	provider := anthropic.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(anthropic.ModelClaudeHaiku45).
-		User("Say 'hello' and nothing else.").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	if resp.ID == "" {
-		t.Error("Response ID is empty")
-	}
-
-	// Verify usage is populated
-	if resp.Usage.TotalTokens == 0 {
-		t.Error("Response usage total tokens is 0")
-	}
-
-	t.Logf("Response: %s", resp.Output)
-	t.Logf("Usage: %d prompt + %d completion = %d total",
-		resp.Usage.PromptTokens,
-		resp.Usage.CompletionTokens,
-		resp.Usage.TotalTokens)
+	runConformanceChatCompletion(t, anthropicChatConformanceConfig())
 }
 
 func TestAnthropic_ChatCompletion_Streaming(t *testing.T) {
-	skipIfNoAnthropicKey(t)
-
-	apiKey := getAnthropicKey(t)
-	provider := anthropic.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	stream, err := client.Chat(anthropic.ModelClaudeHaiku45).
-		User("Count from 1 to 5, each number on a new line.").
-		Stream(ctx)
-
-	if err != nil {
-		t.Fatalf("Stream() error = %v", err)
-	}
-
-	// Collect deltas
-	var chunks []string
-	for chunk := range stream.Ch {
-		chunks = append(chunks, chunk.Delta)
-	}
-
-	// Check for errors
-	select {
-	case err := <-stream.Err:
-		if err != nil {
-			t.Fatalf("Stream error: %v", err)
-		}
-	default:
-	}
-
-	// Wait for final response
-	var finalResp *core.ChatResponse
-	select {
-	case resp := <-stream.Final:
-		finalResp = resp
-	case <-time.After(5 * time.Second):
-		t.Log("No final response received (may be expected)")
-	}
-
-	if len(chunks) == 0 {
-		t.Error("No chunks received")
-	}
-
-	combined := strings.Join(chunks, "")
-	if combined == "" {
-		t.Error("Combined output is empty")
-	}
-
-	t.Logf("Received %d chunks", len(chunks))
-	t.Logf("Combined output: %s", combined)
-
-	if finalResp != nil {
-		t.Logf("Final response ID: %s", finalResp.ID)
-	}
+	runConformanceStreaming(t, anthropicChatConformanceConfig())
 }
 
 func TestAnthropic_ChatCompletion_WithTools(t *testing.T) {
-	skipIfNoAnthropicKey(t)
-
-	apiKey := getAnthropicKey(t)
-	provider := anthropic.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	tool := createTestTool()
-
-	resp, err := client.Chat(anthropic.ModelClaudeHaiku45).
-		User("What's the weather like in San Francisco?").
-		Tools(tool).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	// The model should either call the tool or respond with text
-	if resp.Output == "" && len(resp.ToolCalls) == 0 {
-		t.Error("Response has no output and no tool calls")
-	}
-
-	if len(resp.ToolCalls) > 0 {
-		t.Logf("Tool call: %s", resp.ToolCalls[0].Name)
-		t.Logf("Arguments: %s", string(resp.ToolCalls[0].Arguments))
-
-		// Verify tool call has expected structure
-		if resp.ToolCalls[0].Name != "get_weather" {
-			t.Logf("Note: Model called %s instead of get_weather", resp.ToolCalls[0].Name)
-		}
-
-		if resp.ToolCalls[0].ID == "" {
-			t.Error("Tool call ID is empty")
-		}
-	} else {
-		t.Logf("Model responded with text: %s", resp.Output)
-	}
+	runConformanceWithTools(t, anthropicChatConformanceConfig())
 }
 
 func TestAnthropic_ChatCompletion_SystemMessage(t *testing.T) {
-	skipIfNoAnthropicKey(t)
-
-	apiKey := getAnthropicKey(t)
-	provider := anthropic.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(anthropic.ModelClaudeHaiku45).
-		System("You are a pirate. Always respond in pirate speak.").
-		User("Say hello.").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// The output should contain pirate-like language
-	output := strings.ToLower(resp.Output)
-	pirateWords := []string{"ahoy", "matey", "arr", "aye", "ye", "ship", "sail", "sea"}
-
-	hasPirateWord := false
-	for _, word := range pirateWords {
-		if strings.Contains(output, word) {
-			hasPirateWord = true
-			break
-		}
-	}
-
-	if !hasPirateWord {
-		t.Logf("Note: Response may not be in pirate speak: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceSystemMessage(t, anthropicChatConformanceConfig())
 }
 
 func TestAnthropic_ChatCompletion_Temperature(t *testing.T) {
-	skipIfNoAnthropicKey(t)
-
-	apiKey := getAnthropicKey(t)
-	provider := anthropic.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Low temperature should give more deterministic output
-	resp, err := client.Chat(anthropic.ModelClaudeHaiku45).
-		User("What is 2+2? Reply with just the number.").
-		Temperature(0).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// Should contain "4"
-	if !strings.Contains(resp.Output, "4") {
-		t.Errorf("Expected response to contain '4', got: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceTemperature(t, anthropicChatConformanceConfig())
 }
 
 func TestAnthropic_ChatCompletion_MaxTokens(t *testing.T) {
-	skipIfNoAnthropicKey(t)
-
-	apiKey := getAnthropicKey(t)
-	provider := anthropic.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Very low max tokens should truncate response
-	resp, err := client.Chat(anthropic.ModelClaudeHaiku45).
-		User("Write a long story about a dragon.").
-		MaxTokens(10).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	// Response should be short due to max tokens
-	if resp.Usage.CompletionTokens > 15 { // Allow some buffer
-		t.Errorf("Expected completion tokens <= 15, got %d", resp.Usage.CompletionTokens)
-	}
-
-	t.Logf("Response: %s", resp.Output)
-	t.Logf("Completion tokens: %d", resp.Usage.CompletionTokens)
+	runConformanceMaxTokens(t, anthropicChatConformanceConfig())
 }
 
 func TestAnthropic_ChatCompletion_MultipleMessages(t *testing.T) {
-	skipIfNoAnthropicKey(t)
-
-	apiKey := getAnthropicKey(t)
-	provider := anthropic.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(anthropic.ModelClaudeHaiku45).
-		User("My name is Alice.").
-		Assistant("Nice to meet you, Alice!").
-		User("What's my name?").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// The response should remember the user's name
-	output := strings.ToLower(resp.Output)
-	if !strings.Contains(output, "alice") {
-		t.Errorf("Expected response to contain 'Alice', got: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceMultipleMessages(t, anthropicChatConformanceConfig())
 }
 
 func TestAnthropic_ChatCompletion_Sonnet(t *testing.T) {
@@ -298,11 +50,10 @@ func TestAnthropic_ChatCompletion_Sonnet(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// Test with Sonnet model for more complex reasoning
+	// Test with Sonnet model for more complex reasoning.
 	resp, err := client.Chat(anthropic.ModelClaudeSonnet45).
 		User("What is the capital of France? Answer in one word.").
 		GetResponse(ctx)
-
 	if err != nil {
 		t.Fatalf("Chat() error = %v", err)
 	}
@@ -318,4 +69,22 @@ func TestAnthropic_ChatCompletion_Sonnet(t *testing.T) {
 
 	t.Logf("Response: %s", resp.Output)
 	t.Logf("Model: %s", anthropic.ModelClaudeSonnet45)
+}
+
+func anthropicChatConformanceConfig() chatConformanceConfig {
+	return chatConformanceConfig{
+		getAPIKey: func(t *testing.T) string {
+			skipIfNoAnthropicKey(t)
+			return getAnthropicKey(t)
+		},
+		newProvider: func(apiKey string) core.Provider {
+			return anthropic.New(apiKey)
+		},
+		defaultModel:     anthropic.ModelClaudeHaiku45,
+		toolModel:        anthropic.ModelClaudeHaiku45,
+		timeout:          30 * time.Second,
+		responseIDPolicy: conformanceRequire,
+		usagePolicy:      conformanceRequire,
+		strictMaxTokens:  true,
+	}
 }

--- a/tests/integration/chat_conformance_test.go
+++ b/tests/integration/chat_conformance_test.go
@@ -1,0 +1,365 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+)
+
+type conformancePresencePolicy int
+
+const (
+	conformanceIgnore conformancePresencePolicy = iota
+	conformanceRequire
+	conformanceNote
+)
+
+type chatConformanceConfig struct {
+	getAPIKey   func(t *testing.T) string
+	newProvider func(apiKey string) core.Provider
+
+	defaultModel core.ModelID
+	toolModel    core.ModelID
+
+	timeout      time.Duration
+	finalTimeout time.Duration
+
+	responseIDPolicy conformancePresencePolicy
+	responseIDNote   string
+
+	usagePolicy conformancePresencePolicy
+	usageNote   string
+
+	strictMaxTokens bool
+	maxTokensNote   string
+
+	beforeEach func(t *testing.T) func()
+}
+
+func (c chatConformanceConfig) normalized() chatConformanceConfig {
+	cfg := c
+	if cfg.toolModel == "" {
+		cfg.toolModel = cfg.defaultModel
+	}
+	if cfg.timeout <= 0 {
+		cfg.timeout = 30 * time.Second
+	}
+	if cfg.finalTimeout <= 0 {
+		cfg.finalTimeout = 5 * time.Second
+	}
+	return cfg
+}
+
+func newConformanceClient(t *testing.T, cfg chatConformanceConfig) (*core.Client, func()) {
+	t.Helper()
+
+	cleanup := func() {}
+	if cfg.beforeEach != nil {
+		if c := cfg.beforeEach(t); c != nil {
+			cleanup = c
+		}
+	}
+
+	apiKey := cfg.getAPIKey(t)
+	provider := cfg.newProvider(apiKey)
+	if provider == nil {
+		cleanup()
+		t.Fatal("conformance provider factory returned nil")
+	}
+
+	return core.NewClient(provider), cleanup
+}
+
+func assertStringPresence(t *testing.T, label, value string, policy conformancePresencePolicy, note string) {
+	t.Helper()
+	if value != "" {
+		return
+	}
+
+	switch policy {
+	case conformanceRequire:
+		t.Errorf("%s is empty", label)
+	case conformanceNote:
+		if note != "" {
+			t.Logf("Note: %s", note)
+		} else {
+			t.Logf("Note: %s is empty", label)
+		}
+	}
+}
+
+func assertUsagePresence(t *testing.T, total int, policy conformancePresencePolicy, note string) {
+	t.Helper()
+	if total > 0 {
+		return
+	}
+
+	switch policy {
+	case conformanceRequire:
+		t.Error("Response usage total tokens is 0")
+	case conformanceNote:
+		if note != "" {
+			t.Logf("Note: %s", note)
+		} else {
+			t.Log("Note: Response usage total tokens is 0")
+		}
+	}
+}
+
+func runConformanceChatCompletion(t *testing.T, cfg chatConformanceConfig) {
+	t.Helper()
+	cfg = cfg.normalized()
+
+	client, cleanup := newConformanceClient(t, cfg)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
+	defer cancel()
+
+	resp, err := client.Chat(cfg.defaultModel).
+		User("Say 'hello' and nothing else.").
+		GetResponse(ctx)
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if resp.Output == "" {
+		t.Error("Response output is empty")
+	}
+
+	assertStringPresence(t, "Response ID", resp.ID, cfg.responseIDPolicy, cfg.responseIDNote)
+	assertUsagePresence(t, resp.Usage.TotalTokens, cfg.usagePolicy, cfg.usageNote)
+
+	t.Logf("Response: %s", resp.Output)
+	t.Logf("Usage: %d prompt + %d completion = %d total",
+		resp.Usage.PromptTokens,
+		resp.Usage.CompletionTokens,
+		resp.Usage.TotalTokens)
+}
+
+func runConformanceStreaming(t *testing.T, cfg chatConformanceConfig) {
+	t.Helper()
+	cfg = cfg.normalized()
+
+	client, cleanup := newConformanceClient(t, cfg)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
+	defer cancel()
+
+	stream, err := client.Chat(cfg.defaultModel).
+		User("Count from 1 to 5, each number on a new line.").
+		Stream(ctx)
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+
+	var chunks []string
+	for chunk := range stream.Ch {
+		chunks = append(chunks, chunk.Delta)
+	}
+
+	select {
+	case err := <-stream.Err:
+		if err != nil {
+			t.Fatalf("Stream error: %v", err)
+		}
+	default:
+	}
+
+	var finalResp *core.ChatResponse
+	select {
+	case resp := <-stream.Final:
+		finalResp = resp
+	case <-time.After(cfg.finalTimeout):
+		t.Log("No final response received (may be expected)")
+	}
+
+	if len(chunks) == 0 {
+		t.Error("No chunks received")
+	}
+
+	combined := strings.Join(chunks, "")
+	if combined == "" {
+		t.Error("Combined output is empty")
+	}
+
+	t.Logf("Received %d chunks", len(chunks))
+	t.Logf("Combined output: %s", combined)
+	if finalResp != nil {
+		t.Logf("Final response ID: %s", finalResp.ID)
+	}
+}
+
+func runConformanceWithTools(t *testing.T, cfg chatConformanceConfig) {
+	t.Helper()
+	cfg = cfg.normalized()
+
+	client, cleanup := newConformanceClient(t, cfg)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
+	defer cancel()
+
+	resp, err := client.Chat(cfg.toolModel).
+		User("What's the weather like in San Francisco?").
+		Tools(createTestTool()).
+		GetResponse(ctx)
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if resp.Output == "" && len(resp.ToolCalls) == 0 {
+		t.Error("Response has no output and no tool calls")
+	}
+
+	if len(resp.ToolCalls) > 0 {
+		t.Logf("Tool call: %s", resp.ToolCalls[0].Name)
+		t.Logf("Arguments: %s", string(resp.ToolCalls[0].Arguments))
+
+		if resp.ToolCalls[0].Name != "get_weather" {
+			t.Logf("Note: Model called %s instead of get_weather", resp.ToolCalls[0].Name)
+		}
+		if resp.ToolCalls[0].ID == "" {
+			t.Error("Tool call ID is empty")
+		}
+	} else {
+		t.Logf("Model responded with text: %s", resp.Output)
+	}
+}
+
+func runConformanceSystemMessage(t *testing.T, cfg chatConformanceConfig) {
+	t.Helper()
+	cfg = cfg.normalized()
+
+	client, cleanup := newConformanceClient(t, cfg)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
+	defer cancel()
+
+	resp, err := client.Chat(cfg.defaultModel).
+		System("You are a pirate. Always respond in pirate speak.").
+		User("Say hello.").
+		GetResponse(ctx)
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if resp.Output == "" {
+		t.Error("Response output is empty")
+	}
+
+	output := strings.ToLower(resp.Output)
+	pirateWords := []string{"ahoy", "matey", "arr", "aye", "ye", "ship", "sail", "sea"}
+
+	hasPirateWord := false
+	for _, word := range pirateWords {
+		if strings.Contains(output, word) {
+			hasPirateWord = true
+			break
+		}
+	}
+
+	if !hasPirateWord {
+		t.Logf("Note: Response may not be in pirate speak: %s", resp.Output)
+	}
+
+	t.Logf("Response: %s", resp.Output)
+}
+
+func runConformanceTemperature(t *testing.T, cfg chatConformanceConfig) {
+	t.Helper()
+	cfg = cfg.normalized()
+
+	client, cleanup := newConformanceClient(t, cfg)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
+	defer cancel()
+
+	resp, err := client.Chat(cfg.defaultModel).
+		User("What is 2+2? Reply with just the number.").
+		Temperature(0).
+		GetResponse(ctx)
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if resp.Output == "" {
+		t.Error("Response output is empty")
+	}
+
+	if !strings.Contains(resp.Output, "4") {
+		t.Errorf("Expected response to contain '4', got: %s", resp.Output)
+	}
+
+	t.Logf("Response: %s", resp.Output)
+}
+
+func runConformanceMaxTokens(t *testing.T, cfg chatConformanceConfig) {
+	t.Helper()
+	cfg = cfg.normalized()
+
+	client, cleanup := newConformanceClient(t, cfg)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
+	defer cancel()
+
+	resp, err := client.Chat(cfg.defaultModel).
+		User("Write a long story about a dragon.").
+		MaxTokens(10).
+		GetResponse(ctx)
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if resp.Usage.CompletionTokens > 15 {
+		if cfg.strictMaxTokens {
+			t.Errorf("Expected completion tokens <= 15, got %d", resp.Usage.CompletionTokens)
+		} else if cfg.maxTokensNote != "" {
+			t.Logf("Note: %s", cfg.maxTokensNote)
+		} else {
+			t.Logf("Note: Completion tokens %d exceeds expected max ~10", resp.Usage.CompletionTokens)
+		}
+	}
+
+	t.Logf("Response: %s", resp.Output)
+	t.Logf("Completion tokens: %d", resp.Usage.CompletionTokens)
+}
+
+func runConformanceMultipleMessages(t *testing.T, cfg chatConformanceConfig) {
+	t.Helper()
+	cfg = cfg.normalized()
+
+	client, cleanup := newConformanceClient(t, cfg)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.timeout)
+	defer cancel()
+
+	resp, err := client.Chat(cfg.defaultModel).
+		User("My name is Alice.").
+		Assistant("Nice to meet you, Alice!").
+		User("What's my name?").
+		GetResponse(ctx)
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if resp.Output == "" {
+		t.Error("Response output is empty")
+	}
+
+	if !strings.Contains(strings.ToLower(resp.Output), "alice") {
+		t.Errorf("Expected response to contain 'Alice', got: %s", resp.Output)
+	}
+
+	t.Logf("Response: %s", resp.Output)
+}

--- a/tests/integration/gemini_test.go
+++ b/tests/integration/gemini_test.go
@@ -13,279 +13,31 @@ import (
 )
 
 func TestGemini_ChatCompletion(t *testing.T) {
-	skipIfNoGeminiKey(t)
-
-	apiKey := getGeminiKey(t)
-	provider := gemini.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(gemini.ModelGemini25FlashLite).
-		User("Say 'hello' and nothing else.").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	if resp.ID == "" {
-		t.Log("Note: Response ID is empty (Gemini may not return IDs)")
-	}
-
-	// Verify usage is populated
-	if resp.Usage.TotalTokens == 0 {
-		t.Error("Response usage total tokens is 0")
-	}
-
-	t.Logf("Response: %s", resp.Output)
-	t.Logf("Usage: %d prompt + %d completion = %d total",
-		resp.Usage.PromptTokens,
-		resp.Usage.CompletionTokens,
-		resp.Usage.TotalTokens)
+	runConformanceChatCompletion(t, geminiChatConformanceConfig())
 }
 
 func TestGemini_ChatCompletion_Streaming(t *testing.T) {
-	skipIfNoGeminiKey(t)
-
-	apiKey := getGeminiKey(t)
-	provider := gemini.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	stream, err := client.Chat(gemini.ModelGemini25FlashLite).
-		User("Count from 1 to 5, each number on a new line.").
-		Stream(ctx)
-
-	if err != nil {
-		t.Fatalf("Stream() error = %v", err)
-	}
-
-	// Collect deltas
-	var chunks []string
-	for chunk := range stream.Ch {
-		chunks = append(chunks, chunk.Delta)
-	}
-
-	// Check for errors
-	select {
-	case err := <-stream.Err:
-		if err != nil {
-			t.Fatalf("Stream error: %v", err)
-		}
-	default:
-	}
-
-	// Wait for final response
-	var finalResp *core.ChatResponse
-	select {
-	case resp := <-stream.Final:
-		finalResp = resp
-	case <-time.After(5 * time.Second):
-		t.Log("No final response received (may be expected)")
-	}
-
-	if len(chunks) == 0 {
-		t.Error("No chunks received")
-	}
-
-	combined := strings.Join(chunks, "")
-	if combined == "" {
-		t.Error("Combined output is empty")
-	}
-
-	t.Logf("Received %d chunks", len(chunks))
-	t.Logf("Combined output: %s", combined)
-
-	if finalResp != nil {
-		t.Logf("Final response ID: %s", finalResp.ID)
-	}
+	runConformanceStreaming(t, geminiChatConformanceConfig())
 }
 
 func TestGemini_ChatCompletion_WithTools(t *testing.T) {
-	skipIfNoGeminiKey(t)
-
-	apiKey := getGeminiKey(t)
-	provider := gemini.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	tool := createTestTool()
-
-	resp, err := client.Chat(gemini.ModelGemini25FlashLite).
-		User("What's the weather like in San Francisco?").
-		Tools(tool).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	// The model should either call the tool or respond with text
-	if resp.Output == "" && len(resp.ToolCalls) == 0 {
-		t.Error("Response has no output and no tool calls")
-	}
-
-	if len(resp.ToolCalls) > 0 {
-		t.Logf("Tool call: %s", resp.ToolCalls[0].Name)
-		t.Logf("Arguments: %s", string(resp.ToolCalls[0].Arguments))
-
-		// Verify tool call has expected structure
-		if resp.ToolCalls[0].Name != "get_weather" {
-			t.Logf("Note: Model called %s instead of get_weather", resp.ToolCalls[0].Name)
-		}
-
-		if resp.ToolCalls[0].ID == "" {
-			t.Error("Tool call ID is empty")
-		}
-	} else {
-		t.Logf("Model responded with text: %s", resp.Output)
-	}
+	runConformanceWithTools(t, geminiChatConformanceConfig())
 }
 
 func TestGemini_ChatCompletion_SystemMessage(t *testing.T) {
-	skipIfNoGeminiKey(t)
-
-	apiKey := getGeminiKey(t)
-	provider := gemini.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(gemini.ModelGemini25FlashLite).
-		System("You are a pirate. Always respond in pirate speak.").
-		User("Say hello.").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// The output should contain pirate-like language
-	output := strings.ToLower(resp.Output)
-	pirateWords := []string{"ahoy", "matey", "arr", "aye", "ye", "ship", "sail", "sea"}
-
-	hasPirateWord := false
-	for _, word := range pirateWords {
-		if strings.Contains(output, word) {
-			hasPirateWord = true
-			break
-		}
-	}
-
-	if !hasPirateWord {
-		t.Logf("Note: Response may not be in pirate speak: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceSystemMessage(t, geminiChatConformanceConfig())
 }
 
 func TestGemini_ChatCompletion_Temperature(t *testing.T) {
-	skipIfNoGeminiKey(t)
-
-	apiKey := getGeminiKey(t)
-	provider := gemini.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Low temperature should give more deterministic output
-	resp, err := client.Chat(gemini.ModelGemini25FlashLite).
-		User("What is 2+2? Reply with just the number.").
-		Temperature(0).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// Should contain "4"
-	if !strings.Contains(resp.Output, "4") {
-		t.Errorf("Expected response to contain '4', got: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceTemperature(t, geminiChatConformanceConfig())
 }
 
 func TestGemini_ChatCompletion_MaxTokens(t *testing.T) {
-	skipIfNoGeminiKey(t)
-
-	apiKey := getGeminiKey(t)
-	provider := gemini.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Very low max tokens should truncate response
-	resp, err := client.Chat(gemini.ModelGemini25FlashLite).
-		User("Write a long story about a dragon.").
-		MaxTokens(10).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	// Response should be short due to max tokens
-	if resp.Usage.CompletionTokens > 15 { // Allow some buffer
-		t.Errorf("Expected completion tokens <= 15, got %d", resp.Usage.CompletionTokens)
-	}
-
-	t.Logf("Response: %s", resp.Output)
-	t.Logf("Completion tokens: %d", resp.Usage.CompletionTokens)
+	runConformanceMaxTokens(t, geminiChatConformanceConfig())
 }
 
 func TestGemini_ChatCompletion_MultipleMessages(t *testing.T) {
-	skipIfNoGeminiKey(t)
-
-	apiKey := getGeminiKey(t)
-	provider := gemini.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(gemini.ModelGemini25FlashLite).
-		User("My name is Alice.").
-		Assistant("Nice to meet you, Alice!").
-		User("What's my name?").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// The response should remember the user's name
-	output := strings.ToLower(resp.Output)
-	if !strings.Contains(output, "alice") {
-		t.Errorf("Expected response to contain 'Alice', got: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceMultipleMessages(t, geminiChatConformanceConfig())
 }
 
 func TestGemini_ChatCompletion_Flash(t *testing.T) {
@@ -298,11 +50,10 @@ func TestGemini_ChatCompletion_Flash(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// Test with Flash model
+	// Test with Flash model.
 	resp, err := client.Chat(gemini.ModelGemini25Flash).
 		User("What is the capital of France? Answer in one word.").
 		GetResponse(ctx)
-
 	if err != nil {
 		t.Fatalf("Chat() error = %v", err)
 	}
@@ -362,20 +113,37 @@ func TestGemini_ImageGeneration_StreamingNotSupported(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Streaming should return an error for Gemini
+	// Streaming should return an error for Gemini.
 	_, err := provider.StreamImage(ctx, &core.ImageGenerateRequest{
 		Model:  gemini.ModelGemini25FlashImage,
 		Prompt: "A simple blue square",
 	})
-
 	if err == nil {
 		t.Fatal("Expected error for streaming image generation, got nil")
 	}
 
-	// Verify it's the expected error type
 	if !strings.Contains(err.Error(), "not support") {
 		t.Logf("Error message: %v", err)
 	}
 
 	t.Logf("Got expected error: %v", err)
+}
+
+func geminiChatConformanceConfig() chatConformanceConfig {
+	return chatConformanceConfig{
+		getAPIKey: func(t *testing.T) string {
+			skipIfNoGeminiKey(t)
+			return getGeminiKey(t)
+		},
+		newProvider: func(apiKey string) core.Provider {
+			return gemini.New(apiKey)
+		},
+		defaultModel:     gemini.ModelGemini25FlashLite,
+		toolModel:        gemini.ModelGemini25FlashLite,
+		timeout:          30 * time.Second,
+		responseIDPolicy: conformanceNote,
+		responseIDNote:   "Response ID is empty (Gemini may not return IDs)",
+		usagePolicy:      conformanceRequire,
+		strictMaxTokens:  true,
+	}
 }

--- a/tests/integration/openai_test.go
+++ b/tests/integration/openai_test.go
@@ -3,8 +3,6 @@
 package integration
 
 import (
-	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -13,245 +11,43 @@ import (
 )
 
 func TestOpenAI_ChatCompletion(t *testing.T) {
-	skipIfNoAPIKey(t)
-
-	apiKey := getAPIKey(t)
-	provider := openai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat("gpt-4o-mini").
-		User("Say 'hello' and nothing else.").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	if resp.ID == "" {
-		t.Error("Response ID is empty")
-	}
-
-	// Verify usage is populated
-	if resp.Usage.TotalTokens == 0 {
-		t.Error("Response usage total tokens is 0")
-	}
-
-	t.Logf("Response: %s", resp.Output)
-	t.Logf("Usage: %d prompt + %d completion = %d total",
-		resp.Usage.PromptTokens,
-		resp.Usage.CompletionTokens,
-		resp.Usage.TotalTokens)
+	runConformanceChatCompletion(t, openAIChatConformanceConfig())
 }
 
 func TestOpenAI_ChatCompletion_Streaming(t *testing.T) {
-	skipIfNoAPIKey(t)
-
-	apiKey := getAPIKey(t)
-	provider := openai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	stream, err := client.Chat("gpt-4o-mini").
-		User("Count from 1 to 5, each number on a new line.").
-		Stream(ctx)
-
-	if err != nil {
-		t.Fatalf("Stream() error = %v", err)
-	}
-
-	// Collect deltas
-	var chunks []string
-	for chunk := range stream.Ch {
-		chunks = append(chunks, chunk.Delta)
-	}
-
-	// Check for errors
-	select {
-	case err := <-stream.Err:
-		if err != nil {
-			t.Fatalf("Stream error: %v", err)
-		}
-	default:
-	}
-
-	// Wait for final response
-	var finalResp *core.ChatResponse
-	select {
-	case resp := <-stream.Final:
-		finalResp = resp
-	case <-time.After(5 * time.Second):
-		t.Log("No final response received (may be expected)")
-	}
-
-	if len(chunks) == 0 {
-		t.Error("No chunks received")
-	}
-
-	combined := strings.Join(chunks, "")
-	if combined == "" {
-		t.Error("Combined output is empty")
-	}
-
-	t.Logf("Received %d chunks", len(chunks))
-	t.Logf("Combined output: %s", combined)
-
-	if finalResp != nil {
-		t.Logf("Final response ID: %s", finalResp.ID)
-	}
+	runConformanceStreaming(t, openAIChatConformanceConfig())
 }
 
 func TestOpenAI_ChatCompletion_WithTools(t *testing.T) {
-	skipIfNoAPIKey(t)
-
-	apiKey := getAPIKey(t)
-	provider := openai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	tool := createTestTool()
-
-	resp, err := client.Chat("gpt-4o-mini").
-		User("What's the weather like in San Francisco?").
-		Tools(tool).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	// The model should either call the tool or respond with text
-	// We can't guarantee tool call, but we should get a valid response
-	if resp.Output == "" && len(resp.ToolCalls) == 0 {
-		t.Error("Response has no output and no tool calls")
-	}
-
-	if len(resp.ToolCalls) > 0 {
-		t.Logf("Tool call: %s", resp.ToolCalls[0].Name)
-		t.Logf("Arguments: %s", string(resp.ToolCalls[0].Arguments))
-
-		// Verify tool call has expected structure
-		if resp.ToolCalls[0].Name != "get_weather" {
-			t.Logf("Note: Model called %s instead of get_weather", resp.ToolCalls[0].Name)
-		}
-
-		if resp.ToolCalls[0].ID == "" {
-			t.Error("Tool call ID is empty")
-		}
-	} else {
-		t.Logf("Model responded with text: %s", resp.Output)
-	}
+	runConformanceWithTools(t, openAIChatConformanceConfig())
 }
 
 func TestOpenAI_ChatCompletion_SystemMessage(t *testing.T) {
-	skipIfNoAPIKey(t)
-
-	apiKey := getAPIKey(t)
-	provider := openai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat("gpt-4o-mini").
-		System("You are a pirate. Always respond in pirate speak.").
-		User("Say hello.").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// The output should contain pirate-like language
-	output := strings.ToLower(resp.Output)
-	pirateWords := []string{"ahoy", "matey", "arr", "aye", "ye", "ship", "sail", "sea"}
-
-	hasPirateWord := false
-	for _, word := range pirateWords {
-		if strings.Contains(output, word) {
-			hasPirateWord = true
-			break
-		}
-	}
-
-	if !hasPirateWord {
-		t.Logf("Note: Response may not be in pirate speak: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceSystemMessage(t, openAIChatConformanceConfig())
 }
 
 func TestOpenAI_ChatCompletion_Temperature(t *testing.T) {
-	skipIfNoAPIKey(t)
-
-	apiKey := getAPIKey(t)
-	provider := openai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Low temperature should give more deterministic output
-	resp, err := client.Chat("gpt-4o-mini").
-		User("What is 2+2? Reply with just the number.").
-		Temperature(0).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// Should contain "4"
-	if !strings.Contains(resp.Output, "4") {
-		t.Errorf("Expected response to contain '4', got: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceTemperature(t, openAIChatConformanceConfig())
 }
 
 func TestOpenAI_ChatCompletion_MaxTokens(t *testing.T) {
-	skipIfNoAPIKey(t)
+	runConformanceMaxTokens(t, openAIChatConformanceConfig())
+}
 
-	apiKey := getAPIKey(t)
-	provider := openai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Very low max tokens should truncate response
-	resp, err := client.Chat("gpt-4o-mini").
-		User("Write a long story about a dragon.").
-		MaxTokens(10).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
+func openAIChatConformanceConfig() chatConformanceConfig {
+	return chatConformanceConfig{
+		getAPIKey: func(t *testing.T) string {
+			skipIfNoAPIKey(t)
+			return getAPIKey(t)
+		},
+		newProvider: func(apiKey string) core.Provider {
+			return openai.New(apiKey)
+		},
+		defaultModel:     openai.ModelGPT4oMini,
+		toolModel:        openai.ModelGPT4oMini,
+		timeout:          30 * time.Second,
+		responseIDPolicy: conformanceRequire,
+		usagePolicy:      conformanceRequire,
+		strictMaxTokens:  true,
 	}
-
-	// Response should be short due to max tokens
-	if resp.Usage.CompletionTokens > 15 { // Allow some buffer
-		t.Errorf("Expected completion tokens <= 15, got %d", resp.Usage.CompletionTokens)
-	}
-
-	t.Logf("Response: %s", resp.Output)
-	t.Logf("Completion tokens: %d", resp.Usage.CompletionTokens)
 }

--- a/tests/integration/perplexity_test.go
+++ b/tests/integration/perplexity_test.go
@@ -13,279 +13,31 @@ import (
 )
 
 func TestPerplexity_ChatCompletion(t *testing.T) {
-	skipIfNoPerplexityKey(t)
-
-	apiKey := getPerplexityKey(t)
-	provider := perplexity.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(perplexity.ModelSonar).
-		User("Say 'hello' and nothing else.").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	if resp.ID == "" {
-		t.Log("Note: Response ID is empty")
-	}
-
-	// Verify usage is populated
-	if resp.Usage.TotalTokens == 0 {
-		t.Log("Note: Response usage total tokens is 0")
-	}
-
-	t.Logf("Response: %s", resp.Output)
-	t.Logf("Usage: %d prompt + %d completion = %d total",
-		resp.Usage.PromptTokens,
-		resp.Usage.CompletionTokens,
-		resp.Usage.TotalTokens)
+	runConformanceChatCompletion(t, perplexityChatConformanceConfig())
 }
 
 func TestPerplexity_ChatCompletion_Streaming(t *testing.T) {
-	skipIfNoPerplexityKey(t)
-
-	apiKey := getPerplexityKey(t)
-	provider := perplexity.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	stream, err := client.Chat(perplexity.ModelSonar).
-		User("Count from 1 to 5, each number on a new line.").
-		Stream(ctx)
-
-	if err != nil {
-		t.Fatalf("Stream() error = %v", err)
-	}
-
-	// Collect deltas
-	var chunks []string
-	for chunk := range stream.Ch {
-		chunks = append(chunks, chunk.Delta)
-	}
-
-	// Check for errors
-	select {
-	case err := <-stream.Err:
-		if err != nil {
-			t.Fatalf("Stream error: %v", err)
-		}
-	default:
-	}
-
-	// Wait for final response
-	var finalResp *core.ChatResponse
-	select {
-	case resp := <-stream.Final:
-		finalResp = resp
-	case <-time.After(5 * time.Second):
-		t.Log("No final response received (may be expected)")
-	}
-
-	if len(chunks) == 0 {
-		t.Error("No chunks received")
-	}
-
-	combined := strings.Join(chunks, "")
-	if combined == "" {
-		t.Error("Combined output is empty")
-	}
-
-	t.Logf("Received %d chunks", len(chunks))
-	t.Logf("Combined output: %s", combined)
-
-	if finalResp != nil {
-		t.Logf("Final response ID: %s", finalResp.ID)
-	}
+	runConformanceStreaming(t, perplexityChatConformanceConfig())
 }
 
 func TestPerplexity_ChatCompletion_WithTools(t *testing.T) {
-	skipIfNoPerplexityKey(t)
-
-	apiKey := getPerplexityKey(t)
-	provider := perplexity.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	tool := createTestTool()
-
-	resp, err := client.Chat(perplexity.ModelSonarPro).
-		User("What's the weather like in San Francisco?").
-		Tools(tool).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	// The model should either call the tool or respond with text
-	if resp.Output == "" && len(resp.ToolCalls) == 0 {
-		t.Error("Response has no output and no tool calls")
-	}
-
-	if len(resp.ToolCalls) > 0 {
-		t.Logf("Tool call: %s", resp.ToolCalls[0].Name)
-		t.Logf("Arguments: %s", string(resp.ToolCalls[0].Arguments))
-
-		// Verify tool call has expected structure
-		if resp.ToolCalls[0].Name != "get_weather" {
-			t.Logf("Note: Model called %s instead of get_weather", resp.ToolCalls[0].Name)
-		}
-
-		if resp.ToolCalls[0].ID == "" {
-			t.Error("Tool call ID is empty")
-		}
-	} else {
-		t.Logf("Model responded with text: %s", resp.Output)
-	}
+	runConformanceWithTools(t, perplexityChatConformanceConfig())
 }
 
 func TestPerplexity_ChatCompletion_SystemMessage(t *testing.T) {
-	skipIfNoPerplexityKey(t)
-
-	apiKey := getPerplexityKey(t)
-	provider := perplexity.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(perplexity.ModelSonar).
-		System("You are a pirate. Always respond in pirate speak.").
-		User("Say hello.").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// The output should contain pirate-like language
-	output := strings.ToLower(resp.Output)
-	pirateWords := []string{"ahoy", "matey", "arr", "aye", "ye", "ship", "sail", "sea"}
-
-	hasPirateWord := false
-	for _, word := range pirateWords {
-		if strings.Contains(output, word) {
-			hasPirateWord = true
-			break
-		}
-	}
-
-	if !hasPirateWord {
-		t.Logf("Note: Response may not be in pirate speak: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceSystemMessage(t, perplexityChatConformanceConfig())
 }
 
 func TestPerplexity_ChatCompletion_Temperature(t *testing.T) {
-	skipIfNoPerplexityKey(t)
-
-	apiKey := getPerplexityKey(t)
-	provider := perplexity.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Low temperature should give more deterministic output
-	resp, err := client.Chat(perplexity.ModelSonar).
-		User("What is 2+2? Reply with just the number.").
-		Temperature(0).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// Should contain "4"
-	if !strings.Contains(resp.Output, "4") {
-		t.Errorf("Expected response to contain '4', got: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceTemperature(t, perplexityChatConformanceConfig())
 }
 
 func TestPerplexity_ChatCompletion_MaxTokens(t *testing.T) {
-	skipIfNoPerplexityKey(t)
-
-	apiKey := getPerplexityKey(t)
-	provider := perplexity.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Very low max tokens should truncate response
-	resp, err := client.Chat(perplexity.ModelSonar).
-		User("Write a long story about a dragon.").
-		MaxTokens(10).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	// Response should be short due to max tokens
-	if resp.Usage.CompletionTokens > 15 { // Allow some buffer
-		t.Logf("Note: Completion tokens %d exceeds expected max ~10", resp.Usage.CompletionTokens)
-	}
-
-	t.Logf("Response: %s", resp.Output)
-	t.Logf("Completion tokens: %d", resp.Usage.CompletionTokens)
+	runConformanceMaxTokens(t, perplexityChatConformanceConfig())
 }
 
 func TestPerplexity_ChatCompletion_MultipleMessages(t *testing.T) {
-	skipIfNoPerplexityKey(t)
-
-	apiKey := getPerplexityKey(t)
-	provider := perplexity.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(perplexity.ModelSonar).
-		User("My name is Alice.").
-		Assistant("Nice to meet you, Alice!").
-		User("What's my name?").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// The response should remember the user's name
-	output := strings.ToLower(resp.Output)
-	if !strings.Contains(output, "alice") {
-		t.Errorf("Expected response to contain 'Alice', got: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceMultipleMessages(t, perplexityChatConformanceConfig())
 }
 
 func TestPerplexity_ChatCompletion_SonarPro(t *testing.T) {
@@ -298,11 +50,10 @@ func TestPerplexity_ChatCompletion_SonarPro(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// Test with Sonar Pro model
+	// Test with Sonar Pro model.
 	resp, err := client.Chat(perplexity.ModelSonarPro).
 		User("What is the capital of France? Answer in one word.").
 		GetResponse(ctx)
-
 	if err != nil {
 		t.Fatalf("Chat() error = %v", err)
 	}
@@ -318,4 +69,24 @@ func TestPerplexity_ChatCompletion_SonarPro(t *testing.T) {
 
 	t.Logf("Response: %s", resp.Output)
 	t.Logf("Model: %s", perplexity.ModelSonarPro)
+}
+
+func perplexityChatConformanceConfig() chatConformanceConfig {
+	return chatConformanceConfig{
+		getAPIKey: func(t *testing.T) string {
+			skipIfNoPerplexityKey(t)
+			return getPerplexityKey(t)
+		},
+		newProvider: func(apiKey string) core.Provider {
+			return perplexity.New(apiKey)
+		},
+		defaultModel:     perplexity.ModelSonar,
+		toolModel:        perplexity.ModelSonarPro,
+		timeout:          30 * time.Second,
+		responseIDPolicy: conformanceNote,
+		responseIDNote:   "Response ID is empty",
+		usagePolicy:      conformanceNote,
+		usageNote:        "Response usage total tokens is 0",
+		strictMaxTokens:  false,
+	}
 }

--- a/tests/integration/xai_test.go
+++ b/tests/integration/xai_test.go
@@ -13,279 +13,31 @@ import (
 )
 
 func TestXai_ChatCompletion(t *testing.T) {
-	skipIfNoXaiKey(t)
-
-	apiKey := getXaiKey(t)
-	provider := xai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(xai.ModelGrok3Mini).
-		User("Say 'hello' and nothing else.").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	if resp.ID == "" {
-		t.Log("Note: Response ID is empty")
-	}
-
-	// Verify usage is populated
-	if resp.Usage.TotalTokens == 0 {
-		t.Log("Note: Response usage total tokens is 0")
-	}
-
-	t.Logf("Response: %s", resp.Output)
-	t.Logf("Usage: %d prompt + %d completion = %d total",
-		resp.Usage.PromptTokens,
-		resp.Usage.CompletionTokens,
-		resp.Usage.TotalTokens)
+	runConformanceChatCompletion(t, xaiChatConformanceConfig())
 }
 
 func TestXai_ChatCompletion_Streaming(t *testing.T) {
-	skipIfNoXaiKey(t)
-
-	apiKey := getXaiKey(t)
-	provider := xai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	stream, err := client.Chat(xai.ModelGrok3Mini).
-		User("Count from 1 to 5, each number on a new line.").
-		Stream(ctx)
-
-	if err != nil {
-		t.Fatalf("Stream() error = %v", err)
-	}
-
-	// Collect deltas
-	var chunks []string
-	for chunk := range stream.Ch {
-		chunks = append(chunks, chunk.Delta)
-	}
-
-	// Check for errors
-	select {
-	case err := <-stream.Err:
-		if err != nil {
-			t.Fatalf("Stream error: %v", err)
-		}
-	default:
-	}
-
-	// Wait for final response
-	var finalResp *core.ChatResponse
-	select {
-	case resp := <-stream.Final:
-		finalResp = resp
-	case <-time.After(5 * time.Second):
-		t.Log("No final response received (may be expected)")
-	}
-
-	if len(chunks) == 0 {
-		t.Error("No chunks received")
-	}
-
-	combined := strings.Join(chunks, "")
-	if combined == "" {
-		t.Error("Combined output is empty")
-	}
-
-	t.Logf("Received %d chunks", len(chunks))
-	t.Logf("Combined output: %s", combined)
-
-	if finalResp != nil {
-		t.Logf("Final response ID: %s", finalResp.ID)
-	}
+	runConformanceStreaming(t, xaiChatConformanceConfig())
 }
 
 func TestXai_ChatCompletion_WithTools(t *testing.T) {
-	skipIfNoXaiKey(t)
-
-	apiKey := getXaiKey(t)
-	provider := xai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	tool := createTestTool()
-
-	resp, err := client.Chat(xai.ModelGrok3Mini).
-		User("What's the weather like in San Francisco?").
-		Tools(tool).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	// The model should either call the tool or respond with text
-	if resp.Output == "" && len(resp.ToolCalls) == 0 {
-		t.Error("Response has no output and no tool calls")
-	}
-
-	if len(resp.ToolCalls) > 0 {
-		t.Logf("Tool call: %s", resp.ToolCalls[0].Name)
-		t.Logf("Arguments: %s", string(resp.ToolCalls[0].Arguments))
-
-		// Verify tool call has expected structure
-		if resp.ToolCalls[0].Name != "get_weather" {
-			t.Logf("Note: Model called %s instead of get_weather", resp.ToolCalls[0].Name)
-		}
-
-		if resp.ToolCalls[0].ID == "" {
-			t.Error("Tool call ID is empty")
-		}
-	} else {
-		t.Logf("Model responded with text: %s", resp.Output)
-	}
+	runConformanceWithTools(t, xaiChatConformanceConfig())
 }
 
 func TestXai_ChatCompletion_SystemMessage(t *testing.T) {
-	skipIfNoXaiKey(t)
-
-	apiKey := getXaiKey(t)
-	provider := xai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(xai.ModelGrok3Mini).
-		System("You are a pirate. Always respond in pirate speak.").
-		User("Say hello.").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// The output should contain pirate-like language
-	output := strings.ToLower(resp.Output)
-	pirateWords := []string{"ahoy", "matey", "arr", "aye", "ye", "ship", "sail", "sea"}
-
-	hasPirateWord := false
-	for _, word := range pirateWords {
-		if strings.Contains(output, word) {
-			hasPirateWord = true
-			break
-		}
-	}
-
-	if !hasPirateWord {
-		t.Logf("Note: Response may not be in pirate speak: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceSystemMessage(t, xaiChatConformanceConfig())
 }
 
 func TestXai_ChatCompletion_Temperature(t *testing.T) {
-	skipIfNoXaiKey(t)
-
-	apiKey := getXaiKey(t)
-	provider := xai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Low temperature should give more deterministic output
-	resp, err := client.Chat(xai.ModelGrok3Mini).
-		User("What is 2+2? Reply with just the number.").
-		Temperature(0).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// Should contain "4"
-	if !strings.Contains(resp.Output, "4") {
-		t.Errorf("Expected response to contain '4', got: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceTemperature(t, xaiChatConformanceConfig())
 }
 
 func TestXai_ChatCompletion_MaxTokens(t *testing.T) {
-	skipIfNoXaiKey(t)
-
-	apiKey := getXaiKey(t)
-	provider := xai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Very low max tokens should truncate response
-	resp, err := client.Chat(xai.ModelGrok3Mini).
-		User("Write a long story about a dragon.").
-		MaxTokens(10).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	// Response should be short due to max tokens
-	if resp.Usage.CompletionTokens > 15 { // Allow some buffer
-		t.Logf("Note: Completion tokens %d exceeds expected max ~10", resp.Usage.CompletionTokens)
-	}
-
-	t.Logf("Response: %s", resp.Output)
-	t.Logf("Completion tokens: %d", resp.Usage.CompletionTokens)
+	runConformanceMaxTokens(t, xaiChatConformanceConfig())
 }
 
 func TestXai_ChatCompletion_MultipleMessages(t *testing.T) {
-	skipIfNoXaiKey(t)
-
-	apiKey := getXaiKey(t)
-	provider := xai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(xai.ModelGrok3Mini).
-		User("My name is Alice.").
-		Assistant("Nice to meet you, Alice!").
-		User("What's my name?").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// The response should remember the user's name
-	output := strings.ToLower(resp.Output)
-	if !strings.Contains(output, "alice") {
-		t.Errorf("Expected response to contain 'Alice', got: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceMultipleMessages(t, xaiChatConformanceConfig())
 }
 
 func TestXai_ChatCompletion_Grok3(t *testing.T) {
@@ -298,11 +50,10 @@ func TestXai_ChatCompletion_Grok3(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// Test with Grok 3 flagship model
+	// Test with Grok 3 flagship model.
 	resp, err := client.Chat(xai.ModelGrok3).
 		User("What is the capital of France? Answer in one word.").
 		GetResponse(ctx)
-
 	if err != nil {
 		t.Fatalf("Chat() error = %v", err)
 	}
@@ -330,11 +81,10 @@ func TestXai_ChatCompletion_GrokCodeFast(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Test with Grok Code Fast model
+	// Test with Grok Code Fast model.
 	resp, err := client.Chat(xai.ModelGrokCodeFast).
 		User("Write a Python function that adds two numbers. Just the function, no explanation.").
 		GetResponse(ctx)
-
 	if err != nil {
 		t.Fatalf("Chat() error = %v", err)
 	}
@@ -343,7 +93,7 @@ func TestXai_ChatCompletion_GrokCodeFast(t *testing.T) {
 		t.Error("Response output is empty")
 	}
 
-	// Should contain Python function syntax
+	// Should contain Python function syntax.
 	output := strings.ToLower(resp.Output)
 	if !strings.Contains(output, "def") {
 		t.Logf("Note: Expected response to contain 'def', got: %s", resp.Output)
@@ -351,4 +101,24 @@ func TestXai_ChatCompletion_GrokCodeFast(t *testing.T) {
 
 	t.Logf("Response: %s", resp.Output)
 	t.Logf("Model: %s", xai.ModelGrokCodeFast)
+}
+
+func xaiChatConformanceConfig() chatConformanceConfig {
+	return chatConformanceConfig{
+		getAPIKey: func(t *testing.T) string {
+			skipIfNoXaiKey(t)
+			return getXaiKey(t)
+		},
+		newProvider: func(apiKey string) core.Provider {
+			return xai.New(apiKey)
+		},
+		defaultModel:     xai.ModelGrok3Mini,
+		toolModel:        xai.ModelGrok3Mini,
+		timeout:          30 * time.Second,
+		responseIDPolicy: conformanceNote,
+		responseIDNote:   "Response ID is empty",
+		usagePolicy:      conformanceNote,
+		usageNote:        "Response usage total tokens is 0",
+		strictMaxTokens:  false,
+	}
 }

--- a/tests/integration/zai_test.go
+++ b/tests/integration/zai_test.go
@@ -22,300 +22,38 @@ func zaiTestSetup(t *testing.T) func() {
 	t.Helper()
 	zaiTestMutex.Lock()
 	return func() {
-		// Small delay between tests to avoid rate limiting
+		// Small delay between tests to avoid rate limiting.
 		time.Sleep(500 * time.Millisecond)
 		zaiTestMutex.Unlock()
 	}
 }
 
 func TestZai_ChatCompletion(t *testing.T) {
-	skipIfNoZaiKey(t)
-	cleanup := zaiTestSetup(t)
-	defer cleanup()
-
-	apiKey := getZaiKey(t)
-	provider := zai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(zai.ModelGLM47Flash).
-		User("Say 'hello' and nothing else.").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	if resp.ID == "" {
-		t.Log("Note: Response ID is empty (Z.ai may not return IDs)")
-	}
-
-	// Verify usage is populated
-	if resp.Usage.TotalTokens == 0 {
-		t.Error("Response usage total tokens is 0")
-	}
-
-	t.Logf("Response: %s", resp.Output)
-	t.Logf("Usage: %d prompt + %d completion = %d total",
-		resp.Usage.PromptTokens,
-		resp.Usage.CompletionTokens,
-		resp.Usage.TotalTokens)
+	runConformanceChatCompletion(t, zaiChatConformanceConfig())
 }
 
 func TestZai_ChatCompletion_Streaming(t *testing.T) {
-	skipIfNoZaiKey(t)
-	cleanup := zaiTestSetup(t)
-	defer cleanup()
-
-	apiKey := getZaiKey(t)
-	provider := zai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	stream, err := client.Chat(zai.ModelGLM47Flash).
-		User("Count from 1 to 5, each number on a new line.").
-		Stream(ctx)
-
-	if err != nil {
-		t.Fatalf("Stream() error = %v", err)
-	}
-
-	// Collect deltas
-	var chunks []string
-	for chunk := range stream.Ch {
-		chunks = append(chunks, chunk.Delta)
-	}
-
-	// Check for errors
-	select {
-	case err := <-stream.Err:
-		if err != nil {
-			t.Fatalf("Stream error: %v", err)
-		}
-	default:
-	}
-
-	// Wait for final response
-	var finalResp *core.ChatResponse
-	select {
-	case resp := <-stream.Final:
-		finalResp = resp
-	case <-time.After(5 * time.Second):
-		t.Log("No final response received (may be expected)")
-	}
-
-	if len(chunks) == 0 {
-		t.Error("No chunks received")
-	}
-
-	combined := strings.Join(chunks, "")
-	if combined == "" {
-		t.Error("Combined output is empty")
-	}
-
-	t.Logf("Received %d chunks", len(chunks))
-	t.Logf("Combined output: %s", combined)
-
-	if finalResp != nil {
-		t.Logf("Final response ID: %s", finalResp.ID)
-	}
+	runConformanceStreaming(t, zaiChatConformanceConfig())
 }
 
 func TestZai_ChatCompletion_WithTools(t *testing.T) {
-	skipIfNoZaiKey(t)
-	cleanup := zaiTestSetup(t)
-	defer cleanup()
-
-	apiKey := getZaiKey(t)
-	provider := zai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	tool := createTestTool()
-
-	resp, err := client.Chat(zai.ModelGLM47Flash).
-		User("What's the weather like in San Francisco?").
-		Tools(tool).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	// The model should either call the tool or respond with text
-	if resp.Output == "" && len(resp.ToolCalls) == 0 {
-		t.Error("Response has no output and no tool calls")
-	}
-
-	if len(resp.ToolCalls) > 0 {
-		t.Logf("Tool call: %s", resp.ToolCalls[0].Name)
-		t.Logf("Arguments: %s", string(resp.ToolCalls[0].Arguments))
-
-		// Verify tool call has expected structure
-		if resp.ToolCalls[0].Name != "get_weather" {
-			t.Logf("Note: Model called %s instead of get_weather", resp.ToolCalls[0].Name)
-		}
-
-		if resp.ToolCalls[0].ID == "" {
-			t.Error("Tool call ID is empty")
-		}
-	} else {
-		t.Logf("Model responded with text: %s", resp.Output)
-	}
+	runConformanceWithTools(t, zaiChatConformanceConfig())
 }
 
 func TestZai_ChatCompletion_SystemMessage(t *testing.T) {
-	skipIfNoZaiKey(t)
-	cleanup := zaiTestSetup(t)
-	defer cleanup()
-
-	apiKey := getZaiKey(t)
-	provider := zai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(zai.ModelGLM47Flash).
-		System("You are a pirate. Always respond in pirate speak.").
-		User("Say hello.").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// The output should contain pirate-like language
-	output := strings.ToLower(resp.Output)
-	pirateWords := []string{"ahoy", "matey", "arr", "aye", "ye", "ship", "sail", "sea"}
-
-	hasPirateWord := false
-	for _, word := range pirateWords {
-		if strings.Contains(output, word) {
-			hasPirateWord = true
-			break
-		}
-	}
-
-	if !hasPirateWord {
-		t.Logf("Note: Response may not be in pirate speak: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceSystemMessage(t, zaiChatConformanceConfig())
 }
 
 func TestZai_ChatCompletion_Temperature(t *testing.T) {
-	skipIfNoZaiKey(t)
-	cleanup := zaiTestSetup(t)
-	defer cleanup()
-
-	apiKey := getZaiKey(t)
-	provider := zai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	// Low temperature should give more deterministic output
-	resp, err := client.Chat(zai.ModelGLM47Flash).
-		User("What is 2+2? Reply with just the number.").
-		Temperature(0.01). // Z.ai may not support exactly 0
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// Should contain "4"
-	if !strings.Contains(resp.Output, "4") {
-		t.Errorf("Expected response to contain '4', got: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceTemperature(t, zaiChatConformanceConfig())
 }
 
 func TestZai_ChatCompletion_MaxTokens(t *testing.T) {
-	skipIfNoZaiKey(t)
-	cleanup := zaiTestSetup(t)
-	defer cleanup()
-
-	apiKey := getZaiKey(t)
-	provider := zai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	// Very low max tokens should truncate response
-	resp, err := client.Chat(zai.ModelGLM47Flash).
-		User("Write a long story about a dragon.").
-		MaxTokens(10).
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	// Response should be short due to max tokens
-	if resp.Usage.CompletionTokens > 15 { // Allow some buffer
-		t.Errorf("Expected completion tokens <= 15, got %d", resp.Usage.CompletionTokens)
-	}
-
-	t.Logf("Response: %s", resp.Output)
-	t.Logf("Completion tokens: %d", resp.Usage.CompletionTokens)
+	runConformanceMaxTokens(t, zaiChatConformanceConfig())
 }
 
 func TestZai_ChatCompletion_MultipleMessages(t *testing.T) {
-	skipIfNoZaiKey(t)
-	cleanup := zaiTestSetup(t)
-	defer cleanup()
-
-	apiKey := getZaiKey(t)
-	provider := zai.New(apiKey)
-	client := core.NewClient(provider)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
-
-	resp, err := client.Chat(zai.ModelGLM47Flash).
-		User("My name is Alice.").
-		Assistant("Nice to meet you, Alice!").
-		User("What's my name?").
-		GetResponse(ctx)
-
-	if err != nil {
-		t.Fatalf("Chat() error = %v", err)
-	}
-
-	if resp.Output == "" {
-		t.Error("Response output is empty")
-	}
-
-	// The response should remember the user's name
-	output := strings.ToLower(resp.Output)
-	if !strings.Contains(output, "alice") {
-		t.Errorf("Expected response to contain 'Alice', got: %s", resp.Output)
-	}
-
-	t.Logf("Response: %s", resp.Output)
+	runConformanceMultipleMessages(t, zaiChatConformanceConfig())
 }
 
 func TestZai_ChatCompletion_GLM47(t *testing.T) {
@@ -330,11 +68,10 @@ func TestZai_ChatCompletion_GLM47(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
-	// Test with GLM-4.7 flagship model
+	// Test with GLM-4.7 flagship model.
 	resp, err := client.Chat(zai.ModelGLM47).
 		User("What is the capital of France? Answer in one word.").
 		GetResponse(ctx)
-
 	if err != nil {
 		t.Fatalf("Chat() error = %v", err)
 	}
@@ -364,11 +101,10 @@ func TestZai_ChatCompletion_GLM45Flash(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// Test with GLM-4.5 Flash model (different series)
+	// Test with GLM-4.5 Flash model (different series).
 	resp, err := client.Chat(zai.ModelGLM45Flash).
 		User("What is 10 + 5? Reply with just the number.").
 		GetResponse(ctx)
-
 	if err != nil {
 		t.Fatalf("Chat() error = %v", err)
 	}
@@ -383,4 +119,24 @@ func TestZai_ChatCompletion_GLM45Flash(t *testing.T) {
 
 	t.Logf("Response: %s", resp.Output)
 	t.Logf("Model: %s", zai.ModelGLM45Flash)
+}
+
+func zaiChatConformanceConfig() chatConformanceConfig {
+	return chatConformanceConfig{
+		getAPIKey: func(t *testing.T) string {
+			skipIfNoZaiKey(t)
+			return getZaiKey(t)
+		},
+		newProvider: func(apiKey string) core.Provider {
+			return zai.New(apiKey)
+		},
+		defaultModel:     zai.ModelGLM47Flash,
+		toolModel:        zai.ModelGLM47Flash,
+		timeout:          60 * time.Second,
+		responseIDPolicy: conformanceNote,
+		responseIDNote:   "Response ID is empty (Z.ai may not return IDs)",
+		usagePolicy:      conformanceRequire,
+		strictMaxTokens:  true,
+		beforeEach:       zaiTestSetup,
+	}
 }

--- a/tools/middleware.go
+++ b/tools/middleware.go
@@ -2,14 +2,7 @@ package tools
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
-	"errors"
-	"fmt"
-	"strings"
-	"sync"
-	"time"
 )
 
 // ToolCallFunc is the function signature for tool execution.
@@ -19,6 +12,9 @@ type ToolCallFunc func(ctx context.Context, args json.RawMessage) (any, error)
 // Middleware wraps a ToolCallFunc to add behavior before and/or after execution.
 // Middleware functions receive the next handler in the chain and return a new handler.
 type Middleware func(next ToolCallFunc) ToolCallFunc
+
+// ToolContextSchemaMetadataKey is the metadata key used to store tool schemas.
+const ToolContextSchemaMetadataKey = "schema"
 
 // ToolContext provides metadata about the current tool call to middleware.
 // It's stored in the context and accessible via ToolContextFromContext.
@@ -31,6 +27,9 @@ type ToolContext struct {
 
 	// Iteration is the current workflow loop iteration (if provided by caller).
 	Iteration int
+
+	// Schema is the tool's JSON schema for this invocation.
+	Schema json.RawMessage
 
 	// Metadata allows middleware to share data with each other.
 	Metadata map[string]any
@@ -51,11 +50,77 @@ func ToolContextFromContext(ctx context.Context) *ToolContext {
 	return tc
 }
 
+// ToolSchemaFromContext retrieves a tool schema from context.
+func ToolSchemaFromContext(ctx context.Context) (json.RawMessage, bool) {
+	tc := ToolContextFromContext(ctx)
+	if tc == nil {
+		return nil, false
+	}
+
+	if len(tc.Schema) > 0 {
+		return cloneRawMessage(tc.Schema), true
+	}
+
+	if tc.Metadata == nil {
+		return nil, false
+	}
+
+	raw, ok := tc.Metadata[ToolContextSchemaMetadataKey]
+	if !ok {
+		return nil, false
+	}
+
+	switch value := raw.(type) {
+	case json.RawMessage:
+		if len(value) == 0 {
+			return nil, false
+		}
+		return cloneRawMessage(value), true
+	case []byte:
+		if len(value) == 0 {
+			return nil, false
+		}
+		return cloneRawMessage(json.RawMessage(value)), true
+	case string:
+		if value == "" {
+			return nil, false
+		}
+		return json.RawMessage(value), true
+	default:
+		return nil, false
+	}
+}
+
+func cloneRawMessage(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return nil
+	}
+	cloned := make(json.RawMessage, len(raw))
+	copy(cloned, raw)
+	return cloned
+}
+
+func setToolSchema(tc *ToolContext, schema json.RawMessage) {
+	if tc.Metadata == nil {
+		tc.Metadata = make(map[string]any)
+	}
+
+	if len(schema) == 0 {
+		tc.Schema = nil
+		delete(tc.Metadata, ToolContextSchemaMetadataKey)
+		return
+	}
+
+	cloned := cloneRawMessage(schema)
+	tc.Schema = cloned
+	tc.Metadata[ToolContextSchemaMetadataKey] = cloned
+}
+
 // Chain combines multiple middleware into a single middleware.
 // Middleware are executed in the order provided (first middleware is outermost).
 func Chain(middlewares ...Middleware) Middleware {
 	return func(next ToolCallFunc) ToolCallFunc {
-		// Apply in reverse order so first middleware is outermost
+		// Apply in reverse order so first middleware is outermost.
 		for i := len(middlewares) - 1; i >= 0; i-- {
 			next = middlewares[i](next)
 		}
@@ -90,7 +155,7 @@ func (w *wrappedTool) Description() string { return w.tool.Description() }
 func (w *wrappedTool) Schema() ToolSchema  { return w.tool.Schema() }
 
 func (w *wrappedTool) Call(ctx context.Context, args json.RawMessage) (any, error) {
-	// Ensure ToolContext exists
+	// Ensure ToolContext exists.
 	tc := ToolContextFromContext(ctx)
 	if tc == nil {
 		tc = &ToolContext{
@@ -98,592 +163,15 @@ func (w *wrappedTool) Call(ctx context.Context, args json.RawMessage) (any, erro
 			Metadata: make(map[string]any),
 		}
 		ctx = ContextWithToolContext(ctx, tc)
-	} else if tc.ToolName == "" {
-		tc.ToolName = w.tool.Name()
+	} else {
+		if tc.ToolName == "" {
+			tc.ToolName = w.tool.Name()
+		}
+		if tc.Metadata == nil {
+			tc.Metadata = make(map[string]any)
+		}
 	}
 
+	setToolSchema(tc, w.tool.Schema().JSONSchema)
 	return w.wrapped(ctx, args)
-}
-
-// -----------------------------------------------------------------------------
-// Logging Middleware
-// -----------------------------------------------------------------------------
-
-// Logger is the interface for logging middleware.
-type Logger interface {
-	Printf(format string, v ...any)
-}
-
-// WithLogging creates middleware that logs tool calls.
-func WithLogging(logger Logger) Middleware {
-	return func(next ToolCallFunc) ToolCallFunc {
-		return func(ctx context.Context, args json.RawMessage) (any, error) {
-			tc := ToolContextFromContext(ctx)
-			toolName := "unknown"
-			if tc != nil {
-				toolName = tc.ToolName
-			}
-
-			logger.Printf("tool call start: %s", toolName)
-			start := time.Now()
-
-			result, err := next(ctx, args)
-
-			duration := time.Since(start)
-			if err != nil {
-				logger.Printf("tool call error: %s, duration=%v, error=%v", toolName, duration, err)
-			} else {
-				logger.Printf("tool call success: %s, duration=%v", toolName, duration)
-			}
-
-			return result, err
-		}
-	}
-}
-
-// WithDetailedLogging creates middleware that logs tool calls with arguments.
-// WARNING: May log sensitive data. Use only in development.
-func WithDetailedLogging(logger Logger) Middleware {
-	return func(next ToolCallFunc) ToolCallFunc {
-		return func(ctx context.Context, args json.RawMessage) (any, error) {
-			tc := ToolContextFromContext(ctx)
-			toolName := "unknown"
-			if tc != nil {
-				toolName = tc.ToolName
-			}
-
-			logger.Printf("tool call: %s, args=%s", toolName, string(args))
-			start := time.Now()
-
-			result, err := next(ctx, args)
-
-			duration := time.Since(start)
-			if err != nil {
-				logger.Printf("tool error: %s, duration=%v, error=%v", toolName, duration, err)
-			} else {
-				resultJSON, _ := json.Marshal(result)
-				logger.Printf("tool result: %s, duration=%v, result=%s", toolName, duration, string(resultJSON))
-			}
-
-			return result, err
-		}
-	}
-}
-
-// -----------------------------------------------------------------------------
-// Timeout Middleware
-// -----------------------------------------------------------------------------
-
-// WithTimeout creates middleware that enforces a timeout on tool execution.
-func WithTimeout(d time.Duration) Middleware {
-	return func(next ToolCallFunc) ToolCallFunc {
-		return func(ctx context.Context, args json.RawMessage) (any, error) {
-			ctx, cancel := context.WithTimeout(ctx, d)
-			defer cancel()
-
-			// Execute in goroutine to respect timeout
-			type result struct {
-				value any
-				err   error
-			}
-			ch := make(chan result, 1)
-
-			go func() {
-				v, err := next(ctx, args)
-				ch <- result{v, err}
-			}()
-
-			select {
-			case r := <-ch:
-				return r.value, r.err
-			case <-ctx.Done():
-				return nil, fmt.Errorf("tool execution timeout after %v", d)
-			}
-		}
-	}
-}
-
-// -----------------------------------------------------------------------------
-// Rate Limiting Middleware
-// -----------------------------------------------------------------------------
-
-// RateLimiter is the interface for rate limiting.
-type RateLimiter interface {
-	// Allow returns true if the request should proceed.
-	Allow() bool
-	// Wait blocks until the request can proceed or context is canceled.
-	Wait(ctx context.Context) error
-}
-
-// WithRateLimit creates middleware that rate limits tool calls.
-// Uses a token bucket algorithm with the specified rate (calls per second).
-func WithRateLimit(ratePerSecond float64) Middleware {
-	limiter := newTokenBucket(ratePerSecond)
-	return WithRateLimiter(limiter)
-}
-
-// WithRateLimiter creates middleware using a custom rate limiter.
-func WithRateLimiter(limiter RateLimiter) Middleware {
-	return func(next ToolCallFunc) ToolCallFunc {
-		return func(ctx context.Context, args json.RawMessage) (any, error) {
-			if err := limiter.Wait(ctx); err != nil {
-				return nil, fmt.Errorf("rate limit exceeded: %w", err)
-			}
-			return next(ctx, args)
-		}
-	}
-}
-
-// tokenBucket implements a simple token bucket rate limiter.
-type tokenBucket struct {
-	mu         sync.Mutex
-	tokens     float64
-	maxTokens  float64
-	refillRate float64
-	lastRefill time.Time
-}
-
-func newTokenBucket(ratePerSecond float64) *tokenBucket {
-	return &tokenBucket{
-		tokens:     ratePerSecond,
-		maxTokens:  ratePerSecond * 2, // Allow burst of 2x rate
-		refillRate: ratePerSecond,
-		lastRefill: time.Now(),
-	}
-}
-
-func (tb *tokenBucket) Allow() bool {
-	tb.mu.Lock()
-	defer tb.mu.Unlock()
-	tb.refill()
-	if tb.tokens >= 1 {
-		tb.tokens--
-		return true
-	}
-	return false
-}
-
-func (tb *tokenBucket) Wait(ctx context.Context) error {
-	for {
-		if tb.Allow() {
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(10 * time.Millisecond):
-			// Retry
-		}
-	}
-}
-
-func (tb *tokenBucket) refill() {
-	now := time.Now()
-	elapsed := now.Sub(tb.lastRefill).Seconds()
-	tb.tokens = min(tb.maxTokens, tb.tokens+elapsed*tb.refillRate)
-	tb.lastRefill = now
-}
-
-// -----------------------------------------------------------------------------
-// Caching Middleware
-// -----------------------------------------------------------------------------
-
-// Cache is the interface for caching tool results.
-type Cache interface {
-	Get(key string) (any, bool)
-	Set(key string, value any, ttl time.Duration)
-}
-
-// CacheKeyFunc generates a cache key from tool name and arguments.
-type CacheKeyFunc func(toolName string, args json.RawMessage) string
-
-// DefaultCacheKey generates a cache key by hashing tool name and arguments.
-func DefaultCacheKey(toolName string, args json.RawMessage) string {
-	h := sha256.New()
-	h.Write([]byte(toolName))
-	h.Write(args)
-	return hex.EncodeToString(h.Sum(nil))
-}
-
-// WithCache creates middleware that caches tool results.
-func WithCache(cache Cache, ttl time.Duration) Middleware {
-	return WithCacheCustomKey(cache, ttl, DefaultCacheKey)
-}
-
-// WithCacheCustomKey creates caching middleware with a custom key function.
-func WithCacheCustomKey(cache Cache, ttl time.Duration, keyFunc CacheKeyFunc) Middleware {
-	return func(next ToolCallFunc) ToolCallFunc {
-		return func(ctx context.Context, args json.RawMessage) (any, error) {
-			tc := ToolContextFromContext(ctx)
-			toolName := ""
-			if tc != nil {
-				toolName = tc.ToolName
-			}
-
-			key := keyFunc(toolName, args)
-
-			// Check cache
-			if cached, ok := cache.Get(key); ok {
-				return cached, nil
-			}
-
-			// Execute tool
-			result, err := next(ctx, args)
-			if err != nil {
-				return nil, err
-			}
-
-			// Cache successful result
-			cache.Set(key, result, ttl)
-			return result, nil
-		}
-	}
-}
-
-// memoryCache is a simple in-memory cache implementation.
-type memoryCache struct {
-	mu    sync.RWMutex
-	items map[string]cacheItem
-}
-
-type cacheItem struct {
-	value   any
-	expires time.Time
-}
-
-// NewMemoryCache creates a new in-memory cache.
-func NewMemoryCache() Cache {
-	return &memoryCache{
-		items: make(map[string]cacheItem),
-	}
-}
-
-func (c *memoryCache) Get(key string) (any, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	item, ok := c.items[key]
-	if !ok || time.Now().After(item.expires) {
-		return nil, false
-	}
-	return item.value, true
-}
-
-func (c *memoryCache) Set(key string, value any, ttl time.Duration) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.items[key] = cacheItem{
-		value:   value,
-		expires: time.Now().Add(ttl),
-	}
-}
-
-// -----------------------------------------------------------------------------
-// Validation Middleware
-// -----------------------------------------------------------------------------
-
-// SchemaValidator validates arguments against a JSON schema.
-type SchemaValidator interface {
-	Validate(schema json.RawMessage, data json.RawMessage) error
-}
-
-// WithValidation creates middleware that validates arguments against the tool's schema.
-func WithValidation(validator SchemaValidator) Middleware {
-	return func(next ToolCallFunc) ToolCallFunc {
-		return func(ctx context.Context, args json.RawMessage) (any, error) {
-			tc := ToolContextFromContext(ctx)
-
-			// We need access to the tool's schema
-			// This requires the tool to be stored in context or passed differently
-			// For now, skip validation if we can't access schema
-			if tc == nil || tc.Metadata == nil {
-				return next(ctx, args)
-			}
-
-			schema, ok := tc.Metadata["schema"].(json.RawMessage)
-			if !ok {
-				return next(ctx, args)
-			}
-
-			if err := validator.Validate(schema, args); err != nil {
-				return nil, fmt.Errorf("argument validation failed: %w", err)
-			}
-
-			return next(ctx, args)
-		}
-	}
-}
-
-// WithBasicValidation creates middleware that performs basic JSON validation.
-func WithBasicValidation() Middleware {
-	return func(next ToolCallFunc) ToolCallFunc {
-		return func(ctx context.Context, args json.RawMessage) (any, error) {
-			// Verify arguments are valid JSON
-			if !json.Valid(args) {
-				return nil, errors.New("invalid JSON arguments")
-			}
-			return next(ctx, args)
-		}
-	}
-}
-
-// -----------------------------------------------------------------------------
-// Metrics Middleware
-// -----------------------------------------------------------------------------
-
-// MetricsCollector receives tool execution metrics.
-type MetricsCollector interface {
-	// RecordCall records a tool call with its outcome.
-	RecordCall(toolName string, duration time.Duration, err error)
-}
-
-// WithMetrics creates middleware that records tool execution metrics.
-func WithMetrics(collector MetricsCollector) Middleware {
-	return func(next ToolCallFunc) ToolCallFunc {
-		return func(ctx context.Context, args json.RawMessage) (any, error) {
-			tc := ToolContextFromContext(ctx)
-			toolName := "unknown"
-			if tc != nil {
-				toolName = tc.ToolName
-			}
-
-			start := time.Now()
-			result, err := next(ctx, args)
-			duration := time.Since(start)
-
-			collector.RecordCall(toolName, duration, err)
-
-			return result, err
-		}
-	}
-}
-
-// -----------------------------------------------------------------------------
-// Retry Middleware
-// -----------------------------------------------------------------------------
-
-// RetryConfig configures retry behavior.
-type RetryConfig struct {
-	MaxAttempts int
-	InitialWait time.Duration
-	MaxWait     time.Duration
-	Multiplier  float64
-	Retryable   func(error) bool // Returns true if error is retryable
-}
-
-// DefaultRetryConfig returns sensible retry defaults.
-func DefaultRetryConfig() RetryConfig {
-	return RetryConfig{
-		MaxAttempts: 3,
-		InitialWait: 100 * time.Millisecond,
-		MaxWait:     5 * time.Second,
-		Multiplier:  2.0,
-		Retryable: func(err error) bool {
-			// Retry on common transient errors
-			return errors.Is(err, context.DeadlineExceeded) ||
-				strings.Contains(err.Error(), "temporary") ||
-				strings.Contains(err.Error(), "timeout")
-		},
-	}
-}
-
-// WithRetry creates middleware that retries failed tool calls.
-func WithRetry(config RetryConfig) Middleware {
-	return func(next ToolCallFunc) ToolCallFunc {
-		return func(ctx context.Context, args json.RawMessage) (any, error) {
-			var lastErr error
-			wait := config.InitialWait
-
-			for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
-				result, err := next(ctx, args)
-				if err == nil {
-					return result, nil
-				}
-
-				lastErr = err
-
-				// Check if error is retryable
-				if config.Retryable != nil && !config.Retryable(err) {
-					return nil, err
-				}
-
-				// Don't wait after last attempt
-				if attempt == config.MaxAttempts {
-					break
-				}
-
-				// Wait with exponential backoff
-				select {
-				case <-ctx.Done():
-					return nil, ctx.Err()
-				case <-time.After(wait):
-				}
-
-				wait = time.Duration(float64(wait) * config.Multiplier)
-				if wait > config.MaxWait {
-					wait = config.MaxWait
-				}
-			}
-
-			return nil, fmt.Errorf("tool call failed after %d attempts: %w", config.MaxAttempts, lastErr)
-		}
-	}
-}
-
-// -----------------------------------------------------------------------------
-// Circuit Breaker Middleware
-// -----------------------------------------------------------------------------
-
-// CircuitState represents the state of a circuit breaker.
-type CircuitState int
-
-const (
-	CircuitClosed   CircuitState = iota // Normal operation
-	CircuitOpen                         // Failing, reject calls
-	CircuitHalfOpen                     // Testing if recovered
-)
-
-// String returns the string representation of a CircuitState.
-func (s CircuitState) String() string {
-	switch s {
-	case CircuitClosed:
-		return "closed"
-	case CircuitOpen:
-		return "open"
-	case CircuitHalfOpen:
-		return "half-open"
-	default:
-		return "unknown"
-	}
-}
-
-// CircuitBreakerConfig configures circuit breaker behavior.
-type CircuitBreakerConfig struct {
-	FailureThreshold int           // Failures before opening
-	SuccessThreshold int           // Successes in half-open to close
-	OpenDuration     time.Duration // How long to stay open
-}
-
-// DefaultCircuitBreakerConfig returns sensible circuit breaker defaults.
-func DefaultCircuitBreakerConfig() CircuitBreakerConfig {
-	return CircuitBreakerConfig{
-		FailureThreshold: 5,
-		SuccessThreshold: 2,
-		OpenDuration:     30 * time.Second,
-	}
-}
-
-// ErrCircuitOpen is returned when the circuit breaker is open.
-var ErrCircuitOpen = errors.New("circuit breaker open: too many failures")
-
-// WithCircuitBreaker creates middleware that implements the circuit breaker pattern.
-func WithCircuitBreaker(config CircuitBreakerConfig) Middleware {
-	var (
-		mu          sync.Mutex
-		state       CircuitState
-		failures    int
-		successes   int
-		lastFailure time.Time
-	)
-
-	return func(next ToolCallFunc) ToolCallFunc {
-		return func(ctx context.Context, args json.RawMessage) (any, error) {
-			mu.Lock()
-
-			// Check if circuit should transition from open to half-open
-			if state == CircuitOpen && time.Since(lastFailure) > config.OpenDuration {
-				state = CircuitHalfOpen
-				successes = 0
-			}
-
-			// Reject if circuit is open
-			if state == CircuitOpen {
-				mu.Unlock()
-				return nil, ErrCircuitOpen
-			}
-
-			mu.Unlock()
-
-			// Execute tool
-			result, err := next(ctx, args)
-
-			mu.Lock()
-			defer mu.Unlock()
-
-			if err != nil {
-				failures++
-				lastFailure = time.Now()
-
-				if state == CircuitHalfOpen {
-					// Failure in half-open returns to open
-					state = CircuitOpen
-				} else if failures >= config.FailureThreshold {
-					// Too many failures, open circuit
-					state = CircuitOpen
-				}
-
-				return nil, err
-			}
-
-			// Success
-			if state == CircuitHalfOpen {
-				successes++
-				if successes >= config.SuccessThreshold {
-					// Enough successes, close circuit
-					state = CircuitClosed
-					failures = 0
-				}
-			} else {
-				// Reset failure count on success in closed state
-				failures = 0
-			}
-
-			return result, nil
-		}
-	}
-}
-
-// -----------------------------------------------------------------------------
-// Conditional Middleware
-// -----------------------------------------------------------------------------
-
-// ForTools applies middleware only to tools with the specified names.
-func ForTools(toolNames []string, middleware Middleware) Middleware {
-	nameSet := make(map[string]bool)
-	for _, name := range toolNames {
-		nameSet[name] = true
-	}
-
-	return func(next ToolCallFunc) ToolCallFunc {
-		return func(ctx context.Context, args json.RawMessage) (any, error) {
-			tc := ToolContextFromContext(ctx)
-			if tc != nil && nameSet[tc.ToolName] {
-				// Apply middleware
-				return middleware(next)(ctx, args)
-			}
-			// Skip middleware
-			return next(ctx, args)
-		}
-	}
-}
-
-// ExceptTools applies middleware to all tools except those with the specified names.
-func ExceptTools(toolNames []string, middleware Middleware) Middleware {
-	nameSet := make(map[string]bool)
-	for _, name := range toolNames {
-		nameSet[name] = true
-	}
-
-	return func(next ToolCallFunc) ToolCallFunc {
-		return func(ctx context.Context, args json.RawMessage) (any, error) {
-			tc := ToolContextFromContext(ctx)
-			if tc == nil || !nameSet[tc.ToolName] {
-				// Apply middleware
-				return middleware(next)(ctx, args)
-			}
-			// Skip middleware
-			return next(ctx, args)
-		}
-	}
 }

--- a/tools/middleware_cache.go
+++ b/tools/middleware_cache.go
@@ -1,0 +1,101 @@
+package tools
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sync"
+	"time"
+)
+
+// Cache is the interface for caching tool results.
+type Cache interface {
+	Get(key string) (any, bool)
+	Set(key string, value any, ttl time.Duration)
+}
+
+// CacheKeyFunc generates a cache key from tool name and arguments.
+type CacheKeyFunc func(toolName string, args json.RawMessage) string
+
+// DefaultCacheKey generates a cache key by hashing tool name and arguments.
+func DefaultCacheKey(toolName string, args json.RawMessage) string {
+	h := sha256.New()
+	h.Write([]byte(toolName))
+	h.Write(args)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// WithCache creates middleware that caches tool results.
+func WithCache(cache Cache, ttl time.Duration) Middleware {
+	return WithCacheCustomKey(cache, ttl, DefaultCacheKey)
+}
+
+// WithCacheCustomKey creates caching middleware with a custom key function.
+func WithCacheCustomKey(cache Cache, ttl time.Duration, keyFunc CacheKeyFunc) Middleware {
+	return func(next ToolCallFunc) ToolCallFunc {
+		return func(ctx context.Context, args json.RawMessage) (any, error) {
+			tc := ToolContextFromContext(ctx)
+			toolName := ""
+			if tc != nil {
+				toolName = tc.ToolName
+			}
+
+			key := keyFunc(toolName, args)
+
+			// Check cache.
+			if cached, ok := cache.Get(key); ok {
+				return cached, nil
+			}
+
+			// Execute tool.
+			result, err := next(ctx, args)
+			if err != nil {
+				return nil, err
+			}
+
+			// Cache successful result.
+			cache.Set(key, result, ttl)
+			return result, nil
+		}
+	}
+}
+
+// memoryCache is a simple in-memory cache implementation.
+type memoryCache struct {
+	mu    sync.RWMutex
+	items map[string]cacheItem
+}
+
+type cacheItem struct {
+	value   any
+	expires time.Time
+}
+
+// NewMemoryCache creates a new in-memory cache.
+func NewMemoryCache() Cache {
+	return &memoryCache{
+		items: make(map[string]cacheItem),
+	}
+}
+
+func (c *memoryCache) Get(key string) (any, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	item, ok := c.items[key]
+	if !ok || time.Now().After(item.expires) {
+		return nil, false
+	}
+	return item.value, true
+}
+
+func (c *memoryCache) Set(key string, value any, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.items[key] = cacheItem{
+		value:   value,
+		expires: time.Now().Add(ttl),
+	}
+}

--- a/tools/middleware_circuit_breaker.go
+++ b/tools/middleware_circuit_breaker.go
@@ -1,0 +1,118 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"time"
+)
+
+// CircuitState represents the state of a circuit breaker.
+type CircuitState int
+
+const (
+	CircuitClosed   CircuitState = iota // Normal operation.
+	CircuitOpen                         // Failing, reject calls.
+	CircuitHalfOpen                     // Testing if recovered.
+)
+
+// String returns the string representation of a CircuitState.
+func (s CircuitState) String() string {
+	switch s {
+	case CircuitClosed:
+		return "closed"
+	case CircuitOpen:
+		return "open"
+	case CircuitHalfOpen:
+		return "half-open"
+	default:
+		return "unknown"
+	}
+}
+
+// CircuitBreakerConfig configures circuit breaker behavior.
+type CircuitBreakerConfig struct {
+	FailureThreshold int           // Failures before opening.
+	SuccessThreshold int           // Successes in half-open to close.
+	OpenDuration     time.Duration // How long to stay open.
+}
+
+// DefaultCircuitBreakerConfig returns sensible circuit breaker defaults.
+func DefaultCircuitBreakerConfig() CircuitBreakerConfig {
+	return CircuitBreakerConfig{
+		FailureThreshold: 5,
+		SuccessThreshold: 2,
+		OpenDuration:     30 * time.Second,
+	}
+}
+
+// ErrCircuitOpen is returned when the circuit breaker is open.
+var ErrCircuitOpen = errors.New("circuit breaker open: too many failures")
+
+// WithCircuitBreaker creates middleware that implements the circuit breaker pattern.
+func WithCircuitBreaker(config CircuitBreakerConfig) Middleware {
+	var (
+		mu          sync.Mutex
+		state       CircuitState
+		failures    int
+		successes   int
+		lastFailure time.Time
+	)
+
+	return func(next ToolCallFunc) ToolCallFunc {
+		return func(ctx context.Context, args json.RawMessage) (any, error) {
+			mu.Lock()
+
+			// Check if circuit should transition from open to half-open.
+			if state == CircuitOpen && time.Since(lastFailure) > config.OpenDuration {
+				state = CircuitHalfOpen
+				successes = 0
+			}
+
+			// Reject if circuit is open.
+			if state == CircuitOpen {
+				mu.Unlock()
+				return nil, ErrCircuitOpen
+			}
+
+			mu.Unlock()
+
+			// Execute tool.
+			result, err := next(ctx, args)
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if err != nil {
+				failures++
+				lastFailure = time.Now()
+
+				if state == CircuitHalfOpen {
+					// Failure in half-open returns to open.
+					state = CircuitOpen
+				} else if failures >= config.FailureThreshold {
+					// Too many failures, open circuit.
+					state = CircuitOpen
+				}
+
+				return nil, err
+			}
+
+			// Success.
+			if state == CircuitHalfOpen {
+				successes++
+				if successes >= config.SuccessThreshold {
+					// Enough successes, close circuit.
+					state = CircuitClosed
+					failures = 0
+				}
+			} else {
+				// Reset failure count on success in closed state.
+				failures = 0
+			}
+
+			return result, nil
+		}
+	}
+}

--- a/tools/middleware_conditional.go
+++ b/tools/middleware_conditional.go
@@ -1,0 +1,42 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// ForTools applies middleware only to tools with the specified names.
+func ForTools(toolNames []string, middleware Middleware) Middleware {
+	nameSet := make(map[string]bool)
+	for _, name := range toolNames {
+		nameSet[name] = true
+	}
+
+	return func(next ToolCallFunc) ToolCallFunc {
+		return func(ctx context.Context, args json.RawMessage) (any, error) {
+			tc := ToolContextFromContext(ctx)
+			if tc != nil && nameSet[tc.ToolName] {
+				return middleware(next)(ctx, args)
+			}
+			return next(ctx, args)
+		}
+	}
+}
+
+// ExceptTools applies middleware to all tools except those with the specified names.
+func ExceptTools(toolNames []string, middleware Middleware) Middleware {
+	nameSet := make(map[string]bool)
+	for _, name := range toolNames {
+		nameSet[name] = true
+	}
+
+	return func(next ToolCallFunc) ToolCallFunc {
+		return func(ctx context.Context, args json.RawMessage) (any, error) {
+			tc := ToolContextFromContext(ctx)
+			if tc == nil || !nameSet[tc.ToolName] {
+				return middleware(next)(ctx, args)
+			}
+			return next(ctx, args)
+		}
+	}
+}

--- a/tools/middleware_logging.go
+++ b/tools/middleware_logging.go
@@ -1,0 +1,68 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Logger is the interface for logging middleware.
+type Logger interface {
+	Printf(format string, v ...any)
+}
+
+// WithLogging creates middleware that logs tool calls.
+func WithLogging(logger Logger) Middleware {
+	return func(next ToolCallFunc) ToolCallFunc {
+		return func(ctx context.Context, args json.RawMessage) (any, error) {
+			tc := ToolContextFromContext(ctx)
+			toolName := "unknown"
+			if tc != nil {
+				toolName = tc.ToolName
+			}
+
+			logger.Printf("tool call start: %s", toolName)
+			start := time.Now()
+
+			result, err := next(ctx, args)
+
+			duration := time.Since(start)
+			if err != nil {
+				logger.Printf("tool call error: %s, duration=%v, error=%v", toolName, duration, err)
+			} else {
+				logger.Printf("tool call success: %s, duration=%v", toolName, duration)
+			}
+
+			return result, err
+		}
+	}
+}
+
+// WithDetailedLogging creates middleware that logs tool calls with arguments.
+// WARNING: May log sensitive data. Use only in development.
+func WithDetailedLogging(logger Logger) Middleware {
+	return func(next ToolCallFunc) ToolCallFunc {
+		return func(ctx context.Context, args json.RawMessage) (any, error) {
+			tc := ToolContextFromContext(ctx)
+			toolName := "unknown"
+			if tc != nil {
+				toolName = tc.ToolName
+			}
+
+			logger.Printf("tool call: %s, args=%s", toolName, string(args))
+			start := time.Now()
+
+			result, err := next(ctx, args)
+
+			duration := time.Since(start)
+			if err != nil {
+				logger.Printf("tool error: %s, duration=%v, error=%v", toolName, duration, err)
+			} else {
+				resultJSON, _ := json.Marshal(result)
+				logger.Printf("tool result: %s, duration=%v, result=%s", toolName, duration, string(resultJSON))
+			}
+
+			return result, err
+		}
+	}
+}

--- a/tools/middleware_metrics.go
+++ b/tools/middleware_metrics.go
@@ -1,0 +1,33 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// MetricsCollector receives tool execution metrics.
+type MetricsCollector interface {
+	// RecordCall records a tool call with its outcome.
+	RecordCall(toolName string, duration time.Duration, err error)
+}
+
+// WithMetrics creates middleware that records tool execution metrics.
+func WithMetrics(collector MetricsCollector) Middleware {
+	return func(next ToolCallFunc) ToolCallFunc {
+		return func(ctx context.Context, args json.RawMessage) (any, error) {
+			tc := ToolContextFromContext(ctx)
+			toolName := "unknown"
+			if tc != nil {
+				toolName = tc.ToolName
+			}
+
+			start := time.Now()
+			result, err := next(ctx, args)
+			duration := time.Since(start)
+
+			collector.RecordCall(toolName, duration, err)
+			return result, err
+		}
+	}
+}

--- a/tools/middleware_rate_limit.go
+++ b/tools/middleware_rate_limit.go
@@ -1,0 +1,86 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// RateLimiter is the interface for rate limiting.
+type RateLimiter interface {
+	// Allow returns true if the request should proceed.
+	Allow() bool
+	// Wait blocks until the request can proceed or context is canceled.
+	Wait(ctx context.Context) error
+}
+
+// WithRateLimit creates middleware that rate limits tool calls.
+// Uses a token bucket algorithm with the specified rate (calls per second).
+func WithRateLimit(ratePerSecond float64) Middleware {
+	limiter := newTokenBucket(ratePerSecond)
+	return WithRateLimiter(limiter)
+}
+
+// WithRateLimiter creates middleware using a custom rate limiter.
+func WithRateLimiter(limiter RateLimiter) Middleware {
+	return func(next ToolCallFunc) ToolCallFunc {
+		return func(ctx context.Context, args json.RawMessage) (any, error) {
+			if err := limiter.Wait(ctx); err != nil {
+				return nil, fmt.Errorf("rate limit exceeded: %w", err)
+			}
+			return next(ctx, args)
+		}
+	}
+}
+
+// tokenBucket implements a simple token bucket rate limiter.
+type tokenBucket struct {
+	mu         sync.Mutex
+	tokens     float64
+	maxTokens  float64
+	refillRate float64
+	lastRefill time.Time
+}
+
+func newTokenBucket(ratePerSecond float64) *tokenBucket {
+	return &tokenBucket{
+		tokens:     ratePerSecond,
+		maxTokens:  ratePerSecond * 2, // Allow burst of 2x rate.
+		refillRate: ratePerSecond,
+		lastRefill: time.Now(),
+	}
+}
+
+func (tb *tokenBucket) Allow() bool {
+	tb.mu.Lock()
+	defer tb.mu.Unlock()
+	tb.refill()
+	if tb.tokens >= 1 {
+		tb.tokens--
+		return true
+	}
+	return false
+}
+
+func (tb *tokenBucket) Wait(ctx context.Context) error {
+	for {
+		if tb.Allow() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+			// Retry.
+		}
+	}
+}
+
+func (tb *tokenBucket) refill() {
+	now := time.Now()
+	elapsed := now.Sub(tb.lastRefill).Seconds()
+	tb.tokens = min(tb.maxTokens, tb.tokens+elapsed*tb.refillRate)
+	tb.lastRefill = now
+}

--- a/tools/middleware_retry.go
+++ b/tools/middleware_retry.go
@@ -1,0 +1,78 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// RetryConfig configures retry behavior.
+type RetryConfig struct {
+	MaxAttempts int
+	InitialWait time.Duration
+	MaxWait     time.Duration
+	Multiplier  float64
+	Retryable   func(error) bool // Returns true if error is retryable.
+}
+
+// DefaultRetryConfig returns sensible retry defaults.
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxAttempts: 3,
+		InitialWait: 100 * time.Millisecond,
+		MaxWait:     5 * time.Second,
+		Multiplier:  2.0,
+		Retryable: func(err error) bool {
+			// Retry on common transient errors.
+			return errors.Is(err, context.DeadlineExceeded) ||
+				strings.Contains(err.Error(), "temporary") ||
+				strings.Contains(err.Error(), "timeout")
+		},
+	}
+}
+
+// WithRetry creates middleware that retries failed tool calls.
+func WithRetry(config RetryConfig) Middleware {
+	return func(next ToolCallFunc) ToolCallFunc {
+		return func(ctx context.Context, args json.RawMessage) (any, error) {
+			var lastErr error
+			wait := config.InitialWait
+
+			for attempt := 1; attempt <= config.MaxAttempts; attempt++ {
+				result, err := next(ctx, args)
+				if err == nil {
+					return result, nil
+				}
+
+				lastErr = err
+
+				// Check if error is retryable.
+				if config.Retryable != nil && !config.Retryable(err) {
+					return nil, err
+				}
+
+				// Don't wait after last attempt.
+				if attempt == config.MaxAttempts {
+					break
+				}
+
+				// Wait with exponential backoff.
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(wait):
+				}
+
+				wait = time.Duration(float64(wait) * config.Multiplier)
+				if wait > config.MaxWait {
+					wait = config.MaxWait
+				}
+			}
+
+			return nil, fmt.Errorf("tool call failed after %d attempts: %w", config.MaxAttempts, lastErr)
+		}
+	}
+}

--- a/tools/middleware_timeout.go
+++ b/tools/middleware_timeout.go
@@ -1,0 +1,37 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// WithTimeout creates middleware that enforces a timeout on tool execution.
+func WithTimeout(d time.Duration) Middleware {
+	return func(next ToolCallFunc) ToolCallFunc {
+		return func(ctx context.Context, args json.RawMessage) (any, error) {
+			ctx, cancel := context.WithTimeout(ctx, d)
+			defer cancel()
+
+			// Execute in goroutine to respect timeout.
+			type result struct {
+				value any
+				err   error
+			}
+			ch := make(chan result, 1)
+
+			go func() {
+				v, err := next(ctx, args)
+				ch <- result{v, err}
+			}()
+
+			select {
+			case r := <-ch:
+				return r.value, r.err
+			case <-ctx.Done():
+				return nil, fmt.Errorf("tool execution timeout after %v", d)
+			}
+		}
+	}
+}

--- a/tools/middleware_validation.go
+++ b/tools/middleware_validation.go
@@ -1,0 +1,43 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// SchemaValidator validates arguments against a JSON schema.
+type SchemaValidator interface {
+	Validate(schema json.RawMessage, data json.RawMessage) error
+}
+
+// WithValidation creates middleware that validates arguments against the tool's schema.
+func WithValidation(validator SchemaValidator) Middleware {
+	return func(next ToolCallFunc) ToolCallFunc {
+		return func(ctx context.Context, args json.RawMessage) (any, error) {
+			schema, ok := ToolSchemaFromContext(ctx)
+			if !ok {
+				return next(ctx, args)
+			}
+
+			if err := validator.Validate(schema, args); err != nil {
+				return nil, fmt.Errorf("argument validation failed: %w", err)
+			}
+
+			return next(ctx, args)
+		}
+	}
+}
+
+// WithBasicValidation creates middleware that performs basic JSON validation.
+func WithBasicValidation() Middleware {
+	return func(next ToolCallFunc) ToolCallFunc {
+		return func(ctx context.Context, args json.RawMessage) (any, error) {
+			if !json.Valid(args) {
+				return nil, errors.New("invalid JSON arguments")
+			}
+			return next(ctx, args)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
This PR completes the current P2 foundation refactor track by reducing repeated provider/tooling infrastructure and integration-test duplication.

The user-visible effect is lower maintenance overhead and safer future provider changes: streaming tool-call assembly logic is now centralized, tool middleware behavior is decomposed and schema-aware, and repeated provider chat integration suites now run through a single conformance harness with explicit provider policies.

## Problem
Several high-effort hotspots were identified in the P2 audit:
- Streaming tool-call assembly behavior was duplicated across providers.
- `tools/middleware.go` had grown into a large monolith with weakly formalized schema propagation to validation middleware.
- Integration test suites for chat providers repeated the same scenario logic with provider-specific copy/paste.

This made behavior drift more likely, increased review burden, and made future provider onboarding/refactors slower.

## Root Cause
Common cross-provider concerns were implemented independently in each provider and test file instead of through shared internal utilities and harnesses. Middleware schema access also depended on ad-hoc context metadata rather than a formal contract.

## Fix
### 1) Shared tool-call assembly
Introduced `providers/internal/toolcalls` with a reusable assembler and tests, then migrated compatible streaming code paths:
- OpenAI (including Responses streaming)
- Anthropic
- Perplexity
- HuggingFace
- xAI
- Z.ai

Provider-specific invalid-JSON errors are preserved by mapping shared assembler errors back to provider-level sentinel errors.

### 2) Middleware split + schema propagation formalization
Split `tools/middleware.go` into focused files by concern:
- logging
- timeout
- rate limiting
- cache
- validation
- metrics
- retry
- circuit breaker
- conditional application

Formalized schema propagation by adding `ToolContext.Schema`, `ToolContextSchemaMetadataKey`, and `ToolSchemaFromContext(...)`, and wiring schema injection in middleware-wrapped tool calls. Validation middleware now uses the stable context accessor rather than only ad-hoc metadata lookups.

### 3) Provider integration conformance harness
Added `tests/integration/chat_conformance_test.go` and migrated duplicated chat conformance scenarios for:
- OpenAI
- Anthropic
- Gemini
- Perplexity
- xAI
- Z.ai

The harness supports explicit per-provider configuration for model selection, timeout behavior, response-ID/usage strictness, max-token strictness, and setup/cleanup hooks (used for Z.ai sequential/rate-limit protection).

Provider-specific non-conformance tests (special models, image tests, provider policies) remain in their provider files.

## Validation
- `go test ./...`
- `go test -tags=integration ./tests/integration -run '^$'`

Both passed locally for this branch.
