### PR TITLE
fix(integration): add pre-request delay to Z.ai tests to avoid rate limiting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/petal-labs/iris
 go 1.24.0
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/spf13/cobra v1.8.0
 	golang.org/x/crypto v0.47.0
 	golang.org/x/term v0.39.0
@@ -10,7 +11,6 @@ require (
 )
 
 require (
-	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.40.0 // indirect

--- a/tests/integration/zai_test.go
+++ b/tests/integration/zai_test.go
@@ -18,11 +18,14 @@ var zaiTestMutex sync.Mutex
 
 // zaiTestSetup acquires the mutex and returns cleanup function.
 // This prevents concurrent Z.ai API calls which cause rate limiting.
+// Z.ai has a concurrency limit of 3, so we serialize all tests.
 func zaiTestSetup(t *testing.T) func() {
 	t.Helper()
 	zaiTestMutex.Lock()
+	// Delay before starting the test to ensure spacing between API calls.
+	time.Sleep(2 * time.Second)
 	return func() {
-		// Small delay between tests to avoid rate limiting.
+		// Additional delay after test completes.
 		time.Sleep(500 * time.Millisecond)
 		zaiTestMutex.Unlock()
 	}


### PR DESCRIPTION
## Summary
- Added 2-second pre-request delay to Z.ai integration tests after acquiring the mutex
- Z.ai API has a concurrency limit of 3; the previous post-request-only delay was insufficient
- All 9 Z.ai integration tests now pass consistently

## Test plan
- [x] Ran `go test -tags=integration -run "TestZai" ./tests/integration/...` - all tests pass
- [x] Verified no rate limiting errors (status 429) occur

🤖 Generated with [Claude Code](https://claude.ai/code)