### PR TITLE
[codex] Wire CI coverage upload to Codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -31,12 +33,21 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
 
-      - name: Upload coverage to Codecov
+      - name: Upload coverage artifact
         if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage.out
+          path: coverage.out
+          if-no-files-found: error
+
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest' && env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ env.CODECOV_TOKEN }}
           files: ./coverage.out
-          fail_ci_if_error: false
+          fail_ci_if_error: true
           verbose: true
 
       - name: Vet


### PR DESCRIPTION
## Summary
This PR updates CI coverage publishing so Go coverage generated in GitHub Actions is uploaded to Codecov using the existing `CODECOV_TOKEN` secret.

## Problem
Coverage generation already existed in CI, but Codecov uploads were not explicitly wired to the token secret. In token-required configurations this can cause uploads to be skipped or fail silently.

## Root Cause
The workflow used `codecov/codecov-action` without passing `CODECOV_TOKEN` from GitHub Secrets, and upload failures were not configured to fail the job.

## Changes
- In `.github/workflows/ci.yml`:
  - Added job env wiring: `CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}`.
  - Added artifact upload step for `coverage.out` on Ubuntu (`actions/upload-artifact@v4`).
  - Updated Codecov upload step to:
    - run only when token is present,
    - pass `token: ${{ env.CODECOV_TOKEN }}`,
    - set `fail_ci_if_error: true`.

## Validation
- Workflow file changes validated locally by review and commit.
- No Go source behavior changed.
