### PR TITLE
feat(providers): add Azure AI Foundry provider

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,7 +43,6 @@ linters:
         - G304  # File path from variable (necessary for config loading)
         - G101  # False positive: env var names, not credentials
         - G404  # Retry jitter doesn't need cryptographic randomness
-        - G704  # SDK intentionally makes HTTP requests to user-specified endpoints
 
   exclusions:
     rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,7 @@ linters:
         - G304  # File path from variable (necessary for config loading)
         - G101  # False positive: env var names, not credentials
         - G404  # Retry jitter doesn't need cryptographic randomness
+        - G704  # SDK intentionally makes HTTP requests to user-specified endpoints
 
   exclusions:
     rules:

--- a/providers/azurefoundry/client_chat.go
+++ b/providers/azurefoundry/client_chat.go
@@ -224,7 +224,13 @@ func retryableStatus(status int) bool {
 
 // calculateBackoff returns the backoff duration for a given attempt.
 func calculateBackoff(attempt int, baseDelay time.Duration) time.Duration {
-	delay := baseDelay * time.Duration(1<<uint(attempt))
+	if attempt < 0 {
+		attempt = 0
+	}
+	if attempt > 10 {
+		attempt = 10 // Cap to prevent overflow
+	}
+	delay := baseDelay * time.Duration(1<<attempt)
 	if delay > 30*time.Second {
 		delay = 30 * time.Second
 	}

--- a/providers/azurefoundry/client_chat.go
+++ b/providers/azurefoundry/client_chat.go
@@ -1,0 +1,232 @@
+package azurefoundry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+)
+
+// doChat performs a non-streaming chat completion request.
+func (p *AzureFoundry) doChat(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	// Apply timeout if configured
+	if p.config.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, p.config.Timeout)
+		defer cancel()
+	}
+
+	// Build Azure request
+	azReq := buildRequest(req, false)
+
+	// Marshal request body
+	body, err := json.Marshal(azReq)
+	if err != nil {
+		return nil, newDecodeError(err)
+	}
+
+	// Build URL
+	url, err := p.buildChatURL(req.Model)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create HTTP request
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+
+	// Set headers (may require context for token refresh)
+	headers, err := p.buildHeaders(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for key, values := range headers {
+		for _, v := range values {
+			httpReq.Header.Add(key, v)
+		}
+	}
+
+	// Execute request
+	resp, err := p.config.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+
+	// Extract request ID from response headers
+	requestID := extractRequestID(resp.Header)
+
+	// Check for error status
+	if resp.StatusCode >= 400 {
+		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+	}
+
+	// Parse response
+	var azResp azureResponse
+	if err := json.Unmarshal(respBody, &azResp); err != nil {
+		return nil, newDecodeError(err)
+	}
+
+	// Check for content filtering in response
+	if len(azResp.Choices) > 0 {
+		choice := azResp.Choices[0]
+		if choice.ContentFilterResults != nil && choice.ContentFilterResults.IsFiltered() {
+			return nil, newContentFilterError(choice.ContentFilterResults)
+		}
+	}
+
+	// Map to Iris response
+	return mapChatResponse(&azResp)
+}
+
+// doStreamChat performs a streaming chat completion request.
+func (p *AzureFoundry) doStreamChat(ctx context.Context, req *core.ChatRequest) (*core.ChatStream, error) {
+	// Apply timeout if configured
+	if p.config.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, p.config.Timeout)
+		defer cancel()
+	}
+
+	// Build Azure request with streaming enabled
+	azReq := buildRequest(req, true)
+
+	// Marshal request body
+	body, err := json.Marshal(azReq)
+	if err != nil {
+		return nil, newDecodeError(err)
+	}
+
+	// Build URL
+	url, err := p.buildChatURL(req.Model)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create HTTP request
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+
+	// Set headers
+	headers, err := p.buildHeaders(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for key, values := range headers {
+		for _, v := range values {
+			httpReq.Header.Add(key, v)
+		}
+	}
+
+	// Execute request
+	resp, err := p.config.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+
+	// Extract request ID
+	requestID := extractRequestID(resp.Header)
+
+	// Check for error status before streaming
+	if resp.StatusCode >= 400 {
+		defer resp.Body.Close()
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, newNetworkError(err)
+		}
+		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+	}
+
+	// Process SSE stream
+	return p.processSSEStream(ctx, resp, req.Model)
+}
+
+// mapChatResponse converts an Azure response to an Iris ChatResponse.
+func mapChatResponse(resp *azureResponse) (*core.ChatResponse, error) {
+	result := &core.ChatResponse{
+		ID:    resp.ID,
+		Model: core.ModelID(resp.Model),
+		Usage: mapUsage(resp.Usage),
+	}
+
+	// Extract content from first choice
+	if len(resp.Choices) > 0 {
+		choice := resp.Choices[0]
+		if choice.Message != nil {
+			result.Output = choice.Message.Content
+
+			// Map tool calls if present
+			if len(choice.Message.ToolCalls) > 0 {
+				toolCalls, err := mapToolCallsWithValidation(choice.Message.ToolCalls)
+				if err != nil {
+					return nil, err
+				}
+				result.ToolCalls = toolCalls
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// mapToolCallsWithValidation converts Azure tool calls to Iris ToolCalls with JSON validation.
+func mapToolCallsWithValidation(calls []azureToolCall) ([]core.ToolCall, error) {
+	result := make([]core.ToolCall, len(calls))
+
+	for i, call := range calls {
+		// Validate that arguments is valid JSON
+		if !json.Valid([]byte(call.Function.Arguments)) {
+			return nil, ErrToolArgsInvalidJSON
+		}
+
+		result[i] = core.ToolCall{
+			ID:        call.ID,
+			Name:      call.Function.Name,
+			Arguments: json.RawMessage(call.Function.Arguments),
+		}
+	}
+
+	return result, nil
+}
+
+// extractRequestID extracts the request ID from Azure response headers.
+// Azure uses different header names depending on the endpoint.
+func extractRequestID(h http.Header) string {
+	// Try Azure-specific headers first
+	if id := h.Get("x-ms-request-id"); id != "" {
+		return id
+	}
+	if id := h.Get("apim-request-id"); id != "" {
+		return id
+	}
+	// Fall back to OpenAI-style header
+	return h.Get("x-request-id")
+}
+
+// retryableStatus returns true if the HTTP status code indicates a retryable error.
+func retryableStatus(status int) bool {
+	return status == http.StatusTooManyRequests || status >= 500
+}
+
+// calculateBackoff returns the backoff duration for a given attempt.
+func calculateBackoff(attempt int, baseDelay time.Duration) time.Duration {
+	delay := baseDelay * time.Duration(1<<uint(attempt))
+	if delay > 30*time.Second {
+		delay = 30 * time.Second
+	}
+	return delay
+}

--- a/providers/azurefoundry/doc.go
+++ b/providers/azurefoundry/doc.go
@@ -1,0 +1,94 @@
+// Package azurefoundry provides an Iris provider implementation for Azure AI Foundry.
+//
+// Azure AI Foundry is Microsoft's unified AI platform providing access to multiple
+// model families (OpenAI, Meta Llama, Mistral, Cohere, and more) through a
+// standardized inference API.
+//
+// # Authentication
+//
+// The provider supports two authentication methods:
+//
+// API Key Authentication:
+//
+//	provider := azurefoundry.New(
+//	    "https://my-resource.services.ai.azure.com",
+//	    "my-api-key",
+//	)
+//
+// Microsoft Entra ID (Azure AD) Authentication:
+//
+//	cred, _ := azidentity.NewDefaultAzureCredential(nil)
+//	provider := azurefoundry.NewWithCredential(
+//	    "https://my-resource.services.ai.azure.com",
+//	    cred,
+//	)
+//
+// Environment Variables:
+//
+//	provider, err := azurefoundry.NewFromEnv()
+//	// Uses AZURE_AI_ENDPOINT and AZURE_AI_API_KEY
+//
+// # Endpoint Formats
+//
+// Azure AI Foundry supports two endpoint formats:
+//
+// Model Inference API (default):
+//
+//	POST https://{resource}.services.ai.azure.com/models/chat/completions
+//
+// Azure OpenAI Service:
+//
+//	POST https://{resource}.openai.azure.com/openai/deployments/{deployment}/chat/completions
+//
+// Use WithOpenAIEndpoint() to switch to the Azure OpenAI format:
+//
+//	provider := azurefoundry.New(endpoint, apiKey,
+//	    azurefoundry.WithOpenAIEndpoint(),
+//	    azurefoundry.WithDeploymentID("gpt-4o"),
+//	)
+//
+// # Basic Usage
+//
+//	provider := azurefoundry.New(
+//	    "https://my-resource.services.ai.azure.com",
+//	    "my-api-key",
+//	)
+//
+//	client := core.NewClient(provider)
+//
+//	resp, err := client.Chat().
+//	    Model("gpt-4o").
+//	    System("You are a helpful assistant.").
+//	    User("Hello!").
+//	    GetResponse(context.Background())
+//
+// # Streaming
+//
+//	stream, err := client.Chat().
+//	    Model("gpt-4o").
+//	    User("Write a poem.").
+//	    Stream(context.Background())
+//
+//	for chunk := range stream.Ch {
+//	    fmt.Print(chunk.Delta)
+//	}
+//
+// # Supported Features
+//
+//   - Chat completions
+//   - Streaming responses
+//   - Tool calling (function calling)
+//   - Structured output (JSON mode, JSON Schema)
+//   - Embeddings
+//
+// # Models
+//
+// Azure AI Foundry provides access to various models depending on your deployment:
+//   - OpenAI: GPT-4o, GPT-4 Turbo, GPT-3.5 Turbo
+//   - Meta: Llama 3.1 (8B, 70B, 405B)
+//   - Mistral: Mistral Large, Mistral Small
+//   - Cohere: Command R, Command R+
+//   - And more via the Model Inference API
+//
+// Use the model deployment name from your Azure configuration as the model ID.
+package azurefoundry

--- a/providers/azurefoundry/embeddings.go
+++ b/providers/azurefoundry/embeddings.go
@@ -26,10 +26,10 @@ type azureEmbeddingRequest struct {
 
 // azureEmbeddingResponse is the response from embeddings endpoint.
 type azureEmbeddingResponse struct {
-	Object string                `json:"object"`
-	Data   []azureEmbeddingData  `json:"data"`
-	Model  string                `json:"model"`
-	Usage  azureEmbeddingUsage   `json:"usage"`
+	Object string               `json:"object"`
+	Data   []azureEmbeddingData `json:"data"`
+	Model  string               `json:"model"`
+	Usage  azureEmbeddingUsage  `json:"usage"`
 }
 
 // azureEmbeddingData represents a single embedding in the response.

--- a/providers/azurefoundry/embeddings.go
+++ b/providers/azurefoundry/embeddings.go
@@ -1,0 +1,212 @@
+package azurefoundry
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/petal-labs/iris/core"
+)
+
+// ----------------------------------------------------------------------------
+// Embeddings Request/Response Types
+// ----------------------------------------------------------------------------
+
+// azureEmbeddingRequest is the request body for embeddings.
+type azureEmbeddingRequest struct {
+	Model          string   `json:"model,omitempty"`
+	Input          []string `json:"input"`
+	EncodingFormat string   `json:"encoding_format,omitempty"`
+	Dimensions     *int     `json:"dimensions,omitempty"`
+	User           string   `json:"user,omitempty"`
+	InputType      string   `json:"input_type,omitempty"` // Azure/Cohere: "query" or "document"
+}
+
+// azureEmbeddingResponse is the response from embeddings endpoint.
+type azureEmbeddingResponse struct {
+	Object string                `json:"object"`
+	Data   []azureEmbeddingData  `json:"data"`
+	Model  string                `json:"model"`
+	Usage  azureEmbeddingUsage   `json:"usage"`
+}
+
+// azureEmbeddingData represents a single embedding in the response.
+type azureEmbeddingData struct {
+	Object    string `json:"object"`
+	Index     int    `json:"index"`
+	Embedding any    `json:"embedding"` // []float64 or base64 string
+}
+
+// azureEmbeddingUsage contains token usage for the embedding request.
+type azureEmbeddingUsage struct {
+	PromptTokens int `json:"prompt_tokens"`
+	TotalTokens  int `json:"total_tokens"`
+}
+
+// ----------------------------------------------------------------------------
+// EmbeddingProvider Implementation
+// ----------------------------------------------------------------------------
+
+// CreateEmbeddings generates embeddings for the given input texts.
+// Implements core.EmbeddingProvider.
+func (p *AzureFoundry) CreateEmbeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	// Apply timeout if configured
+	if p.config.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, p.config.Timeout)
+		defer cancel()
+	}
+
+	// Build Azure request
+	azReq := buildEmbeddingRequest(req)
+
+	// Marshal request body
+	body, err := json.Marshal(azReq)
+	if err != nil {
+		return nil, newDecodeError(err)
+	}
+
+	// Build URL
+	url, err := p.buildEmbeddingsURL(req.Model)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create HTTP request
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+
+	// Set headers
+	headers, err := p.buildHeaders(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for key, values := range headers {
+		for _, v := range values {
+			httpReq.Header.Add(key, v)
+		}
+	}
+
+	// Execute request
+	resp, err := p.config.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+
+	// Extract request ID
+	requestID := extractRequestID(resp.Header)
+
+	// Check for error status
+	if resp.StatusCode >= 400 {
+		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+	}
+
+	// Parse response
+	var azResp azureEmbeddingResponse
+	if err := json.Unmarshal(respBody, &azResp); err != nil {
+		return nil, newDecodeError(err)
+	}
+
+	// Map to Iris response
+	return mapEmbeddingResponse(&azResp, req), nil
+}
+
+// buildEmbeddingsURL constructs the URL for embeddings.
+func (p *AzureFoundry) buildEmbeddingsURL(model core.ModelID) (string, error) {
+	if p.config.UseOpenAIEndpoint {
+		// Azure OpenAI format: /openai/deployments/{deployment-id}/embeddings
+		deploymentID := p.config.DeploymentID
+		if deploymentID == "" {
+			deploymentID = string(model)
+		}
+		if deploymentID == "" {
+			return "", ErrDeploymentRequired
+		}
+		return p.config.Endpoint + "/openai/deployments/" + deploymentID +
+			"/embeddings?api-version=" + p.config.APIVersion, nil
+	}
+
+	// Model Inference API format: /models/embeddings
+	return p.config.Endpoint + "/models/embeddings?api-version=" + p.config.APIVersion, nil
+}
+
+// buildEmbeddingRequest converts core request to Azure format.
+func buildEmbeddingRequest(req *core.EmbeddingRequest) *azureEmbeddingRequest {
+	inputs := make([]string, len(req.Input))
+	for i, input := range req.Input {
+		inputs[i] = input.Text
+	}
+
+	azReq := &azureEmbeddingRequest{
+		Model: string(req.Model),
+		Input: inputs,
+		User:  req.User,
+	}
+
+	if req.EncodingFormat != "" {
+		azReq.EncodingFormat = string(req.EncodingFormat)
+	}
+	if req.Dimensions != nil {
+		azReq.Dimensions = req.Dimensions
+	}
+	if req.InputType != "" {
+		azReq.InputType = string(req.InputType)
+	}
+
+	return azReq
+}
+
+// mapEmbeddingResponse converts Azure response to core format.
+func mapEmbeddingResponse(resp *azureEmbeddingResponse, req *core.EmbeddingRequest) *core.EmbeddingResponse {
+	vectors := make([]core.EmbeddingVector, len(resp.Data))
+
+	for i, data := range resp.Data {
+		vec := core.EmbeddingVector{
+			Index: data.Index,
+		}
+
+		// Copy ID and Metadata from input if index is valid
+		if data.Index >= 0 && data.Index < len(req.Input) {
+			vec.ID = req.Input[data.Index].ID
+			vec.Metadata = req.Input[data.Index].Metadata
+		}
+
+		// Handle embedding based on type (float array or base64 string)
+		switch emb := data.Embedding.(type) {
+		case []interface{}:
+			vec.Vector = make([]float32, len(emb))
+			for j, v := range emb {
+				if f, ok := v.(float64); ok {
+					vec.Vector[j] = float32(f)
+				}
+			}
+		case string:
+			vec.VectorB64 = emb
+		}
+
+		vectors[i] = vec
+	}
+
+	return &core.EmbeddingResponse{
+		Vectors: vectors,
+		Model:   core.ModelID(resp.Model),
+		Usage: core.EmbeddingUsage{
+			PromptTokens: resp.Usage.PromptTokens,
+			TotalTokens:  resp.Usage.TotalTokens,
+		},
+	}
+}
+
+// Compile-time check that AzureFoundry implements EmbeddingProvider.
+var _ core.EmbeddingProvider = (*AzureFoundry)(nil)

--- a/providers/azurefoundry/embeddings_test.go
+++ b/providers/azurefoundry/embeddings_test.go
@@ -1,0 +1,473 @@
+package azurefoundry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestCreateEmbeddingsSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request
+		if r.Method != http.MethodPost {
+			t.Errorf("Method = %q, want POST", r.Method)
+		}
+
+		// Verify API key header
+		if r.Header.Get("api-key") != "test-key" {
+			t.Errorf("api-key = %q, want test-key", r.Header.Get("api-key"))
+		}
+
+		// Parse request body
+		var req azureEmbeddingRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Failed to decode request: %v", err)
+		}
+
+		if len(req.Input) != 2 {
+			t.Errorf("len(Input) = %d, want 2", len(req.Input))
+		}
+
+		// Send response
+		resp := azureEmbeddingResponse{
+			Object: "list",
+			Model:  "text-embedding-3-large",
+			Data: []azureEmbeddingData{
+				{
+					Object:    "embedding",
+					Index:     0,
+					Embedding: []interface{}{0.1, 0.2, 0.3},
+				},
+				{
+					Object:    "embedding",
+					Index:     1,
+					Embedding: []interface{}{0.4, 0.5, 0.6},
+				},
+			},
+			Usage: azureEmbeddingUsage{
+				PromptTokens: 10,
+				TotalTokens:  10,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	resp, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "text-embedding-3-large",
+		Input: []core.EmbeddingInput{
+			{Text: "Hello world"},
+			{Text: "Goodbye world"},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("CreateEmbeddings() error = %v", err)
+	}
+
+	if len(resp.Vectors) != 2 {
+		t.Fatalf("len(Vectors) = %d, want 2", len(resp.Vectors))
+	}
+
+	if resp.Vectors[0].Index != 0 {
+		t.Errorf("Vectors[0].Index = %d, want 0", resp.Vectors[0].Index)
+	}
+
+	if len(resp.Vectors[0].Vector) != 3 {
+		t.Errorf("len(Vectors[0].Vector) = %d, want 3", len(resp.Vectors[0].Vector))
+	}
+
+	if resp.Model != "text-embedding-3-large" {
+		t.Errorf("Model = %q, want text-embedding-3-large", resp.Model)
+	}
+
+	if resp.Usage.TotalTokens != 10 {
+		t.Errorf("Usage.TotalTokens = %d, want 10", resp.Usage.TotalTokens)
+	}
+}
+
+func TestCreateEmbeddingsWithMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := azureEmbeddingResponse{
+			Object: "list",
+			Model:  "text-embedding-3-large",
+			Data: []azureEmbeddingData{
+				{
+					Object:    "embedding",
+					Index:     0,
+					Embedding: []interface{}{0.1, 0.2, 0.3},
+				},
+			},
+			Usage: azureEmbeddingUsage{
+				PromptTokens: 5,
+				TotalTokens:  5,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	resp, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "text-embedding-3-large",
+		Input: []core.EmbeddingInput{
+			{
+				ID:       "doc-1",
+				Text:     "Hello world",
+				Metadata: map[string]string{"source": "test"},
+			},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("CreateEmbeddings() error = %v", err)
+	}
+
+	if resp.Vectors[0].ID != "doc-1" {
+		t.Errorf("Vectors[0].ID = %q, want doc-1", resp.Vectors[0].ID)
+	}
+
+	if resp.Vectors[0].Metadata["source"] != "test" {
+		t.Errorf("Vectors[0].Metadata[source] = %v, want test", resp.Vectors[0].Metadata["source"])
+	}
+}
+
+func TestCreateEmbeddingsWithDimensions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req azureEmbeddingRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Failed to decode request: %v", err)
+		}
+
+		if req.Dimensions == nil || *req.Dimensions != 256 {
+			t.Errorf("Dimensions = %v, want 256", req.Dimensions)
+		}
+
+		resp := azureEmbeddingResponse{
+			Object: "list",
+			Model:  "text-embedding-3-large",
+			Data: []azureEmbeddingData{
+				{
+					Object:    "embedding",
+					Index:     0,
+					Embedding: make([]interface{}, 256), // 256-dim embedding
+				},
+			},
+			Usage: azureEmbeddingUsage{
+				PromptTokens: 5,
+				TotalTokens:  5,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	dims := 256
+	resp, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "text-embedding-3-large",
+		Input: []core.EmbeddingInput{
+			{Text: "Hello world"},
+		},
+		Dimensions: &dims,
+	})
+
+	if err != nil {
+		t.Fatalf("CreateEmbeddings() error = %v", err)
+	}
+
+	if len(resp.Vectors[0].Vector) != 256 {
+		t.Errorf("len(Vector) = %d, want 256", len(resp.Vectors[0].Vector))
+	}
+}
+
+func TestCreateEmbeddingsWithInputType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req azureEmbeddingRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Failed to decode request: %v", err)
+		}
+
+		if req.InputType != "query" {
+			t.Errorf("InputType = %q, want query", req.InputType)
+		}
+
+		resp := azureEmbeddingResponse{
+			Object: "list",
+			Model:  "text-embedding-3-large",
+			Data: []azureEmbeddingData{
+				{
+					Object:    "embedding",
+					Index:     0,
+					Embedding: []interface{}{0.1, 0.2, 0.3},
+				},
+			},
+			Usage: azureEmbeddingUsage{
+				PromptTokens: 5,
+				TotalTokens:  5,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	_, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "text-embedding-3-large",
+		Input: []core.EmbeddingInput{
+			{Text: "Hello world"},
+		},
+		InputType: core.InputTypeQuery,
+	})
+
+	if err != nil {
+		t.Fatalf("CreateEmbeddings() error = %v", err)
+	}
+}
+
+func TestCreateEmbeddingsBase64Response(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := azureEmbeddingResponse{
+			Object: "list",
+			Model:  "text-embedding-3-large",
+			Data: []azureEmbeddingData{
+				{
+					Object:    "embedding",
+					Index:     0,
+					Embedding: "AAAA/wAAgD8AAAA/", // base64 encoded
+				},
+			},
+			Usage: azureEmbeddingUsage{
+				PromptTokens: 5,
+				TotalTokens:  5,
+			},
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	resp, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model:          "text-embedding-3-large",
+		EncodingFormat: core.EncodingFormatBase64,
+		Input: []core.EmbeddingInput{
+			{Text: "Hello world"},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("CreateEmbeddings() error = %v", err)
+	}
+
+	if resp.Vectors[0].VectorB64 != "AAAA/wAAgD8AAAA/" {
+		t.Errorf("VectorB64 = %q, want AAAA/wAAgD8AAAA/", resp.Vectors[0].VectorB64)
+	}
+}
+
+func TestCreateEmbeddingsError400(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":{"message":"Invalid model","code":"invalid_model"}}`))
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	_, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "invalid-model",
+		Input: []core.EmbeddingInput{
+			{Text: "Hello world"},
+		},
+	})
+
+	if !errors.Is(err, ErrModelNotFound) {
+		t.Errorf("expected ErrModelNotFound, got %v", err)
+	}
+}
+
+func TestCreateEmbeddingsError429(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":{"message":"Rate limited"}}`))
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	_, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "text-embedding-3-large",
+		Input: []core.EmbeddingInput{
+			{Text: "Hello world"},
+		},
+	})
+
+	if !errors.Is(err, core.ErrRateLimited) {
+		t.Errorf("expected ErrRateLimited, got %v", err)
+	}
+}
+
+func TestBuildEmbeddingRequest(t *testing.T) {
+	dims := 256
+	req := &core.EmbeddingRequest{
+		Model: "text-embedding-3-large",
+		Input: []core.EmbeddingInput{
+			{Text: "Hello"},
+			{Text: "World"},
+		},
+		EncodingFormat: core.EncodingFormatFloat,
+		Dimensions:     &dims,
+		User:           "user-123",
+		InputType:      core.InputTypeDocument,
+	}
+
+	result := buildEmbeddingRequest(req)
+
+	if result.Model != "text-embedding-3-large" {
+		t.Errorf("Model = %q, want text-embedding-3-large", result.Model)
+	}
+
+	if len(result.Input) != 2 {
+		t.Fatalf("len(Input) = %d, want 2", len(result.Input))
+	}
+
+	if result.Input[0] != "Hello" {
+		t.Errorf("Input[0] = %q, want Hello", result.Input[0])
+	}
+
+	if result.EncodingFormat != "float" {
+		t.Errorf("EncodingFormat = %q, want float", result.EncodingFormat)
+	}
+
+	if result.Dimensions == nil || *result.Dimensions != 256 {
+		t.Errorf("Dimensions = %v, want 256", result.Dimensions)
+	}
+
+	if result.User != "user-123" {
+		t.Errorf("User = %q, want user-123", result.User)
+	}
+
+	if result.InputType != "document" {
+		t.Errorf("InputType = %q, want document", result.InputType)
+	}
+}
+
+func TestBuildEmbeddingRequestMinimal(t *testing.T) {
+	req := &core.EmbeddingRequest{
+		Model: "text-embedding-3-large",
+		Input: []core.EmbeddingInput{
+			{Text: "Hello"},
+		},
+	}
+
+	result := buildEmbeddingRequest(req)
+
+	if result.EncodingFormat != "" {
+		t.Errorf("EncodingFormat = %q, want empty", result.EncodingFormat)
+	}
+
+	if result.Dimensions != nil {
+		t.Errorf("Dimensions = %v, want nil", result.Dimensions)
+	}
+
+	if result.InputType != "" {
+		t.Errorf("InputType = %q, want empty", result.InputType)
+	}
+}
+
+func TestMapEmbeddingResponse(t *testing.T) {
+	req := &core.EmbeddingRequest{
+		Model: "text-embedding-3-large",
+		Input: []core.EmbeddingInput{
+			{ID: "doc-1", Text: "Hello", Metadata: map[string]string{"key": "value"}},
+		},
+	}
+
+	resp := &azureEmbeddingResponse{
+		Object: "list",
+		Model:  "text-embedding-3-large",
+		Data: []azureEmbeddingData{
+			{
+				Object:    "embedding",
+				Index:     0,
+				Embedding: []interface{}{0.1, 0.2, 0.3},
+			},
+		},
+		Usage: azureEmbeddingUsage{
+			PromptTokens: 5,
+			TotalTokens:  5,
+		},
+	}
+
+	result := mapEmbeddingResponse(resp, req)
+
+	if result.Model != "text-embedding-3-large" {
+		t.Errorf("Model = %q, want text-embedding-3-large", result.Model)
+	}
+
+	if len(result.Vectors) != 1 {
+		t.Fatalf("len(Vectors) = %d, want 1", len(result.Vectors))
+	}
+
+	vec := result.Vectors[0]
+	if vec.ID != "doc-1" {
+		t.Errorf("ID = %q, want doc-1", vec.ID)
+	}
+
+	if vec.Metadata["key"] != "value" {
+		t.Errorf("Metadata[key] = %v, want value", vec.Metadata["key"])
+	}
+
+	if len(vec.Vector) != 3 {
+		t.Errorf("len(Vector) = %d, want 3", len(vec.Vector))
+	}
+
+	if result.Usage.TotalTokens != 5 {
+		t.Errorf("Usage.TotalTokens = %d, want 5", result.Usage.TotalTokens)
+	}
+}
+
+func TestMapEmbeddingResponseOutOfBoundsIndex(t *testing.T) {
+	req := &core.EmbeddingRequest{
+		Model: "text-embedding-3-large",
+		Input: []core.EmbeddingInput{
+			{ID: "doc-1", Text: "Hello"},
+		},
+	}
+
+	resp := &azureEmbeddingResponse{
+		Object: "list",
+		Model:  "text-embedding-3-large",
+		Data: []azureEmbeddingData{
+			{
+				Object:    "embedding",
+				Index:     5, // Out of bounds
+				Embedding: []interface{}{0.1, 0.2, 0.3},
+			},
+		},
+		Usage: azureEmbeddingUsage{
+			PromptTokens: 5,
+			TotalTokens:  5,
+		},
+	}
+
+	result := mapEmbeddingResponse(resp, req)
+
+	// Should handle gracefully - no ID/Metadata copied
+	if result.Vectors[0].ID != "" {
+		t.Errorf("ID = %q, want empty (out of bounds index)", result.Vectors[0].ID)
+	}
+}

--- a/providers/azurefoundry/errors.go
+++ b/providers/azurefoundry/errors.go
@@ -1,0 +1,364 @@
+package azurefoundry
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
+)
+
+// Sentinel errors for Azure AI Foundry.
+var (
+	// ErrContentFiltered is returned when Azure's content safety filters block content.
+	ErrContentFiltered = errors.New("azurefoundry: content filtered by safety policy")
+
+	// ErrToolArgsInvalidJSON is returned when tool call arguments contain invalid JSON.
+	ErrToolArgsInvalidJSON = errors.New("azurefoundry: tool arguments are not valid JSON")
+
+	// ErrDeploymentNotFound is returned when the specified deployment does not exist.
+	ErrDeploymentNotFound = errors.New("azurefoundry: deployment not found")
+
+	// ErrModelNotFound is returned when the specified model is not available.
+	ErrModelNotFound = errors.New("azurefoundry: model not found")
+
+	// ErrQuotaExceeded is returned when the account quota has been exceeded.
+	ErrQuotaExceeded = errors.New("azurefoundry: quota exceeded")
+
+	// ErrContextLengthExceeded is returned when the request exceeds the model's context length.
+	ErrContextLengthExceeded = errors.New("azurefoundry: context length exceeded")
+
+	// ErrInvalidAPIKey is returned when the API key is invalid or expired.
+	ErrInvalidAPIKey = errors.New("azurefoundry: invalid API key")
+
+	// ErrTokenExpired is returned when the Entra ID token has expired.
+	ErrTokenExpired = errors.New("azurefoundry: token expired")
+)
+
+// Azure-specific error codes.
+const (
+	// Content safety error codes
+	codeContentFilter           = "content_filter"
+	codeResponsibleAIViolation  = "ResponsibleAIPolicyViolation"
+	codeContentFilterResult     = "content_filter_result"
+
+	// Deployment and model error codes
+	codeDeploymentNotFound = "DeploymentNotFound"
+	codeModelNotFound      = "model_not_found"
+	codeInvalidModel       = "invalid_model"
+
+	// Quota and limit error codes
+	codeQuotaExceeded        = "quota_exceeded"
+	codeTokensPerMinute      = "tokens_per_minute"
+	codeRequestsPerMinute    = "requests_per_minute"
+	codeContextLengthExceeded = "context_length_exceeded"
+	codeMaxTokensExceeded    = "max_tokens_exceeded"
+
+	// Authentication error codes
+	codeInvalidAPIKey       = "invalid_api_key"
+	codeInvalidSubscription = "invalid_subscription_key"
+	codeTokenExpired        = "TokenExpired"
+	codeInvalidToken        = "InvalidAuthenticationToken"
+)
+
+// azureErrorResponse represents an Azure API error response.
+type azureErrorResponse struct {
+	Error azureErrorDetail `json:"error"`
+}
+
+// azureErrorDetail contains the error details.
+type azureErrorDetail struct {
+	Message    string            `json:"message"`
+	Type       string            `json:"type"`
+	Code       string            `json:"code"`
+	Param      string            `json:"param,omitempty"`
+	InnerError *azureInnerError  `json:"innererror,omitempty"`
+}
+
+// azureInnerError contains additional error details.
+type azureInnerError struct {
+	Code                 string                 `json:"code"`
+	Message              string                 `json:"message"`
+	ContentFilterResults map[string]interface{} `json:"content_filter_result,omitempty"`
+}
+
+// normalizeError converts an HTTP error response to a ProviderError with the appropriate sentinel.
+func normalizeError(status int, body []byte, requestID string) error {
+	var errResp azureErrorResponse
+	if err := json.Unmarshal(body, &errResp); err != nil {
+		// Could not parse error response, use generic handling
+		return normalize.OpenAIStyleProviderError("azurefoundry", status, body, requestID)
+	}
+
+	detail := errResp.Error
+	code := detail.Code
+	message := detail.Message
+
+	// Get inner error code if available
+	innerCode := ""
+	if detail.InnerError != nil {
+		innerCode = detail.InnerError.Code
+		if message == "" && detail.InnerError.Message != "" {
+			message = detail.InnerError.Message
+		}
+	}
+
+	// Classify error based on code
+	sentinel := classifyErrorCode(code, innerCode, status)
+
+	return &core.ProviderError{
+		Provider:  "azurefoundry",
+		Status:    status,
+		RequestID: requestID,
+		Code:      code,
+		Message:   message,
+		Err:       sentinel,
+	}
+}
+
+// classifyErrorCode maps Azure error codes to sentinel errors.
+func classifyErrorCode(code, innerCode string, status int) error {
+	// Check inner code first for more specific errors
+	switch innerCode {
+	case codeResponsibleAIViolation:
+		return ErrContentFiltered
+	case codeTokenExpired, codeInvalidToken:
+		return ErrTokenExpired
+	}
+
+	// Check main code
+	switch code {
+	// Content filtering
+	case codeContentFilter, codeContentFilterResult:
+		return ErrContentFiltered
+
+	// Deployment and model errors
+	case codeDeploymentNotFound:
+		return ErrDeploymentNotFound
+	case codeModelNotFound, codeInvalidModel:
+		return ErrModelNotFound
+
+	// Quota and limits
+	case codeQuotaExceeded, codeTokensPerMinute, codeRequestsPerMinute:
+		return ErrQuotaExceeded
+	case codeContextLengthExceeded, codeMaxTokensExceeded:
+		return ErrContextLengthExceeded
+
+	// Authentication
+	case codeInvalidAPIKey, codeInvalidSubscription:
+		return ErrInvalidAPIKey
+	}
+
+	// Fall back to status-based classification
+	return normalize.SentinelForStatus(status)
+}
+
+// normalizeErrorWithRetry extracts retry-after information along with the error.
+func normalizeErrorWithRetry(status int, body []byte, headers http.Header, requestID string) (error, time.Duration) {
+	err := normalizeError(status, body, requestID)
+
+	// Extract retry-after header for rate limiting
+	retryAfter := parseRetryAfter(headers)
+
+	return err, retryAfter
+}
+
+// parseRetryAfter extracts the retry-after duration from response headers.
+// Returns 0 if no retry-after header is present.
+func parseRetryAfter(headers http.Header) time.Duration {
+	// Try Retry-After header (standard)
+	if val := headers.Get("Retry-After"); val != "" {
+		return parseRetryAfterValue(val)
+	}
+
+	// Try x-ms-retry-after-ms (Azure-specific, in milliseconds)
+	if val := headers.Get("x-ms-retry-after-ms"); val != "" {
+		if ms, err := strconv.ParseInt(val, 10, 64); err == nil {
+			return time.Duration(ms) * time.Millisecond
+		}
+	}
+
+	// Try x-ratelimit-reset-requests or x-ratelimit-reset-tokens (OpenAI-style)
+	if val := headers.Get("x-ratelimit-reset-requests"); val != "" {
+		return parseRetryAfterValue(val)
+	}
+	if val := headers.Get("x-ratelimit-reset-tokens"); val != "" {
+		return parseRetryAfterValue(val)
+	}
+
+	return 0
+}
+
+// parseRetryAfterValue parses a retry-after value which can be seconds or a duration string.
+func parseRetryAfterValue(val string) time.Duration {
+	// Try parsing as seconds (integer)
+	if seconds, err := strconv.ParseInt(val, 10, 64); err == nil {
+		return time.Duration(seconds) * time.Second
+	}
+
+	// Try parsing as duration string (e.g., "1m30s")
+	if d, err := time.ParseDuration(val); err == nil {
+		return d
+	}
+
+	// Try parsing as duration with 's' suffix (e.g., "30s")
+	val = strings.TrimSuffix(val, "s")
+	if seconds, err := strconv.ParseFloat(val, 64); err == nil {
+		return time.Duration(seconds * float64(time.Second))
+	}
+
+	return 0
+}
+
+// newNetworkError creates a ProviderError for network-related failures.
+func newNetworkError(err error) error {
+	return normalize.NetworkError("azurefoundry", err)
+}
+
+// newDecodeError creates a ProviderError for JSON decode failures.
+func newDecodeError(err error) error {
+	return normalize.DecodeError("azurefoundry", err)
+}
+
+// ContentFilterError wraps content filter information into an error.
+type ContentFilterError struct {
+	Filters  *azureContentFilters
+	Category string // The primary category that triggered filtering
+	Severity string // The severity level if available
+}
+
+// Error implements the error interface.
+func (e *ContentFilterError) Error() string {
+	if e.Category != "" {
+		if e.Severity != "" {
+			return fmt.Sprintf("content was filtered by Azure AI safety policy: %s (severity: %s)", e.Category, e.Severity)
+		}
+		return fmt.Sprintf("content was filtered by Azure AI safety policy: %s", e.Category)
+	}
+	return "content was filtered by Azure AI safety policy"
+}
+
+// Unwrap returns the underlying sentinel error.
+func (e *ContentFilterError) Unwrap() error {
+	return ErrContentFiltered
+}
+
+// FilteredCategories returns a list of categories that triggered filtering.
+func (e *ContentFilterError) FilteredCategories() []string {
+	if e.Filters == nil {
+		return nil
+	}
+
+	var categories []string
+
+	if e.Filters.Hate != nil && e.Filters.Hate.Filtered {
+		categories = append(categories, "hate")
+	}
+	if e.Filters.SelfHarm != nil && e.Filters.SelfHarm.Filtered {
+		categories = append(categories, "self_harm")
+	}
+	if e.Filters.Sexual != nil && e.Filters.Sexual.Filtered {
+		categories = append(categories, "sexual")
+	}
+	if e.Filters.Violence != nil && e.Filters.Violence.Filtered {
+		categories = append(categories, "violence")
+	}
+	if e.Filters.Jailbreak != nil && e.Filters.Jailbreak.Filtered {
+		categories = append(categories, "jailbreak")
+	}
+	if e.Filters.ProtectedMaterialText != nil && e.Filters.ProtectedMaterialText.Filtered {
+		categories = append(categories, "protected_material_text")
+	}
+	if e.Filters.ProtectedMaterialCode != nil && e.Filters.ProtectedMaterialCode.Filtered {
+		categories = append(categories, "protected_material_code")
+	}
+
+	return categories
+}
+
+// newContentFilterError creates a ContentFilterError with category details.
+func newContentFilterError(filters *azureContentFilters) *ContentFilterError {
+	err := &ContentFilterError{Filters: filters}
+
+	if filters == nil {
+		return err
+	}
+
+	// Determine the primary category and severity
+	if filters.Hate != nil && filters.Hate.Filtered {
+		err.Category = "hate"
+		err.Severity = filters.Hate.Severity
+	} else if filters.Violence != nil && filters.Violence.Filtered {
+		err.Category = "violence"
+		err.Severity = filters.Violence.Severity
+	} else if filters.Sexual != nil && filters.Sexual.Filtered {
+		err.Category = "sexual"
+		err.Severity = filters.Sexual.Severity
+	} else if filters.SelfHarm != nil && filters.SelfHarm.Filtered {
+		err.Category = "self_harm"
+		err.Severity = filters.SelfHarm.Severity
+	} else if filters.Jailbreak != nil && filters.Jailbreak.Filtered {
+		err.Category = "jailbreak"
+	} else if filters.ProtectedMaterialText != nil && filters.ProtectedMaterialText.Filtered {
+		err.Category = "protected_material_text"
+	} else if filters.ProtectedMaterialCode != nil && filters.ProtectedMaterialCode.Filtered {
+		err.Category = "protected_material_code"
+	}
+
+	return err
+}
+
+// IsRetryable returns true if the error indicates a retryable condition.
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check for rate limiting
+	if errors.Is(err, core.ErrRateLimited) {
+		return true
+	}
+
+	// Check for quota exceeded (may become available later)
+	if errors.Is(err, ErrQuotaExceeded) {
+		return true
+	}
+
+	// Check for server errors
+	if errors.Is(err, core.ErrServer) {
+		return true
+	}
+
+	// Check for network errors
+	if errors.Is(err, core.ErrNetwork) {
+		return true
+	}
+
+	// Check for expired token (can be refreshed)
+	if errors.Is(err, ErrTokenExpired) {
+		return true
+	}
+
+	return false
+}
+
+// IsAuthError returns true if the error is related to authentication.
+func IsAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return errors.Is(err, core.ErrUnauthorized) ||
+		errors.Is(err, ErrInvalidAPIKey) ||
+		errors.Is(err, ErrTokenExpired)
+}
+
+// IsContentFilterError returns true if the error is related to content filtering.
+func IsContentFilterError(err error) bool {
+	return errors.Is(err, ErrContentFiltered)
+}

--- a/providers/azurefoundry/errors.go
+++ b/providers/azurefoundry/errors.go
@@ -43,9 +43,9 @@ var (
 // Azure-specific error codes.
 const (
 	// Content safety error codes
-	codeContentFilter           = "content_filter"
-	codeResponsibleAIViolation  = "ResponsibleAIPolicyViolation"
-	codeContentFilterResult     = "content_filter_result"
+	codeContentFilter          = "content_filter"
+	codeResponsibleAIViolation = "ResponsibleAIPolicyViolation"
+	codeContentFilterResult    = "content_filter_result"
 
 	// Deployment and model error codes
 	codeDeploymentNotFound = "DeploymentNotFound"
@@ -53,11 +53,11 @@ const (
 	codeInvalidModel       = "invalid_model"
 
 	// Quota and limit error codes
-	codeQuotaExceeded        = "quota_exceeded"
-	codeTokensPerMinute      = "tokens_per_minute"
-	codeRequestsPerMinute    = "requests_per_minute"
+	codeQuotaExceeded         = "quota_exceeded"
+	codeTokensPerMinute       = "tokens_per_minute"
+	codeRequestsPerMinute     = "requests_per_minute"
 	codeContextLengthExceeded = "context_length_exceeded"
-	codeMaxTokensExceeded    = "max_tokens_exceeded"
+	codeMaxTokensExceeded     = "max_tokens_exceeded"
 
 	// Authentication error codes
 	codeInvalidAPIKey       = "invalid_api_key"
@@ -73,11 +73,11 @@ type azureErrorResponse struct {
 
 // azureErrorDetail contains the error details.
 type azureErrorDetail struct {
-	Message    string            `json:"message"`
-	Type       string            `json:"type"`
-	Code       string            `json:"code"`
-	Param      string            `json:"param,omitempty"`
-	InnerError *azureInnerError  `json:"innererror,omitempty"`
+	Message    string           `json:"message"`
+	Type       string           `json:"type"`
+	Code       string           `json:"code"`
+	Param      string           `json:"param,omitempty"`
+	InnerError *azureInnerError `json:"innererror,omitempty"`
 }
 
 // azureInnerError contains additional error details.
@@ -156,16 +156,6 @@ func classifyErrorCode(code, innerCode string, status int) error {
 
 	// Fall back to status-based classification
 	return normalize.SentinelForStatus(status)
-}
-
-// normalizeErrorWithRetry extracts retry-after information along with the error.
-func normalizeErrorWithRetry(status int, body []byte, headers http.Header, requestID string) (error, time.Duration) {
-	err := normalizeError(status, body, requestID)
-
-	// Extract retry-after header for rate limiting
-	retryAfter := parseRetryAfter(headers)
-
-	return err, retryAfter
 }
 
 // parseRetryAfter extracts the retry-after duration from response headers.

--- a/providers/azurefoundry/errors_test.go
+++ b/providers/azurefoundry/errors_test.go
@@ -2,6 +2,7 @@ package azurefoundry
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -464,7 +465,7 @@ func TestCalculateBackoff(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run("attempt_"+string(rune('0'+tt.attempt)), func(t *testing.T) {
+		t.Run(fmt.Sprintf("attempt_%d", tt.attempt), func(t *testing.T) {
 			got := calculateBackoff(tt.attempt, baseDelay)
 			if got != tt.want {
 				t.Errorf("calculateBackoff(%d, %v) = %v, want %v", tt.attempt, baseDelay, got, tt.want)

--- a/providers/azurefoundry/errors_test.go
+++ b/providers/azurefoundry/errors_test.go
@@ -1,0 +1,474 @@
+package azurefoundry
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestNormalizeError400(t *testing.T) {
+	body := []byte(`{"error":{"message":"Invalid model","type":"invalid_request_error","code":"invalid_model"}}`)
+	err := normalizeError(400, body, "req-123")
+
+	var pErr *core.ProviderError
+	if !errors.As(err, &pErr) {
+		t.Fatal("expected ProviderError")
+	}
+
+	if pErr.Status != 400 {
+		t.Errorf("Status = %d, want 400", pErr.Status)
+	}
+
+	if pErr.RequestID != "req-123" {
+		t.Errorf("RequestID = %q, want %q", pErr.RequestID, "req-123")
+	}
+
+	if pErr.Message != "Invalid model" {
+		t.Errorf("Message = %q, want %q", pErr.Message, "Invalid model")
+	}
+
+	if !errors.Is(err, ErrModelNotFound) {
+		t.Error("expected error to wrap ErrModelNotFound")
+	}
+}
+
+func TestNormalizeError401(t *testing.T) {
+	body := []byte(`{"error":{"message":"Invalid API key","code":"invalid_api_key"}}`)
+	err := normalizeError(401, body, "")
+
+	if !errors.Is(err, ErrInvalidAPIKey) {
+		t.Errorf("expected error to wrap ErrInvalidAPIKey, got %v", err)
+	}
+}
+
+func TestNormalizeError401Generic(t *testing.T) {
+	body := []byte(`{"error":{"message":"Unauthorized"}}`)
+	err := normalizeError(401, body, "")
+
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Error("expected error to wrap ErrUnauthorized")
+	}
+}
+
+func TestNormalizeError403(t *testing.T) {
+	body := []byte(`{"error":{"message":"Access denied"}}`)
+	err := normalizeError(403, body, "")
+
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Error("expected error to wrap ErrUnauthorized")
+	}
+}
+
+func TestNormalizeError429(t *testing.T) {
+	body := []byte(`{"error":{"message":"Rate limit exceeded","code":"quota_exceeded"}}`)
+	err := normalizeError(429, body, "req-456")
+
+	var pErr *core.ProviderError
+	if !errors.As(err, &pErr) {
+		t.Fatal("expected ProviderError")
+	}
+
+	if !errors.Is(err, ErrQuotaExceeded) {
+		t.Errorf("expected error to wrap ErrQuotaExceeded, got %v", err)
+	}
+
+	if pErr.RequestID != "req-456" {
+		t.Errorf("RequestID = %q, want %q", pErr.RequestID, "req-456")
+	}
+}
+
+func TestNormalizeError500(t *testing.T) {
+	body := []byte(`{"error":{"message":"Internal server error"}}`)
+	err := normalizeError(500, body, "")
+
+	if !errors.Is(err, core.ErrServer) {
+		t.Error("expected error to wrap ErrServer")
+	}
+}
+
+func TestNormalizeError502(t *testing.T) {
+	body := []byte(`{}`)
+	err := normalizeError(502, body, "")
+
+	if !errors.Is(err, core.ErrServer) {
+		t.Error("expected error to wrap ErrServer")
+	}
+}
+
+func TestNormalizeError503(t *testing.T) {
+	body := []byte(`{"error":{"message":"Service unavailable"}}`)
+	err := normalizeError(503, body, "")
+
+	if !errors.Is(err, core.ErrServer) {
+		t.Error("expected error to wrap ErrServer")
+	}
+}
+
+func TestNormalizeErrorContentFilter(t *testing.T) {
+	body := []byte(`{"error":{"message":"Content filtered","code":"content_filter"}}`)
+	err := normalizeError(400, body, "")
+
+	if !errors.Is(err, ErrContentFiltered) {
+		t.Errorf("expected error to wrap ErrContentFiltered, got %v", err)
+	}
+}
+
+func TestNormalizeErrorDeploymentNotFound(t *testing.T) {
+	body := []byte(`{"error":{"message":"Deployment not found","code":"DeploymentNotFound"}}`)
+	err := normalizeError(404, body, "")
+
+	if !errors.Is(err, ErrDeploymentNotFound) {
+		t.Errorf("expected error to wrap ErrDeploymentNotFound, got %v", err)
+	}
+}
+
+func TestNormalizeErrorContextLength(t *testing.T) {
+	body := []byte(`{"error":{"message":"Context too long","code":"context_length_exceeded"}}`)
+	err := normalizeError(400, body, "")
+
+	if !errors.Is(err, ErrContextLengthExceeded) {
+		t.Errorf("expected error to wrap ErrContextLengthExceeded, got %v", err)
+	}
+}
+
+func TestNormalizeErrorInnerCode(t *testing.T) {
+	body := []byte(`{"error":{"message":"Policy violation","code":"content_filter","innererror":{"code":"ResponsibleAIPolicyViolation"}}}`)
+	err := normalizeError(400, body, "")
+
+	if !errors.Is(err, ErrContentFiltered) {
+		t.Errorf("expected error to wrap ErrContentFiltered, got %v", err)
+	}
+}
+
+func TestNormalizeErrorTokenExpired(t *testing.T) {
+	body := []byte(`{"error":{"message":"Token expired","innererror":{"code":"TokenExpired"}}}`)
+	err := normalizeError(401, body, "")
+
+	if !errors.Is(err, ErrTokenExpired) {
+		t.Errorf("expected error to wrap ErrTokenExpired, got %v", err)
+	}
+}
+
+func TestNormalizeErrorProvider(t *testing.T) {
+	err := normalizeError(400, []byte(`{}`), "")
+
+	var pErr *core.ProviderError
+	if !errors.As(err, &pErr) {
+		t.Fatal("expected ProviderError")
+	}
+
+	if pErr.Provider != "azurefoundry" {
+		t.Errorf("Provider = %q, want %q", pErr.Provider, "azurefoundry")
+	}
+}
+
+func TestNewNetworkError(t *testing.T) {
+	originalErr := errors.New("connection refused")
+	err := newNetworkError(originalErr)
+
+	var pErr *core.ProviderError
+	if !errors.As(err, &pErr) {
+		t.Fatal("expected ProviderError")
+	}
+
+	if pErr.Provider != "azurefoundry" {
+		t.Errorf("Provider = %q, want %q", pErr.Provider, "azurefoundry")
+	}
+
+	if !errors.Is(err, core.ErrNetwork) {
+		t.Error("expected error to wrap ErrNetwork")
+	}
+}
+
+func TestNewDecodeError(t *testing.T) {
+	originalErr := errors.New("unexpected EOF")
+	err := newDecodeError(originalErr)
+
+	var pErr *core.ProviderError
+	if !errors.As(err, &pErr) {
+		t.Fatal("expected ProviderError")
+	}
+
+	if !errors.Is(err, core.ErrDecode) {
+		t.Error("expected error to wrap ErrDecode")
+	}
+}
+
+func TestParseRetryAfterSeconds(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("Retry-After", "30")
+
+	d := parseRetryAfter(headers)
+
+	if d != 30*time.Second {
+		t.Errorf("parseRetryAfter() = %v, want 30s", d)
+	}
+}
+
+func TestParseRetryAfterDuration(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("Retry-After", "1m30s")
+
+	d := parseRetryAfter(headers)
+
+	if d != 90*time.Second {
+		t.Errorf("parseRetryAfter() = %v, want 1m30s", d)
+	}
+}
+
+func TestParseRetryAfterAzureMs(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("x-ms-retry-after-ms", "5000")
+
+	d := parseRetryAfter(headers)
+
+	if d != 5*time.Second {
+		t.Errorf("parseRetryAfter() = %v, want 5s", d)
+	}
+}
+
+func TestParseRetryAfterOpenAIStyle(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("x-ratelimit-reset-requests", "60")
+
+	d := parseRetryAfter(headers)
+
+	if d != 60*time.Second {
+		t.Errorf("parseRetryAfter() = %v, want 60s", d)
+	}
+}
+
+func TestParseRetryAfterNone(t *testing.T) {
+	headers := http.Header{}
+
+	d := parseRetryAfter(headers)
+
+	if d != 0 {
+		t.Errorf("parseRetryAfter() = %v, want 0", d)
+	}
+}
+
+func TestContentFilterError(t *testing.T) {
+	filters := &azureContentFilters{
+		Hate: &azureFilterSeverity{Filtered: true, Severity: "high"},
+	}
+
+	err := newContentFilterError(filters)
+
+	if err.Category != "hate" {
+		t.Errorf("Category = %q, want hate", err.Category)
+	}
+
+	if err.Severity != "high" {
+		t.Errorf("Severity = %q, want high", err.Severity)
+	}
+
+	if !errors.Is(err, ErrContentFiltered) {
+		t.Error("expected error to wrap ErrContentFiltered")
+	}
+
+	// Check error message
+	msg := err.Error()
+	if msg == "" {
+		t.Error("Error() returned empty string")
+	}
+}
+
+func TestContentFilterErrorCategories(t *testing.T) {
+	filters := &azureContentFilters{
+		Hate:     &azureFilterSeverity{Filtered: true, Severity: "high"},
+		Violence: &azureFilterSeverity{Filtered: true, Severity: "medium"},
+	}
+
+	err := newContentFilterError(filters)
+	categories := err.FilteredCategories()
+
+	if len(categories) != 2 {
+		t.Fatalf("len(FilteredCategories()) = %d, want 2", len(categories))
+	}
+
+	hasHate := false
+	hasViolence := false
+	for _, c := range categories {
+		if c == "hate" {
+			hasHate = true
+		}
+		if c == "violence" {
+			hasViolence = true
+		}
+	}
+
+	if !hasHate {
+		t.Error("FilteredCategories() missing hate")
+	}
+	if !hasViolence {
+		t.Error("FilteredCategories() missing violence")
+	}
+}
+
+func TestContentFilterErrorNilFilters(t *testing.T) {
+	err := newContentFilterError(nil)
+
+	if err.Category != "" {
+		t.Errorf("Category = %q, want empty", err.Category)
+	}
+
+	categories := err.FilteredCategories()
+	if categories != nil {
+		t.Errorf("FilteredCategories() = %v, want nil", categories)
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"rate limited", core.ErrRateLimited, true},
+		{"quota exceeded", ErrQuotaExceeded, true},
+		{"server error", core.ErrServer, true},
+		{"network error", core.ErrNetwork, true},
+		{"token expired", ErrTokenExpired, true},
+		{"bad request", core.ErrBadRequest, false},
+		{"content filtered", ErrContentFiltered, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsRetryable(tt.err)
+			if got != tt.want {
+				t.Errorf("IsRetryable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsAuthError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unauthorized", core.ErrUnauthorized, true},
+		{"invalid api key", ErrInvalidAPIKey, true},
+		{"token expired", ErrTokenExpired, true},
+		{"bad request", core.ErrBadRequest, false},
+		{"rate limited", core.ErrRateLimited, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsAuthError(tt.err)
+			if got != tt.want {
+				t.Errorf("IsAuthError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsContentFilterError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"content filtered", ErrContentFiltered, true},
+		{"bad request", core.ErrBadRequest, false},
+		{"nil", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsContentFilterError(tt.err)
+			if got != tt.want {
+				t.Errorf("IsContentFilterError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyErrorCode(t *testing.T) {
+	tests := []struct {
+		code      string
+		innerCode string
+		status    int
+		want      error
+	}{
+		{"content_filter", "", 400, ErrContentFiltered},
+		{"DeploymentNotFound", "", 404, ErrDeploymentNotFound},
+		{"model_not_found", "", 404, ErrModelNotFound},
+		{"quota_exceeded", "", 429, ErrQuotaExceeded},
+		{"context_length_exceeded", "", 400, ErrContextLengthExceeded},
+		{"invalid_api_key", "", 401, ErrInvalidAPIKey},
+		{"", "ResponsibleAIPolicyViolation", 400, ErrContentFiltered},
+		{"", "TokenExpired", 401, ErrTokenExpired},
+		{"unknown", "", 400, core.ErrBadRequest},
+		{"unknown", "", 500, core.ErrServer},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code+"_"+tt.innerCode, func(t *testing.T) {
+			got := classifyErrorCode(tt.code, tt.innerCode, tt.status)
+			if !errors.Is(got, tt.want) {
+				t.Errorf("classifyErrorCode(%q, %q, %d) = %v, want %v", tt.code, tt.innerCode, tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryableStatus(t *testing.T) {
+	tests := []struct {
+		status int
+		want   bool
+	}{
+		{200, false},
+		{400, false},
+		{401, false},
+		{429, true},
+		{500, true},
+		{502, true},
+		{503, true},
+		{504, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(http.StatusText(tt.status), func(t *testing.T) {
+			got := retryableStatus(tt.status)
+			if got != tt.want {
+				t.Errorf("retryableStatus(%d) = %v, want %v", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalculateBackoff(t *testing.T) {
+	baseDelay := time.Second
+
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{0, 1 * time.Second},
+		{1, 2 * time.Second},
+		{2, 4 * time.Second},
+		{3, 8 * time.Second},
+		{4, 16 * time.Second},
+		{5, 30 * time.Second}, // capped
+		{6, 30 * time.Second}, // capped
+	}
+
+	for _, tt := range tests {
+		t.Run("attempt_"+string(rune('0'+tt.attempt)), func(t *testing.T) {
+			got := calculateBackoff(tt.attempt, baseDelay)
+			if got != tt.want {
+				t.Errorf("calculateBackoff(%d, %v) = %v, want %v", tt.attempt, baseDelay, got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/azurefoundry/mapping.go
+++ b/providers/azurefoundry/mapping.go
@@ -1,0 +1,416 @@
+package azurefoundry
+
+import (
+	"encoding/json"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/tools"
+)
+
+// ----------------------------------------------------------------------------
+// Request Types
+// ----------------------------------------------------------------------------
+
+// azureRequest represents a request to the Azure AI chat completions API.
+type azureRequest struct {
+	Model               string               `json:"model,omitempty"`
+	Messages            []azureMessage       `json:"messages"`
+	Temperature         *float32             `json:"temperature,omitempty"`
+	TopP                *float32             `json:"top_p,omitempty"`
+	MaxTokens           *int                 `json:"max_tokens,omitempty"`
+	MaxCompletionTokens *int                 `json:"max_completion_tokens,omitempty"`
+	Stop                []string             `json:"stop,omitempty"`
+	Stream              bool                 `json:"stream"`
+	Tools               []azureTool          `json:"tools,omitempty"`
+	ToolChoice          any                  `json:"tool_choice,omitempty"`
+	ResponseFormat      *azureResponseFormat `json:"response_format,omitempty"`
+	Seed                *int                 `json:"seed,omitempty"`
+	FrequencyPenalty    *float32             `json:"frequency_penalty,omitempty"`
+	PresencePenalty     *float32             `json:"presence_penalty,omitempty"`
+	User                string               `json:"user,omitempty"`
+}
+
+// azureMessage represents a message in the Azure format.
+type azureMessage struct {
+	Role       string            `json:"role"`
+	Content    any               `json:"content,omitempty"` // string or []contentPart for multimodal
+	Name       string            `json:"name,omitempty"`
+	ToolCalls  []azureToolCall   `json:"tool_calls,omitempty"`   // For assistant messages requesting tools
+	ToolCallID string            `json:"tool_call_id,omitempty"` // For tool result messages
+}
+
+// azureContentPart represents a content part for multimodal messages.
+type azureContentPart struct {
+	Type     string            `json:"type"` // "text" or "image_url"
+	Text     string            `json:"text,omitempty"`
+	ImageURL *azureImageURL    `json:"image_url,omitempty"`
+}
+
+// azureImageURL represents an image URL in a multimodal message.
+type azureImageURL struct {
+	URL    string `json:"url"`
+	Detail string `json:"detail,omitempty"` // "auto", "low", "high"
+}
+
+// azureTool represents a tool definition in the Azure format.
+type azureTool struct {
+	Type     string        `json:"type"` // "function"
+	Function azureFunction `json:"function"`
+}
+
+// azureFunction represents a function definition for Azure tools.
+type azureFunction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
+	Strict      *bool           `json:"strict,omitempty"`
+}
+
+// azureResponseFormat represents the response_format parameter.
+type azureResponseFormat struct {
+	Type       string           `json:"type"` // "text", "json_object", "json_schema"
+	JSONSchema *azureJSONSchema `json:"json_schema,omitempty"`
+}
+
+// azureJSONSchema represents the JSON schema configuration for structured output.
+type azureJSONSchema struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Schema      json.RawMessage `json:"schema"`
+	Strict      bool            `json:"strict,omitempty"`
+}
+
+// ----------------------------------------------------------------------------
+// Response Types
+// ----------------------------------------------------------------------------
+
+// azureResponse represents a response from the Azure AI chat completions API.
+type azureResponse struct {
+	ID                  string               `json:"id"`
+	Object              string               `json:"object"`
+	Created             int64                `json:"created"`
+	Model               string               `json:"model"`
+	Choices             []azureChoice        `json:"choices"`
+	Usage               azureUsage           `json:"usage"`
+	SystemFingerprint   string               `json:"system_fingerprint,omitempty"`
+	PromptFilterResults []azureFilterResult  `json:"prompt_filter_results,omitempty"`
+}
+
+// azureChoice represents a single choice in an Azure response.
+type azureChoice struct {
+	Index                int                   `json:"index"`
+	Message              *azureRespMsg         `json:"message,omitempty"`
+	Delta                *azureRespMsg         `json:"delta,omitempty"` // For streaming
+	FinishReason         string                `json:"finish_reason"`
+	ContentFilterResults *azureContentFilters  `json:"content_filter_results,omitempty"`
+}
+
+// azureRespMsg represents the assistant message in a response.
+type azureRespMsg struct {
+	Role      string          `json:"role"`
+	Content   string          `json:"content"`
+	ToolCalls []azureToolCall `json:"tool_calls,omitempty"`
+	Refusal   string          `json:"refusal,omitempty"`
+}
+
+// azureToolCall represents a tool call in an Azure response.
+type azureToolCall struct {
+	ID       string             `json:"id"`
+	Type     string             `json:"type"`
+	Function azureFunctionCall  `json:"function"`
+	Index    *int               `json:"index,omitempty"` // For streaming tool calls
+}
+
+// azureFunctionCall represents the function details in a tool call.
+type azureFunctionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+// azureUsage represents token usage in an Azure response.
+type azureUsage struct {
+	PromptTokens            int                      `json:"prompt_tokens"`
+	CompletionTokens        int                      `json:"completion_tokens"`
+	TotalTokens             int                      `json:"total_tokens"`
+	CompletionTokensDetails *azureCompletionDetails  `json:"completion_tokens_details,omitempty"`
+	PromptTokensDetails     *azurePromptDetails      `json:"prompt_tokens_details,omitempty"`
+}
+
+// azureCompletionDetails contains detailed token usage for completions.
+type azureCompletionDetails struct {
+	ReasoningTokens          int `json:"reasoning_tokens,omitempty"`
+	AcceptedPredictionTokens int `json:"accepted_prediction_tokens,omitempty"`
+	RejectedPredictionTokens int `json:"rejected_prediction_tokens,omitempty"`
+	AudioTokens              int `json:"audio_tokens,omitempty"`
+}
+
+// azurePromptDetails contains detailed token usage for prompts.
+type azurePromptDetails struct {
+	CachedTokens int `json:"cached_tokens,omitempty"`
+	AudioTokens  int `json:"audio_tokens,omitempty"`
+}
+
+// ----------------------------------------------------------------------------
+// Content Filtering Types
+// ----------------------------------------------------------------------------
+
+// azureFilterResult represents content filtering results for a prompt.
+type azureFilterResult struct {
+	PromptIndex          int                  `json:"prompt_index"`
+	ContentFilterResults azureContentFilters  `json:"content_filter_results"`
+}
+
+// azureContentFilters contains all content filter results.
+type azureContentFilters struct {
+	Hate                  *azureFilterSeverity `json:"hate,omitempty"`
+	SelfHarm              *azureFilterSeverity `json:"self_harm,omitempty"`
+	Sexual                *azureFilterSeverity `json:"sexual,omitempty"`
+	Violence              *azureFilterSeverity `json:"violence,omitempty"`
+	Jailbreak             *azureFilterDetected `json:"jailbreak,omitempty"`
+	ProtectedMaterialText *azureFilterDetected `json:"protected_material_text,omitempty"`
+	ProtectedMaterialCode *azureFilterDetected `json:"protected_material_code,omitempty"`
+}
+
+// azureFilterSeverity represents a severity-based filter result.
+type azureFilterSeverity struct {
+	Filtered bool   `json:"filtered"`
+	Severity string `json:"severity"` // "safe", "low", "medium", "high"
+}
+
+// azureFilterDetected represents a detection-based filter result.
+type azureFilterDetected struct {
+	Filtered bool `json:"filtered"`
+	Detected bool `json:"detected"`
+}
+
+// IsFiltered returns true if any content was filtered.
+func (f *azureContentFilters) IsFiltered() bool {
+	if f == nil {
+		return false
+	}
+	return (f.Hate != nil && f.Hate.Filtered) ||
+		(f.SelfHarm != nil && f.SelfHarm.Filtered) ||
+		(f.Sexual != nil && f.Sexual.Filtered) ||
+		(f.Violence != nil && f.Violence.Filtered) ||
+		(f.Jailbreak != nil && f.Jailbreak.Filtered) ||
+		(f.ProtectedMaterialText != nil && f.ProtectedMaterialText.Filtered) ||
+		(f.ProtectedMaterialCode != nil && f.ProtectedMaterialCode.Filtered)
+}
+
+// ----------------------------------------------------------------------------
+// Mapping Functions
+// ----------------------------------------------------------------------------
+
+// schemaProvider is an interface for tools that provide a JSON schema.
+type schemaProvider interface {
+	Schema() tools.ToolSchema
+}
+
+// mapMessages converts Iris messages to Azure message format.
+func mapMessages(msgs []core.Message) []azureMessage {
+	result := make([]azureMessage, 0, len(msgs))
+
+	for _, msg := range msgs {
+		switch msg.Role {
+		case core.RoleTool:
+			// Tool result messages: expand into individual messages per result
+			for _, tr := range msg.ToolResults {
+				content := marshalToolResultContent(tr.Content)
+				result = append(result, azureMessage{
+					Role:       "tool",
+					Content:    content,
+					ToolCallID: tr.CallID,
+				})
+			}
+
+		case core.RoleAssistant:
+			// Assistant messages may include tool calls
+			azMsg := azureMessage{
+				Role:    "assistant",
+				Content: msg.Content,
+			}
+			if len(msg.ToolCalls) > 0 {
+				azMsg.ToolCalls = mapToolCallsToAzure(msg.ToolCalls)
+			}
+			result = append(result, azMsg)
+
+		default:
+			// System, User messages
+			result = append(result, azureMessage{
+				Role:    string(msg.Role),
+				Content: msg.Content,
+			})
+		}
+	}
+
+	return result
+}
+
+// mapToolCallsToAzure converts Iris ToolCalls to Azure format.
+func mapToolCallsToAzure(calls []core.ToolCall) []azureToolCall {
+	result := make([]azureToolCall, len(calls))
+	for i, tc := range calls {
+		result[i] = azureToolCall{
+			ID:   tc.ID,
+			Type: "function",
+			Function: azureFunctionCall{
+				Name:      tc.Name,
+				Arguments: string(tc.Arguments),
+			},
+		}
+	}
+	return result
+}
+
+// marshalToolResultContent converts tool result content to a JSON string.
+func marshalToolResultContent(content any) string {
+	switch v := content.(type) {
+	case string:
+		return v
+	default:
+		data, err := json.Marshal(v)
+		if err != nil {
+			return `{"error": "failed to marshal tool result"}`
+		}
+		return string(data)
+	}
+}
+
+// mapTools converts Iris tools to Azure tool format.
+func mapTools(irisTools []core.Tool) []azureTool {
+	if len(irisTools) == 0 {
+		return nil
+	}
+
+	result := make([]azureTool, len(irisTools))
+	for i, t := range irisTools {
+		var params json.RawMessage
+
+		// Check if the tool provides a schema
+		if sp, ok := t.(schemaProvider); ok {
+			params = sp.Schema().JSONSchema
+		}
+
+		// Default to empty object if no schema
+		if params == nil {
+			params = json.RawMessage(`{}`)
+		}
+
+		result[i] = azureTool{
+			Type: "function",
+			Function: azureFunction{
+				Name:        t.Name(),
+				Description: t.Description(),
+				Parameters:  params,
+			},
+		}
+	}
+	return result
+}
+
+// buildRequest creates an Azure API request from an Iris ChatRequest.
+func buildRequest(req *core.ChatRequest, stream bool) *azureRequest {
+	azReq := &azureRequest{
+		Model:    string(req.Model),
+		Messages: mapMessages(req.Messages),
+		Stream:   stream,
+	}
+
+	// Only set optional fields if provided
+	if req.Temperature != nil {
+		azReq.Temperature = req.Temperature
+	}
+
+	if req.MaxTokens != nil {
+		azReq.MaxTokens = req.MaxTokens
+	}
+
+	// Map tools if present
+	if len(req.Tools) > 0 {
+		azReq.Tools = mapTools(req.Tools)
+		azReq.ToolChoice = "auto"
+	}
+
+	// Map response format for structured output
+	azReq.ResponseFormat = mapResponseFormat(req)
+
+	return azReq
+}
+
+// mapResponseFormat converts Iris response format to Azure format.
+func mapResponseFormat(req *core.ChatRequest) *azureResponseFormat {
+	switch req.ResponseFormat {
+	case core.ResponseFormatJSON:
+		return &azureResponseFormat{Type: "json_object"}
+	case core.ResponseFormatJSONSchema:
+		if req.JSONSchema == nil {
+			return nil
+		}
+		return &azureResponseFormat{
+			Type: "json_schema",
+			JSONSchema: &azureJSONSchema{
+				Name:        req.JSONSchema.Name,
+				Description: req.JSONSchema.Description,
+				Schema:      req.JSONSchema.Schema,
+				Strict:      req.JSONSchema.Strict,
+			},
+		}
+	default:
+		// ResponseFormatText or empty: no response_format constraint
+		return nil
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Response Mapping
+// ----------------------------------------------------------------------------
+
+// mapResponse converts an Azure response to an Iris ChatResponse.
+func mapResponse(resp *azureResponse) *core.ChatResponse {
+	if resp == nil || len(resp.Choices) == 0 {
+		return &core.ChatResponse{
+			ID:    resp.ID,
+			Model: core.ModelID(resp.Model),
+		}
+	}
+
+	choice := resp.Choices[0]
+	result := &core.ChatResponse{
+		ID:    resp.ID,
+		Model: core.ModelID(resp.Model),
+		Usage: mapUsage(resp.Usage),
+	}
+
+	if choice.Message != nil {
+		result.Output = choice.Message.Content
+		result.ToolCalls = mapToolCallsFromAzure(choice.Message.ToolCalls)
+	}
+
+	return result
+}
+
+// mapUsage converts Azure token usage to Iris format.
+func mapUsage(usage azureUsage) core.TokenUsage {
+	return core.TokenUsage{
+		PromptTokens:     usage.PromptTokens,
+		CompletionTokens: usage.CompletionTokens,
+		TotalTokens:      usage.TotalTokens,
+	}
+}
+
+// mapToolCallsFromAzure converts Azure tool calls to Iris format.
+func mapToolCallsFromAzure(calls []azureToolCall) []core.ToolCall {
+	if len(calls) == 0 {
+		return nil
+	}
+
+	result := make([]core.ToolCall, len(calls))
+	for i, tc := range calls {
+		result[i] = core.ToolCall{
+			ID:        tc.ID,
+			Name:      tc.Function.Name,
+			Arguments: json.RawMessage(tc.Function.Arguments),
+		}
+	}
+	return result
+}

--- a/providers/azurefoundry/mapping.go
+++ b/providers/azurefoundry/mapping.go
@@ -32,24 +32,11 @@ type azureRequest struct {
 
 // azureMessage represents a message in the Azure format.
 type azureMessage struct {
-	Role       string            `json:"role"`
-	Content    any               `json:"content,omitempty"` // string or []contentPart for multimodal
-	Name       string            `json:"name,omitempty"`
-	ToolCalls  []azureToolCall   `json:"tool_calls,omitempty"`   // For assistant messages requesting tools
-	ToolCallID string            `json:"tool_call_id,omitempty"` // For tool result messages
-}
-
-// azureContentPart represents a content part for multimodal messages.
-type azureContentPart struct {
-	Type     string            `json:"type"` // "text" or "image_url"
-	Text     string            `json:"text,omitempty"`
-	ImageURL *azureImageURL    `json:"image_url,omitempty"`
-}
-
-// azureImageURL represents an image URL in a multimodal message.
-type azureImageURL struct {
-	URL    string `json:"url"`
-	Detail string `json:"detail,omitempty"` // "auto", "low", "high"
+	Role       string          `json:"role"`
+	Content    any             `json:"content,omitempty"` // string or []contentPart for multimodal
+	Name       string          `json:"name,omitempty"`
+	ToolCalls  []azureToolCall `json:"tool_calls,omitempty"`   // For assistant messages requesting tools
+	ToolCallID string          `json:"tool_call_id,omitempty"` // For tool result messages
 }
 
 // azureTool represents a tool definition in the Azure format.
@@ -86,23 +73,23 @@ type azureJSONSchema struct {
 
 // azureResponse represents a response from the Azure AI chat completions API.
 type azureResponse struct {
-	ID                  string               `json:"id"`
-	Object              string               `json:"object"`
-	Created             int64                `json:"created"`
-	Model               string               `json:"model"`
-	Choices             []azureChoice        `json:"choices"`
-	Usage               azureUsage           `json:"usage"`
-	SystemFingerprint   string               `json:"system_fingerprint,omitempty"`
-	PromptFilterResults []azureFilterResult  `json:"prompt_filter_results,omitempty"`
+	ID                  string              `json:"id"`
+	Object              string              `json:"object"`
+	Created             int64               `json:"created"`
+	Model               string              `json:"model"`
+	Choices             []azureChoice       `json:"choices"`
+	Usage               azureUsage          `json:"usage"`
+	SystemFingerprint   string              `json:"system_fingerprint,omitempty"`
+	PromptFilterResults []azureFilterResult `json:"prompt_filter_results,omitempty"`
 }
 
 // azureChoice represents a single choice in an Azure response.
 type azureChoice struct {
-	Index                int                   `json:"index"`
-	Message              *azureRespMsg         `json:"message,omitempty"`
-	Delta                *azureRespMsg         `json:"delta,omitempty"` // For streaming
-	FinishReason         string                `json:"finish_reason"`
-	ContentFilterResults *azureContentFilters  `json:"content_filter_results,omitempty"`
+	Index                int                  `json:"index"`
+	Message              *azureRespMsg        `json:"message,omitempty"`
+	Delta                *azureRespMsg        `json:"delta,omitempty"` // For streaming
+	FinishReason         string               `json:"finish_reason"`
+	ContentFilterResults *azureContentFilters `json:"content_filter_results,omitempty"`
 }
 
 // azureRespMsg represents the assistant message in a response.
@@ -115,10 +102,10 @@ type azureRespMsg struct {
 
 // azureToolCall represents a tool call in an Azure response.
 type azureToolCall struct {
-	ID       string             `json:"id"`
-	Type     string             `json:"type"`
-	Function azureFunctionCall  `json:"function"`
-	Index    *int               `json:"index,omitempty"` // For streaming tool calls
+	ID       string            `json:"id"`
+	Type     string            `json:"type"`
+	Function azureFunctionCall `json:"function"`
+	Index    *int              `json:"index,omitempty"` // For streaming tool calls
 }
 
 // azureFunctionCall represents the function details in a tool call.
@@ -129,11 +116,11 @@ type azureFunctionCall struct {
 
 // azureUsage represents token usage in an Azure response.
 type azureUsage struct {
-	PromptTokens            int                      `json:"prompt_tokens"`
-	CompletionTokens        int                      `json:"completion_tokens"`
-	TotalTokens             int                      `json:"total_tokens"`
-	CompletionTokensDetails *azureCompletionDetails  `json:"completion_tokens_details,omitempty"`
-	PromptTokensDetails     *azurePromptDetails      `json:"prompt_tokens_details,omitempty"`
+	PromptTokens            int                     `json:"prompt_tokens"`
+	CompletionTokens        int                     `json:"completion_tokens"`
+	TotalTokens             int                     `json:"total_tokens"`
+	CompletionTokensDetails *azureCompletionDetails `json:"completion_tokens_details,omitempty"`
+	PromptTokensDetails     *azurePromptDetails     `json:"prompt_tokens_details,omitempty"`
 }
 
 // azureCompletionDetails contains detailed token usage for completions.
@@ -156,8 +143,8 @@ type azurePromptDetails struct {
 
 // azureFilterResult represents content filtering results for a prompt.
 type azureFilterResult struct {
-	PromptIndex          int                  `json:"prompt_index"`
-	ContentFilterResults azureContentFilters  `json:"content_filter_results"`
+	PromptIndex          int                 `json:"prompt_index"`
+	ContentFilterResults azureContentFilters `json:"content_filter_results"`
 }
 
 // azureContentFilters contains all content filter results.

--- a/providers/azurefoundry/mapping_test.go
+++ b/providers/azurefoundry/mapping_test.go
@@ -1,0 +1,575 @@
+package azurefoundry
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestMapMessages(t *testing.T) {
+	msgs := []core.Message{
+		{Role: core.RoleSystem, Content: "You are helpful."},
+		{Role: core.RoleUser, Content: "Hello"},
+		{Role: core.RoleAssistant, Content: "Hi there!"},
+	}
+
+	result := mapMessages(msgs)
+
+	if len(result) != 3 {
+		t.Fatalf("len(result) = %d, want 3", len(result))
+	}
+
+	if result[0].Role != "system" {
+		t.Errorf("result[0].Role = %q, want system", result[0].Role)
+	}
+	if result[0].Content != "You are helpful." {
+		t.Errorf("result[0].Content = %q, want 'You are helpful.'", result[0].Content)
+	}
+
+	if result[1].Role != "user" {
+		t.Errorf("result[1].Role = %q, want user", result[1].Role)
+	}
+
+	if result[2].Role != "assistant" {
+		t.Errorf("result[2].Role = %q, want assistant", result[2].Role)
+	}
+}
+
+func TestMapMessagesEmpty(t *testing.T) {
+	result := mapMessages([]core.Message{})
+
+	if len(result) != 0 {
+		t.Errorf("len(result) = %d, want 0", len(result))
+	}
+}
+
+func TestMapMessagesWithToolCalls(t *testing.T) {
+	msgs := []core.Message{
+		{
+			Role:    core.RoleAssistant,
+			Content: "",
+			ToolCalls: []core.ToolCall{
+				{
+					ID:        "call_123",
+					Name:      "get_weather",
+					Arguments: json.RawMessage(`{"location":"NYC"}`),
+				},
+			},
+		},
+	}
+
+	result := mapMessages(msgs)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+
+	if len(result[0].ToolCalls) != 1 {
+		t.Fatalf("len(result[0].ToolCalls) = %d, want 1", len(result[0].ToolCalls))
+	}
+
+	tc := result[0].ToolCalls[0]
+	if tc.ID != "call_123" {
+		t.Errorf("ToolCalls[0].ID = %q, want call_123", tc.ID)
+	}
+	if tc.Function.Name != "get_weather" {
+		t.Errorf("ToolCalls[0].Function.Name = %q, want get_weather", tc.Function.Name)
+	}
+	if tc.Function.Arguments != `{"location":"NYC"}` {
+		t.Errorf("ToolCalls[0].Function.Arguments = %q, want {\"location\":\"NYC\"}", tc.Function.Arguments)
+	}
+}
+
+func TestMapMessagesWithToolResults(t *testing.T) {
+	msgs := []core.Message{
+		{
+			Role: core.RoleTool,
+			ToolResults: []core.ToolResult{
+				{
+					CallID:  "call_123",
+					Content: "Sunny, 72°F",
+				},
+				{
+					CallID:  "call_456",
+					Content: map[string]interface{}{"temp": 72, "condition": "sunny"},
+				},
+			},
+		},
+	}
+
+	result := mapMessages(msgs)
+
+	// Each tool result should become a separate message
+	if len(result) != 2 {
+		t.Fatalf("len(result) = %d, want 2", len(result))
+	}
+
+	if result[0].Role != "tool" {
+		t.Errorf("result[0].Role = %q, want tool", result[0].Role)
+	}
+	if result[0].ToolCallID != "call_123" {
+		t.Errorf("result[0].ToolCallID = %q, want call_123", result[0].ToolCallID)
+	}
+	if result[0].Content != "Sunny, 72°F" {
+		t.Errorf("result[0].Content = %q, want 'Sunny, 72°F'", result[0].Content)
+	}
+
+	if result[1].ToolCallID != "call_456" {
+		t.Errorf("result[1].ToolCallID = %q, want call_456", result[1].ToolCallID)
+	}
+}
+
+func TestBuildRequest(t *testing.T) {
+	temp := float32(0.7)
+	maxTok := 100
+
+	req := &core.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: "Hello"},
+		},
+		Temperature: &temp,
+		MaxTokens:   &maxTok,
+	}
+
+	result := buildRequest(req, false)
+
+	if result.Model != "gpt-4o" {
+		t.Errorf("Model = %q, want gpt-4o", result.Model)
+	}
+
+	if result.Stream {
+		t.Error("Stream = true, want false")
+	}
+
+	if *result.Temperature != 0.7 {
+		t.Errorf("Temperature = %v, want 0.7", *result.Temperature)
+	}
+
+	if *result.MaxTokens != 100 {
+		t.Errorf("MaxTokens = %v, want 100", *result.MaxTokens)
+	}
+
+	if len(result.Messages) != 1 {
+		t.Fatalf("len(Messages) = %d, want 1", len(result.Messages))
+	}
+}
+
+func TestBuildRequestStream(t *testing.T) {
+	req := &core.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: "Hello"},
+		},
+	}
+
+	result := buildRequest(req, true)
+
+	if !result.Stream {
+		t.Error("Stream = false, want true")
+	}
+}
+
+func TestBuildRequestNoOptionalFields(t *testing.T) {
+	req := &core.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: "Hello"},
+		},
+	}
+
+	result := buildRequest(req, false)
+
+	if result.Temperature != nil {
+		t.Error("Temperature should be nil")
+	}
+
+	if result.MaxTokens != nil {
+		t.Error("MaxTokens should be nil")
+	}
+
+	if result.Tools != nil {
+		t.Error("Tools should be nil")
+	}
+}
+
+func TestMapToolsEmpty(t *testing.T) {
+	result := mapTools(nil)
+	if result != nil {
+		t.Errorf("mapTools(nil) = %v, want nil", result)
+	}
+
+	result = mapTools([]core.Tool{})
+	if result != nil {
+		t.Errorf("mapTools([]) = %v, want nil", result)
+	}
+}
+
+// mockTool implements core.Tool for testing.
+type mockTool struct {
+	name        string
+	description string
+}
+
+func (m *mockTool) Name() string        { return m.name }
+func (m *mockTool) Description() string { return m.description }
+
+func TestMapToolsBasic(t *testing.T) {
+	tools := []core.Tool{
+		&mockTool{name: "get_weather", description: "Get weather info"},
+	}
+
+	result := mapTools(tools)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+
+	if result[0].Type != "function" {
+		t.Errorf("Type = %q, want function", result[0].Type)
+	}
+
+	if result[0].Function.Name != "get_weather" {
+		t.Errorf("Function.Name = %q, want get_weather", result[0].Function.Name)
+	}
+
+	if result[0].Function.Description != "Get weather info" {
+		t.Errorf("Function.Description = %q, want 'Get weather info'", result[0].Function.Description)
+	}
+
+	// Default empty schema
+	if string(result[0].Function.Parameters) != "{}" {
+		t.Errorf("Function.Parameters = %s, want {}", result[0].Function.Parameters)
+	}
+}
+
+func TestMapResponseFormatText(t *testing.T) {
+	req := &core.ChatRequest{
+		ResponseFormat: core.ResponseFormatText,
+	}
+
+	result := mapResponseFormat(req)
+
+	if result != nil {
+		t.Errorf("mapResponseFormat(text) = %v, want nil", result)
+	}
+}
+
+func TestMapResponseFormatJSON(t *testing.T) {
+	req := &core.ChatRequest{
+		ResponseFormat: core.ResponseFormatJSON,
+	}
+
+	result := mapResponseFormat(req)
+
+	if result == nil {
+		t.Fatal("mapResponseFormat(json) = nil, want non-nil")
+	}
+
+	if result.Type != "json_object" {
+		t.Errorf("Type = %q, want json_object", result.Type)
+	}
+}
+
+func TestMapResponseFormatJSONSchema(t *testing.T) {
+	req := &core.ChatRequest{
+		ResponseFormat: core.ResponseFormatJSONSchema,
+		JSONSchema: &core.JSONSchemaDefinition{
+			Name:        "my_schema",
+			Description: "A test schema",
+			Schema:      json.RawMessage(`{"type":"object"}`),
+			Strict:      true,
+		},
+	}
+
+	result := mapResponseFormat(req)
+
+	if result == nil {
+		t.Fatal("mapResponseFormat(json_schema) = nil, want non-nil")
+	}
+
+	if result.Type != "json_schema" {
+		t.Errorf("Type = %q, want json_schema", result.Type)
+	}
+
+	if result.JSONSchema == nil {
+		t.Fatal("JSONSchema is nil")
+	}
+
+	if result.JSONSchema.Name != "my_schema" {
+		t.Errorf("JSONSchema.Name = %q, want my_schema", result.JSONSchema.Name)
+	}
+
+	if !result.JSONSchema.Strict {
+		t.Error("JSONSchema.Strict = false, want true")
+	}
+}
+
+func TestMapResponseFormatJSONSchemaNoSchema(t *testing.T) {
+	req := &core.ChatRequest{
+		ResponseFormat: core.ResponseFormatJSONSchema,
+		JSONSchema:     nil,
+	}
+
+	result := mapResponseFormat(req)
+
+	if result != nil {
+		t.Errorf("mapResponseFormat(json_schema, nil) = %v, want nil", result)
+	}
+}
+
+func TestMapUsage(t *testing.T) {
+	usage := azureUsage{
+		PromptTokens:     10,
+		CompletionTokens: 20,
+		TotalTokens:      30,
+	}
+
+	result := mapUsage(usage)
+
+	if result.PromptTokens != 10 {
+		t.Errorf("PromptTokens = %d, want 10", result.PromptTokens)
+	}
+	if result.CompletionTokens != 20 {
+		t.Errorf("CompletionTokens = %d, want 20", result.CompletionTokens)
+	}
+	if result.TotalTokens != 30 {
+		t.Errorf("TotalTokens = %d, want 30", result.TotalTokens)
+	}
+}
+
+func TestMapToolCallsFromAzureEmpty(t *testing.T) {
+	result := mapToolCallsFromAzure(nil)
+	if result != nil {
+		t.Errorf("mapToolCallsFromAzure(nil) = %v, want nil", result)
+	}
+
+	result = mapToolCallsFromAzure([]azureToolCall{})
+	if result != nil {
+		t.Errorf("mapToolCallsFromAzure([]) = %v, want nil", result)
+	}
+}
+
+func TestMapToolCallsFromAzure(t *testing.T) {
+	calls := []azureToolCall{
+		{
+			ID:   "call_abc",
+			Type: "function",
+			Function: azureFunctionCall{
+				Name:      "get_weather",
+				Arguments: `{"location":"NYC"}`,
+			},
+		},
+	}
+
+	result := mapToolCallsFromAzure(calls)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+
+	if result[0].ID != "call_abc" {
+		t.Errorf("ID = %q, want call_abc", result[0].ID)
+	}
+	if result[0].Name != "get_weather" {
+		t.Errorf("Name = %q, want get_weather", result[0].Name)
+	}
+	if string(result[0].Arguments) != `{"location":"NYC"}` {
+		t.Errorf("Arguments = %s, want {\"location\":\"NYC\"}", result[0].Arguments)
+	}
+}
+
+func TestMapToolCallsToAzure(t *testing.T) {
+	calls := []core.ToolCall{
+		{
+			ID:        "call_xyz",
+			Name:      "send_email",
+			Arguments: json.RawMessage(`{"to":"test@example.com"}`),
+		},
+	}
+
+	result := mapToolCallsToAzure(calls)
+
+	if len(result) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(result))
+	}
+
+	if result[0].ID != "call_xyz" {
+		t.Errorf("ID = %q, want call_xyz", result[0].ID)
+	}
+	if result[0].Type != "function" {
+		t.Errorf("Type = %q, want function", result[0].Type)
+	}
+	if result[0].Function.Name != "send_email" {
+		t.Errorf("Function.Name = %q, want send_email", result[0].Function.Name)
+	}
+	if result[0].Function.Arguments != `{"to":"test@example.com"}` {
+		t.Errorf("Function.Arguments = %q, want {\"to\":\"test@example.com\"}", result[0].Function.Arguments)
+	}
+}
+
+func TestMarshalToolResultContentString(t *testing.T) {
+	result := marshalToolResultContent("plain text")
+	if result != "plain text" {
+		t.Errorf("marshalToolResultContent(string) = %q, want 'plain text'", result)
+	}
+}
+
+func TestMarshalToolResultContentObject(t *testing.T) {
+	obj := map[string]interface{}{"key": "value"}
+	result := marshalToolResultContent(obj)
+
+	if result != `{"key":"value"}` {
+		t.Errorf("marshalToolResultContent(object) = %q, want {\"key\":\"value\"}", result)
+	}
+}
+
+func TestContentFiltersIsFiltered(t *testing.T) {
+	tests := []struct {
+		name    string
+		filters *azureContentFilters
+		want    bool
+	}{
+		{
+			name:    "nil filters",
+			filters: nil,
+			want:    false,
+		},
+		{
+			name:    "empty filters",
+			filters: &azureContentFilters{},
+			want:    false,
+		},
+		{
+			name: "hate filtered",
+			filters: &azureContentFilters{
+				Hate: &azureFilterSeverity{Filtered: true, Severity: "high"},
+			},
+			want: true,
+		},
+		{
+			name: "violence not filtered",
+			filters: &azureContentFilters{
+				Violence: &azureFilterSeverity{Filtered: false, Severity: "low"},
+			},
+			want: false,
+		},
+		{
+			name: "jailbreak filtered",
+			filters: &azureContentFilters{
+				Jailbreak: &azureFilterDetected{Filtered: true, Detected: true},
+			},
+			want: true,
+		},
+		{
+			name: "protected material filtered",
+			filters: &azureContentFilters{
+				ProtectedMaterialCode: &azureFilterDetected{Filtered: true, Detected: true},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.filters.IsFiltered()
+			if got != tt.want {
+				t.Errorf("IsFiltered() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapResponse(t *testing.T) {
+	resp := &azureResponse{
+		ID:    "chatcmpl-123",
+		Model: "gpt-4o",
+		Choices: []azureChoice{
+			{
+				Index: 0,
+				Message: &azureRespMsg{
+					Role:    "assistant",
+					Content: "Hello there!",
+				},
+			},
+		},
+		Usage: azureUsage{
+			PromptTokens:     5,
+			CompletionTokens: 3,
+			TotalTokens:      8,
+		},
+	}
+
+	result := mapResponse(resp)
+
+	if result.ID != "chatcmpl-123" {
+		t.Errorf("ID = %q, want chatcmpl-123", result.ID)
+	}
+	if result.Model != "gpt-4o" {
+		t.Errorf("Model = %q, want gpt-4o", result.Model)
+	}
+	if result.Output != "Hello there!" {
+		t.Errorf("Output = %q, want 'Hello there!'", result.Output)
+	}
+	if result.Usage.TotalTokens != 8 {
+		t.Errorf("Usage.TotalTokens = %d, want 8", result.Usage.TotalTokens)
+	}
+}
+
+func TestMapResponseEmpty(t *testing.T) {
+	resp := &azureResponse{
+		ID:      "chatcmpl-empty",
+		Model:   "gpt-4o",
+		Choices: []azureChoice{},
+	}
+
+	result := mapResponse(resp)
+
+	if result.ID != "chatcmpl-empty" {
+		t.Errorf("ID = %q, want chatcmpl-empty", result.ID)
+	}
+	if result.Output != "" {
+		t.Errorf("Output = %q, want empty", result.Output)
+	}
+}
+
+func TestMapResponseWithToolCalls(t *testing.T) {
+	resp := &azureResponse{
+		ID:    "chatcmpl-tools",
+		Model: "gpt-4o",
+		Choices: []azureChoice{
+			{
+				Index: 0,
+				Message: &azureRespMsg{
+					Role:    "assistant",
+					Content: "",
+					ToolCalls: []azureToolCall{
+						{
+							ID:   "call_abc",
+							Type: "function",
+							Function: azureFunctionCall{
+								Name:      "get_weather",
+								Arguments: `{"city":"NYC"}`,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := mapResponse(resp)
+
+	if len(result.ToolCalls) != 1 {
+		t.Fatalf("len(ToolCalls) = %d, want 1", len(result.ToolCalls))
+	}
+
+	tc := result.ToolCalls[0]
+	if tc.ID != "call_abc" {
+		t.Errorf("ToolCalls[0].ID = %q, want call_abc", tc.ID)
+	}
+	if tc.Name != "get_weather" {
+		t.Errorf("ToolCalls[0].Name = %q, want get_weather", tc.Name)
+	}
+}

--- a/providers/azurefoundry/models.go
+++ b/providers/azurefoundry/models.go
@@ -1,0 +1,600 @@
+package azurefoundry
+
+import "github.com/petal-labs/iris/core"
+
+// models defines the common models available through Azure AI Foundry.
+// Actual availability depends on your Azure deployment configuration.
+// These are representative models; Azure supports many more through
+// Azure OpenAI Service and the Model Inference API.
+var models = []core.ModelInfo{
+	// -------------------------------------------------------------------------
+	// OpenAI Models (via Azure OpenAI Service)
+	// -------------------------------------------------------------------------
+
+	// GPT-4o family
+	{
+		ID:          "gpt-4o",
+		DisplayName: "GPT-4o",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureStructuredOutput,
+		},
+	},
+	{
+		ID:          "gpt-4o-mini",
+		DisplayName: "GPT-4o Mini",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureStructuredOutput,
+		},
+	},
+
+	// GPT-4 family
+	{
+		ID:          "gpt-4-turbo",
+		DisplayName: "GPT-4 Turbo",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureStructuredOutput,
+		},
+	},
+	{
+		ID:          "gpt-4",
+		DisplayName: "GPT-4",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+		},
+	},
+	{
+		ID:          "gpt-4-32k",
+		DisplayName: "GPT-4 32K",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+		},
+	},
+
+	// GPT-3.5 family
+	{
+		ID:          "gpt-35-turbo",
+		DisplayName: "GPT-3.5 Turbo",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+		},
+	},
+	{
+		ID:          "gpt-35-turbo-16k",
+		DisplayName: "GPT-3.5 Turbo 16K",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+		},
+	},
+
+	// Reasoning models (o1/o3 series)
+	{
+		ID:          "o1",
+		DisplayName: "o1",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureReasoning,
+		},
+	},
+	{
+		ID:          "o1-mini",
+		DisplayName: "o1 Mini",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureReasoning,
+		},
+	},
+	{
+		ID:          "o1-preview",
+		DisplayName: "o1 Preview",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureReasoning,
+		},
+	},
+	{
+		ID:          "o3-mini",
+		DisplayName: "o3 Mini",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureReasoning,
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// OpenAI Embedding Models
+	// -------------------------------------------------------------------------
+	{
+		ID:          "text-embedding-3-large",
+		DisplayName: "Text Embedding 3 Large",
+		Capabilities: []core.Feature{
+			core.FeatureEmbeddings,
+		},
+	},
+	{
+		ID:          "text-embedding-3-small",
+		DisplayName: "Text Embedding 3 Small",
+		Capabilities: []core.Feature{
+			core.FeatureEmbeddings,
+		},
+	},
+	{
+		ID:          "text-embedding-ada-002",
+		DisplayName: "Text Embedding Ada 002",
+		Capabilities: []core.Feature{
+			core.FeatureEmbeddings,
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// Meta Llama Models (via Model Inference API)
+	// -------------------------------------------------------------------------
+
+	// Llama 3.1 family
+	{
+		ID:          "Meta-Llama-3.1-405B-Instruct",
+		DisplayName: "Llama 3.1 405B Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+		},
+	},
+	{
+		ID:          "Meta-Llama-3.1-70B-Instruct",
+		DisplayName: "Llama 3.1 70B Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+		},
+	},
+	{
+		ID:          "Meta-Llama-3.1-8B-Instruct",
+		DisplayName: "Llama 3.1 8B Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+
+	// Llama 3.2 family
+	{
+		ID:          "Llama-3.2-90B-Vision-Instruct",
+		DisplayName: "Llama 3.2 90B Vision Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Llama-3.2-11B-Vision-Instruct",
+		DisplayName: "Llama 3.2 11B Vision Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Llama-3.2-3B-Instruct",
+		DisplayName: "Llama 3.2 3B Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Llama-3.2-1B-Instruct",
+		DisplayName: "Llama 3.2 1B Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+
+	// Llama 3.3 family
+	{
+		ID:          "Llama-3.3-70B-Instruct",
+		DisplayName: "Llama 3.3 70B Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// Mistral Models (via Model Inference API)
+	// -------------------------------------------------------------------------
+	{
+		ID:          "Mistral-Large-2411",
+		DisplayName: "Mistral Large (Nov 2024)",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+		},
+	},
+	{
+		ID:          "Mistral-Large-2407",
+		DisplayName: "Mistral Large (Jul 2024)",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+		},
+	},
+	{
+		ID:          "Mistral-Small-2409",
+		DisplayName: "Mistral Small (Sep 2024)",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Mistral-Nemo-2407",
+		DisplayName: "Mistral Nemo (Jul 2024)",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Ministral-3B-2410",
+		DisplayName: "Ministral 3B (Oct 2024)",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// Cohere Models (via Model Inference API)
+	// -------------------------------------------------------------------------
+	{
+		ID:          "Cohere-command-r-plus",
+		DisplayName: "Cohere Command R+",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+		},
+	},
+	{
+		ID:          "Cohere-command-r",
+		DisplayName: "Cohere Command R",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Cohere-command-r-08-2024",
+		DisplayName: "Cohere Command R (Aug 2024)",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Cohere-command-r-plus-08-2024",
+		DisplayName: "Cohere Command R+ (Aug 2024)",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+		},
+	},
+
+	// Cohere embedding models
+	{
+		ID:          "Cohere-embed-v3-english",
+		DisplayName: "Cohere Embed v3 English",
+		Capabilities: []core.Feature{
+			core.FeatureEmbeddings,
+		},
+	},
+	{
+		ID:          "Cohere-embed-v3-multilingual",
+		DisplayName: "Cohere Embed v3 Multilingual",
+		Capabilities: []core.Feature{
+			core.FeatureEmbeddings,
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// DeepSeek Models (via Model Inference API)
+	// -------------------------------------------------------------------------
+	{
+		ID:          "DeepSeek-V3",
+		DisplayName: "DeepSeek V3",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureReasoning,
+		},
+	},
+	{
+		ID:          "DeepSeek-R1",
+		DisplayName: "DeepSeek R1",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureReasoning,
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// Microsoft Phi Models (via Model Inference API)
+	// -------------------------------------------------------------------------
+	{
+		ID:          "Phi-4",
+		DisplayName: "Phi-4",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Phi-3.5-mini-instruct",
+		DisplayName: "Phi-3.5 Mini Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Phi-3.5-MoE-instruct",
+		DisplayName: "Phi-3.5 MoE Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Phi-3.5-vision-instruct",
+		DisplayName: "Phi-3.5 Vision Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Phi-3-mini-4k-instruct",
+		DisplayName: "Phi-3 Mini 4K Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Phi-3-mini-128k-instruct",
+		DisplayName: "Phi-3 Mini 128K Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Phi-3-small-8k-instruct",
+		DisplayName: "Phi-3 Small 8K Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Phi-3-small-128k-instruct",
+		DisplayName: "Phi-3 Small 128K Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Phi-3-medium-4k-instruct",
+		DisplayName: "Phi-3 Medium 4K Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "Phi-3-medium-128k-instruct",
+		DisplayName: "Phi-3 Medium 128K Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// AI21 Labs Models (via Model Inference API)
+	// -------------------------------------------------------------------------
+	{
+		ID:          "AI21-Jamba-1.5-Large",
+		DisplayName: "AI21 Jamba 1.5 Large",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "AI21-Jamba-1.5-Mini",
+		DisplayName: "AI21 Jamba 1.5 Mini",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+	{
+		ID:          "jamba-instruct",
+		DisplayName: "AI21 Jamba Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// JAIS Models (via Model Inference API) - Arabic/English bilingual
+	// -------------------------------------------------------------------------
+	{
+		ID:          "jais-30b-chat",
+		DisplayName: "JAIS 30B Chat",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// NVIDIA Models (via Model Inference API)
+	// -------------------------------------------------------------------------
+	{
+		ID:          "Nemotron-4-340B-Instruct",
+		DisplayName: "Nemotron 4 340B Instruct",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+		},
+	},
+}
+
+// GetModelInfo returns the model info for a given model ID, or nil if not found.
+func GetModelInfo(id core.ModelID) *core.ModelInfo {
+	for i := range models {
+		if models[i].ID == id {
+			return &models[i]
+		}
+	}
+	return nil
+}
+
+// ListModels returns all available model definitions.
+func ListModels() []core.ModelInfo {
+	result := make([]core.ModelInfo, len(models))
+	copy(result, models)
+	return result
+}
+
+// ListChatModels returns all models that support chat completions.
+func ListChatModels() []core.ModelInfo {
+	var result []core.ModelInfo
+	for _, m := range models {
+		if m.HasCapability(core.FeatureChat) {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// ListStreamingModels returns all models that support streaming.
+func ListStreamingModels() []core.ModelInfo {
+	var result []core.ModelInfo
+	for _, m := range models {
+		if m.HasCapability(core.FeatureChatStreaming) {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// ListEmbeddingModels returns all models that support embeddings.
+func ListEmbeddingModels() []core.ModelInfo {
+	var result []core.ModelInfo
+	for _, m := range models {
+		if m.HasCapability(core.FeatureEmbeddings) {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// ListToolCallingModels returns all models that support tool calling.
+func ListToolCallingModels() []core.ModelInfo {
+	var result []core.ModelInfo
+	for _, m := range models {
+		if m.HasCapability(core.FeatureToolCalling) {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// ListReasoningModels returns all models that support extended reasoning.
+func ListReasoningModels() []core.ModelInfo {
+	var result []core.ModelInfo
+	for _, m := range models {
+		if m.HasCapability(core.FeatureReasoning) {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// ModelsByCapability returns all models that have the specified capability.
+func ModelsByCapability(capability core.Feature) []core.ModelInfo {
+	var result []core.ModelInfo
+	for _, m := range models {
+		if m.HasCapability(capability) {
+			result = append(result, m)
+		}
+	}
+	return result
+}
+
+// SupportsCapability checks if a model supports a specific capability.
+func SupportsCapability(id core.ModelID, capability core.Feature) bool {
+	info := GetModelInfo(id)
+	if info == nil {
+		return false
+	}
+	return info.HasCapability(capability)
+}
+
+// IsEmbeddingModel returns true if the model is an embedding model.
+func IsEmbeddingModel(id core.ModelID) bool {
+	return SupportsCapability(id, core.FeatureEmbeddings)
+}
+
+// IsChatModel returns true if the model supports chat completions.
+func IsChatModel(id core.ModelID) bool {
+	return SupportsCapability(id, core.FeatureChat)
+}
+
+// IsReasoningModel returns true if the model supports extended reasoning.
+func IsReasoningModel(id core.ModelID) bool {
+	return SupportsCapability(id, core.FeatureReasoning)
+}
+
+// SupportsToolCalling returns true if the model supports tool calling.
+func SupportsToolCalling(id core.ModelID) bool {
+	return SupportsCapability(id, core.FeatureToolCalling)
+}
+
+// SupportsStructuredOutput returns true if the model supports structured output.
+func SupportsStructuredOutput(id core.ModelID) bool {
+	return SupportsCapability(id, core.FeatureStructuredOutput)
+}

--- a/providers/azurefoundry/models_test.go
+++ b/providers/azurefoundry/models_test.go
@@ -1,0 +1,381 @@
+package azurefoundry
+
+import (
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestGetModelInfo(t *testing.T) {
+	info := GetModelInfo("gpt-4o")
+	if info == nil {
+		t.Fatal("GetModelInfo(gpt-4o) returned nil")
+	}
+	if info.ID != "gpt-4o" {
+		t.Errorf("ID = %q, want gpt-4o", info.ID)
+	}
+	if info.DisplayName != "GPT-4o" {
+		t.Errorf("DisplayName = %q, want GPT-4o", info.DisplayName)
+	}
+}
+
+func TestGetModelInfoUnknown(t *testing.T) {
+	info := GetModelInfo("unknown-model")
+	if info != nil {
+		t.Errorf("GetModelInfo(unknown) = %v, want nil", info)
+	}
+}
+
+func TestListModels(t *testing.T) {
+	models := ListModels()
+
+	if len(models) < 40 {
+		t.Errorf("ListModels() returned %d models, want at least 40", len(models))
+	}
+
+	// Verify it returns a copy
+	original := ListModels()
+	models[0].DisplayName = "modified"
+	if original[0].DisplayName == "modified" {
+		t.Error("ListModels() did not return a copy")
+	}
+}
+
+func TestListChatModels(t *testing.T) {
+	models := ListChatModels()
+
+	if len(models) == 0 {
+		t.Error("ListChatModels() returned empty list")
+	}
+
+	for _, m := range models {
+		if !m.HasCapability(core.FeatureChat) {
+			t.Errorf("Model %s in ListChatModels() does not have FeatureChat", m.ID)
+		}
+	}
+}
+
+func TestListStreamingModels(t *testing.T) {
+	models := ListStreamingModels()
+
+	if len(models) == 0 {
+		t.Error("ListStreamingModels() returned empty list")
+	}
+
+	for _, m := range models {
+		if !m.HasCapability(core.FeatureChatStreaming) {
+			t.Errorf("Model %s in ListStreamingModels() does not have FeatureChatStreaming", m.ID)
+		}
+	}
+}
+
+func TestListEmbeddingModels(t *testing.T) {
+	models := ListEmbeddingModels()
+
+	if len(models) < 5 {
+		t.Errorf("ListEmbeddingModels() returned %d models, want at least 5", len(models))
+	}
+
+	for _, m := range models {
+		if !m.HasCapability(core.FeatureEmbeddings) {
+			t.Errorf("Model %s in ListEmbeddingModels() does not have FeatureEmbeddings", m.ID)
+		}
+	}
+
+	// Check for known embedding models
+	found := make(map[core.ModelID]bool)
+	for _, m := range models {
+		found[m.ID] = true
+	}
+
+	if !found["text-embedding-3-large"] {
+		t.Error("ListEmbeddingModels() missing text-embedding-3-large")
+	}
+	if !found["text-embedding-3-small"] {
+		t.Error("ListEmbeddingModels() missing text-embedding-3-small")
+	}
+	if !found["Cohere-embed-v3-english"] {
+		t.Error("ListEmbeddingModels() missing Cohere-embed-v3-english")
+	}
+}
+
+func TestListToolCallingModels(t *testing.T) {
+	models := ListToolCallingModels()
+
+	if len(models) < 10 {
+		t.Errorf("ListToolCallingModels() returned %d models, want at least 10", len(models))
+	}
+
+	for _, m := range models {
+		if !m.HasCapability(core.FeatureToolCalling) {
+			t.Errorf("Model %s in ListToolCallingModels() does not have FeatureToolCalling", m.ID)
+		}
+	}
+}
+
+func TestListReasoningModels(t *testing.T) {
+	models := ListReasoningModels()
+
+	if len(models) < 4 {
+		t.Errorf("ListReasoningModels() returned %d models, want at least 4", len(models))
+	}
+
+	for _, m := range models {
+		if !m.HasCapability(core.FeatureReasoning) {
+			t.Errorf("Model %s in ListReasoningModels() does not have FeatureReasoning", m.ID)
+		}
+	}
+
+	// Check for known reasoning models
+	found := make(map[core.ModelID]bool)
+	for _, m := range models {
+		found[m.ID] = true
+	}
+
+	if !found["o1"] {
+		t.Error("ListReasoningModels() missing o1")
+	}
+	if !found["o1-mini"] {
+		t.Error("ListReasoningModels() missing o1-mini")
+	}
+	if !found["DeepSeek-R1"] {
+		t.Error("ListReasoningModels() missing DeepSeek-R1")
+	}
+}
+
+func TestModelsByCapability(t *testing.T) {
+	models := ModelsByCapability(core.FeatureStructuredOutput)
+
+	if len(models) < 3 {
+		t.Errorf("ModelsByCapability(StructuredOutput) returned %d models, want at least 3", len(models))
+	}
+
+	for _, m := range models {
+		if !m.HasCapability(core.FeatureStructuredOutput) {
+			t.Errorf("Model %s returned by ModelsByCapability does not have requested capability", m.ID)
+		}
+	}
+}
+
+func TestSupportsCapability(t *testing.T) {
+	tests := []struct {
+		model      core.ModelID
+		capability core.Feature
+		want       bool
+	}{
+		{"gpt-4o", core.FeatureChat, true},
+		{"gpt-4o", core.FeatureToolCalling, true},
+		{"gpt-4o", core.FeatureStructuredOutput, true},
+		{"gpt-4o", core.FeatureEmbeddings, false},
+		{"text-embedding-3-large", core.FeatureEmbeddings, true},
+		{"text-embedding-3-large", core.FeatureChat, false},
+		{"o1", core.FeatureReasoning, true},
+		{"o1", core.FeatureToolCalling, false},
+		{"unknown-model", core.FeatureChat, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.model)+"_"+string(tt.capability), func(t *testing.T) {
+			got := SupportsCapability(tt.model, tt.capability)
+			if got != tt.want {
+				t.Errorf("SupportsCapability(%q, %q) = %v, want %v", tt.model, tt.capability, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsEmbeddingModel(t *testing.T) {
+	tests := []struct {
+		model core.ModelID
+		want  bool
+	}{
+		{"text-embedding-3-large", true},
+		{"text-embedding-3-small", true},
+		{"text-embedding-ada-002", true},
+		{"Cohere-embed-v3-english", true},
+		{"gpt-4o", false},
+		{"o1", false},
+		{"unknown", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.model), func(t *testing.T) {
+			got := IsEmbeddingModel(tt.model)
+			if got != tt.want {
+				t.Errorf("IsEmbeddingModel(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsChatModel(t *testing.T) {
+	tests := []struct {
+		model core.ModelID
+		want  bool
+	}{
+		{"gpt-4o", true},
+		{"gpt-4o-mini", true},
+		{"Meta-Llama-3.1-70B-Instruct", true},
+		{"Mistral-Large-2411", true},
+		{"text-embedding-3-large", false},
+		{"unknown", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.model), func(t *testing.T) {
+			got := IsChatModel(tt.model)
+			if got != tt.want {
+				t.Errorf("IsChatModel(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsReasoningModel(t *testing.T) {
+	tests := []struct {
+		model core.ModelID
+		want  bool
+	}{
+		{"o1", true},
+		{"o1-mini", true},
+		{"o1-preview", true},
+		{"o3-mini", true},
+		{"DeepSeek-V3", true},
+		{"DeepSeek-R1", true},
+		{"gpt-4o", false},
+		{"text-embedding-3-large", false},
+		{"unknown", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.model), func(t *testing.T) {
+			got := IsReasoningModel(tt.model)
+			if got != tt.want {
+				t.Errorf("IsReasoningModel(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSupportsToolCalling(t *testing.T) {
+	tests := []struct {
+		model core.ModelID
+		want  bool
+	}{
+		{"gpt-4o", true},
+		{"gpt-4o-mini", true},
+		{"gpt-4-turbo", true},
+		{"Meta-Llama-3.1-405B-Instruct", true},
+		{"Cohere-command-r-plus", true},
+		{"o1", false}, // Reasoning models typically don't support tool calling
+		{"text-embedding-3-large", false},
+		{"Phi-4", false},
+		{"unknown", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.model), func(t *testing.T) {
+			got := SupportsToolCalling(tt.model)
+			if got != tt.want {
+				t.Errorf("SupportsToolCalling(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSupportsStructuredOutput(t *testing.T) {
+	tests := []struct {
+		model core.ModelID
+		want  bool
+	}{
+		{"gpt-4o", true},
+		{"gpt-4o-mini", true},
+		{"gpt-4-turbo", true},
+		{"gpt-4", false}, // Older GPT-4 doesn't have structured output
+		{"gpt-35-turbo", false},
+		{"text-embedding-3-large", false},
+		{"unknown", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.model), func(t *testing.T) {
+			got := SupportsStructuredOutput(tt.model)
+			if got != tt.want {
+				t.Errorf("SupportsStructuredOutput(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAllModelsHaveCapabilities(t *testing.T) {
+	models := ListModels()
+
+	for _, m := range models {
+		if len(m.Capabilities) == 0 {
+			t.Errorf("Model %s has no capabilities", m.ID)
+		}
+	}
+}
+
+func TestAllModelsHaveDisplayName(t *testing.T) {
+	models := ListModels()
+
+	for _, m := range models {
+		if m.DisplayName == "" {
+			t.Errorf("Model %s has empty DisplayName", m.ID)
+		}
+	}
+}
+
+func TestNoDuplicateModelIDs(t *testing.T) {
+	models := ListModels()
+	seen := make(map[core.ModelID]bool)
+
+	for _, m := range models {
+		if seen[m.ID] {
+			t.Errorf("Duplicate model ID: %s", m.ID)
+		}
+		seen[m.ID] = true
+	}
+}
+
+func TestKnownModelsExist(t *testing.T) {
+	knownModels := []core.ModelID{
+		// OpenAI
+		"gpt-4o",
+		"gpt-4o-mini",
+		"gpt-4-turbo",
+		"gpt-4",
+		"gpt-35-turbo",
+		"o1",
+		"o1-mini",
+		"o3-mini",
+		// Embeddings
+		"text-embedding-3-large",
+		"text-embedding-3-small",
+		"text-embedding-ada-002",
+		// Llama
+		"Meta-Llama-3.1-405B-Instruct",
+		"Meta-Llama-3.1-70B-Instruct",
+		"Llama-3.3-70B-Instruct",
+		// Mistral
+		"Mistral-Large-2411",
+		"Mistral-Small-2409",
+		// Cohere
+		"Cohere-command-r-plus",
+		"Cohere-embed-v3-english",
+		// DeepSeek
+		"DeepSeek-V3",
+		"DeepSeek-R1",
+		// Phi
+		"Phi-4",
+		"Phi-3.5-mini-instruct",
+	}
+
+	for _, id := range knownModels {
+		info := GetModelInfo(id)
+		if info == nil {
+			t.Errorf("Known model %s not found", id)
+		}
+	}
+}

--- a/providers/azurefoundry/options.go
+++ b/providers/azurefoundry/options.go
@@ -1,0 +1,136 @@
+package azurefoundry
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+)
+
+// Config holds configuration for the Azure AI Foundry provider.
+type Config struct {
+	// APIKey is the Azure API key (required if not using Entra ID).
+	// Stored as Secret to prevent accidental logging.
+	APIKey core.Secret
+
+	// Endpoint is the Azure resource endpoint (required).
+	// Format: https://{resource}.services.ai.azure.com or
+	//         https://{resource}.openai.azure.com
+	Endpoint string
+
+	// DeploymentID is the model deployment name.
+	// Required when using UseOpenAIEndpoint, optional for Model Inference API.
+	DeploymentID string
+
+	// APIVersion is the API version string.
+	// Defaults to DefaultAPIVersion.
+	APIVersion string
+
+	// HTTPClient is the HTTP client to use.
+	// Defaults to http.DefaultClient.
+	HTTPClient *http.Client
+
+	// TokenCredential provides Entra ID tokens (alternative to APIKey).
+	// When set, APIKey is ignored and Bearer token auth is used.
+	TokenCredential TokenCredential
+
+	// Headers contains optional extra headers to include in requests.
+	Headers http.Header
+
+	// Timeout is the optional request timeout.
+	// If set, requests will be cancelled after this duration.
+	Timeout time.Duration
+
+	// UseOpenAIEndpoint uses the Azure OpenAI endpoint format instead of
+	// the Model Inference API:
+	//   /openai/deployments/{deployment-id}/chat/completions
+	// instead of:
+	//   /models/chat/completions
+	UseOpenAIEndpoint bool
+}
+
+// DefaultAPIVersion is the default API version for the Model Inference API.
+const DefaultAPIVersion = "2024-05-01-preview"
+
+// DefaultOpenAIAPIVersion is the default API version for Azure OpenAI endpoints.
+const DefaultOpenAIAPIVersion = "2024-10-21"
+
+// Option configures the Azure AI Foundry provider.
+type Option func(*Config)
+
+// WithAPIVersion sets the API version.
+// Defaults to "2024-05-01-preview" for Model Inference API
+// or "2024-10-21" for Azure OpenAI endpoints.
+func WithAPIVersion(version string) Option {
+	return func(c *Config) {
+		c.APIVersion = version
+	}
+}
+
+// WithDeploymentID sets a default deployment ID for requests.
+// Required when using WithOpenAIEndpoint(), optional otherwise.
+// The deployment ID corresponds to your model deployment name in Azure.
+func WithDeploymentID(id string) Option {
+	return func(c *Config) {
+		c.DeploymentID = id
+	}
+}
+
+// WithHTTPClient sets a custom HTTP client.
+// Use this to configure custom timeouts, transport settings, or proxies.
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *Config) {
+		c.HTTPClient = client
+	}
+}
+
+// WithHeader adds an extra header to include in all requests.
+// Can be called multiple times to add multiple headers.
+func WithHeader(key, value string) Option {
+	return func(c *Config) {
+		if c.Headers == nil {
+			c.Headers = make(http.Header)
+		}
+		c.Headers.Set(key, value)
+	}
+}
+
+// WithTimeout sets the request timeout.
+// Requests will be cancelled after this duration.
+func WithTimeout(d time.Duration) Option {
+	return func(c *Config) {
+		c.Timeout = d
+	}
+}
+
+// WithOpenAIEndpoint configures the provider to use the Azure OpenAI
+// endpoint format instead of the Model Inference API.
+//
+// Azure OpenAI endpoint format:
+//
+//	POST https://{resource}.openai.azure.com/openai/deployments/{deployment-id}/chat/completions?api-version=2024-10-21
+//
+// Model Inference API format (default):
+//
+//	POST https://{resource}.services.ai.azure.com/models/chat/completions?api-version=2024-05-01-preview
+//
+// Use this option when you need Azure OpenAI-specific features or when
+// your deployment is configured through the Azure OpenAI Service.
+func WithOpenAIEndpoint() Option {
+	return func(c *Config) {
+		c.UseOpenAIEndpoint = true
+	}
+}
+
+// WithTokenCredential sets a token credential for Entra ID authentication.
+// When set, the APIKey is ignored and Bearer token authentication is used.
+//
+// Example with azure-identity:
+//
+//	cred, _ := azidentity.NewDefaultAzureCredential(nil)
+//	provider := azurefoundry.New(endpoint, "", azurefoundry.WithTokenCredential(cred))
+func WithTokenCredential(credential TokenCredential) Option {
+	return func(c *Config) {
+		c.TokenCredential = credential
+	}
+}

--- a/providers/azurefoundry/provider.go
+++ b/providers/azurefoundry/provider.go
@@ -1,0 +1,228 @@
+package azurefoundry
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/petal-labs/iris/core"
+)
+
+// Environment variable names for configuration.
+const (
+	// EnvEndpoint is the environment variable for the Azure endpoint.
+	EnvEndpoint = "AZURE_AI_ENDPOINT"
+	// EnvAPIKey is the environment variable for the Azure API key.
+	EnvAPIKey = "AZURE_AI_API_KEY"
+	// EnvDeploymentID is the optional environment variable for deployment ID.
+	EnvDeploymentID = "AZURE_AI_DEPLOYMENT_ID"
+)
+
+// Sentinel errors.
+var (
+	// ErrEndpointNotFound is returned when the endpoint environment variable is not set.
+	ErrEndpointNotFound = errors.New("azurefoundry: AZURE_AI_ENDPOINT environment variable not set")
+	// ErrAPIKeyNotFound is returned when the API key environment variable is not set.
+	ErrAPIKeyNotFound = errors.New("azurefoundry: AZURE_AI_API_KEY environment variable not set")
+	// ErrNoAuth is returned when neither API key nor token credential is configured.
+	ErrNoAuth = errors.New("azurefoundry: no authentication configured (provide API key or token credential)")
+	// ErrDeploymentRequired is returned when deployment ID is required but not set.
+	ErrDeploymentRequired = errors.New("azurefoundry: deployment ID required when using OpenAI endpoint format")
+)
+
+// AzureFoundry is an LLM provider implementation for Azure AI Foundry.
+// AzureFoundry is safe for concurrent use.
+type AzureFoundry struct {
+	config     Config
+	tokenCache *tokenCache
+}
+
+// New creates a new Azure AI Foundry provider with API key authentication.
+//
+// Example:
+//
+//	provider := azurefoundry.New(
+//	    "https://my-resource.services.ai.azure.com",
+//	    "my-api-key",
+//	)
+//	client := core.NewClient(provider)
+func New(endpoint, apiKey string, opts ...Option) *AzureFoundry {
+	cfg := Config{
+		Endpoint:   normalizeEndpoint(endpoint),
+		APIKey:     core.NewSecret(apiKey),
+		APIVersion: DefaultAPIVersion,
+		HTTPClient: http.DefaultClient,
+	}
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	// Adjust default API version for OpenAI endpoint format
+	if cfg.UseOpenAIEndpoint && cfg.APIVersion == DefaultAPIVersion {
+		cfg.APIVersion = DefaultOpenAIAPIVersion
+	}
+
+	return &AzureFoundry{config: cfg}
+}
+
+// NewFromEnv creates a provider using environment variables:
+//   - AZURE_AI_ENDPOINT: The Azure resource endpoint (required)
+//   - AZURE_AI_API_KEY: The API key (required)
+//   - AZURE_AI_DEPLOYMENT_ID: The deployment ID (optional)
+//
+// Example:
+//
+//	provider, err := azurefoundry.NewFromEnv()
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func NewFromEnv(opts ...Option) (*AzureFoundry, error) {
+	endpoint := os.Getenv(EnvEndpoint)
+	if endpoint == "" {
+		return nil, ErrEndpointNotFound
+	}
+
+	apiKey := os.Getenv(EnvAPIKey)
+	if apiKey == "" {
+		return nil, ErrAPIKeyNotFound
+	}
+
+	// Check for optional deployment ID
+	if deploymentID := os.Getenv(EnvDeploymentID); deploymentID != "" {
+		opts = append([]Option{WithDeploymentID(deploymentID)}, opts...)
+	}
+
+	return New(endpoint, apiKey, opts...), nil
+}
+
+// NewWithCredential creates a provider with Entra ID (Azure AD) authentication.
+// The credential must implement the TokenCredential interface, which is compatible
+// with azure-sdk-for-go's azcore.TokenCredential.
+//
+// Example with azure-identity:
+//
+//	cred, err := azidentity.NewDefaultAzureCredential(nil)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	provider := azurefoundry.NewWithCredential(
+//	    "https://my-resource.services.ai.azure.com",
+//	    cred,
+//	)
+func NewWithCredential(endpoint string, credential TokenCredential, opts ...Option) *AzureFoundry {
+	cfg := Config{
+		Endpoint:        normalizeEndpoint(endpoint),
+		TokenCredential: credential,
+		APIVersion:      DefaultAPIVersion,
+		HTTPClient:      http.DefaultClient,
+	}
+
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	// Adjust default API version for OpenAI endpoint format
+	if cfg.UseOpenAIEndpoint && cfg.APIVersion == DefaultAPIVersion {
+		cfg.APIVersion = DefaultOpenAIAPIVersion
+	}
+
+	p := &AzureFoundry{config: cfg}
+	if credential != nil {
+		p.tokenCache = newTokenCache(credential)
+	}
+
+	return p
+}
+
+// ID returns the provider identifier.
+func (p *AzureFoundry) ID() string {
+	return "azurefoundry"
+}
+
+// Models returns the list of available models.
+// Azure AI Foundry supports various models depending on your deployment.
+// This returns common models; actual availability depends on your Azure configuration.
+func (p *AzureFoundry) Models() []core.ModelInfo {
+	result := make([]core.ModelInfo, len(models))
+	copy(result, models)
+	return result
+}
+
+// Supports reports whether the provider supports the given feature.
+func (p *AzureFoundry) Supports(feature core.Feature) bool {
+	switch feature {
+	case core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling,
+		core.FeatureEmbeddings, core.FeatureStructuredOutput, core.FeatureReasoning:
+		return true
+	default:
+		return false
+	}
+}
+
+// buildHeaders constructs the HTTP headers for an API request.
+func (p *AzureFoundry) buildHeaders(ctx context.Context) (http.Header, error) {
+	headers := make(http.Header)
+	headers.Set("Content-Type", "application/json")
+
+	// Authentication: prefer token credential over API key
+	if p.tokenCache != nil {
+		token, err := p.tokenCache.getToken(ctx)
+		if err != nil {
+			return nil, err
+		}
+		headers.Set("Authorization", "Bearer "+token)
+	} else if !p.config.APIKey.IsEmpty() {
+		headers.Set("api-key", p.config.APIKey.Expose())
+	} else {
+		return nil, ErrNoAuth
+	}
+
+	// Copy any extra headers
+	for key, values := range p.config.Headers {
+		for _, v := range values {
+			headers.Add(key, v)
+		}
+	}
+
+	return headers, nil
+}
+
+// buildChatURL constructs the URL for chat completions.
+func (p *AzureFoundry) buildChatURL(model core.ModelID) (string, error) {
+	if p.config.UseOpenAIEndpoint {
+		// Azure OpenAI format: /openai/deployments/{deployment-id}/chat/completions
+		deploymentID := p.config.DeploymentID
+		if deploymentID == "" {
+			deploymentID = string(model)
+		}
+		if deploymentID == "" {
+			return "", ErrDeploymentRequired
+		}
+		return p.config.Endpoint + "/openai/deployments/" + deploymentID +
+			"/chat/completions?api-version=" + p.config.APIVersion, nil
+	}
+
+	// Model Inference API format: /models/chat/completions
+	return p.config.Endpoint + "/models/chat/completions?api-version=" + p.config.APIVersion, nil
+}
+
+// Chat sends a non-streaming chat request.
+func (p *AzureFoundry) Chat(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	return p.doChat(ctx, req)
+}
+
+// StreamChat sends a streaming chat request.
+func (p *AzureFoundry) StreamChat(ctx context.Context, req *core.ChatRequest) (*core.ChatStream, error) {
+	return p.doStreamChat(ctx, req)
+}
+
+// normalizeEndpoint removes trailing slashes from the endpoint URL.
+func normalizeEndpoint(endpoint string) string {
+	return strings.TrimRight(endpoint, "/")
+}
+
+// Compile-time check that AzureFoundry implements Provider.
+var _ core.Provider = (*AzureFoundry)(nil)

--- a/providers/azurefoundry/provider_test.go
+++ b/providers/azurefoundry/provider_test.go
@@ -14,7 +14,6 @@ func TestAzureFoundryImplementsProvider(t *testing.T) {
 	var _ core.Provider = p
 }
 
-
 func TestAzureFoundryImplementsEmbeddingProvider(t *testing.T) {
 	p := New("https://test.openai.azure.com", "test-key")
 	var _ core.EmbeddingProvider = p

--- a/providers/azurefoundry/provider_test.go
+++ b/providers/azurefoundry/provider_test.go
@@ -1,0 +1,356 @@
+package azurefoundry
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestAzureFoundryImplementsProvider(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key")
+	var _ core.Provider = p
+}
+
+
+func TestAzureFoundryImplementsEmbeddingProvider(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key")
+	var _ core.EmbeddingProvider = p
+}
+
+func TestID(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key")
+
+	if p.ID() != "azurefoundry" {
+		t.Errorf("ID() = %q, want %q", p.ID(), "azurefoundry")
+	}
+}
+
+func TestModels(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key")
+	models := p.Models()
+
+	if len(models) < 10 {
+		t.Errorf("Models() returned %d models, want at least 10", len(models))
+	}
+
+	// Check for required models
+	modelIDs := make(map[core.ModelID]bool)
+	for _, m := range models {
+		modelIDs[m.ID] = true
+	}
+
+	if !modelIDs["gpt-4o"] {
+		t.Error("Models() missing gpt-4o")
+	}
+
+	if !modelIDs["gpt-4o-mini"] {
+		t.Error("Models() missing gpt-4o-mini")
+	}
+
+	if !modelIDs["text-embedding-3-large"] {
+		t.Error("Models() missing text-embedding-3-large")
+	}
+}
+
+func TestModelsReturnsCopy(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key")
+	models1 := p.Models()
+	models2 := p.Models()
+
+	if len(models1) > 0 {
+		models1[0].DisplayName = "modified"
+	}
+
+	if models2[0].DisplayName == "modified" {
+		t.Error("Models() did not return a copy")
+	}
+}
+
+func TestModelsHaveCapabilities(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key")
+	models := p.Models()
+
+	for _, m := range models {
+		if len(m.Capabilities) == 0 {
+			t.Errorf("Model %s has no capabilities", m.ID)
+		}
+	}
+}
+
+func TestSupportsChat(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key")
+
+	if !p.Supports(core.FeatureChat) {
+		t.Error("Supports(FeatureChat) = false, want true")
+	}
+}
+
+func TestSupportsChatStreaming(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key")
+
+	if !p.Supports(core.FeatureChatStreaming) {
+		t.Error("Supports(FeatureChatStreaming) = false, want true")
+	}
+}
+
+func TestProviderSupportsToolCalling(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key")
+
+	if !p.Supports(core.FeatureToolCalling) {
+		t.Error("Supports(FeatureToolCalling) = false, want true")
+	}
+}
+
+func TestSupportsEmbeddings(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key")
+
+	if !p.Supports(core.FeatureEmbeddings) {
+		t.Error("Supports(FeatureEmbeddings) = false, want true")
+	}
+}
+
+func TestProviderSupportsStructuredOutput(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key")
+
+	if !p.Supports(core.FeatureStructuredOutput) {
+		t.Error("Supports(FeatureStructuredOutput) = false, want true")
+	}
+}
+
+func TestSupportsReasoning(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key")
+
+	if !p.Supports(core.FeatureReasoning) {
+		t.Error("Supports(FeatureReasoning) = false, want true")
+	}
+}
+
+func TestSupportsUnknownFeature(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key")
+
+	if p.Supports(core.Feature("unknown_feature")) {
+		t.Error("Supports(unknown) = true, want false")
+	}
+}
+
+func TestNewWithEndpointAndKey(t *testing.T) {
+	p := New("https://my-resource.openai.azure.com", "my-api-key")
+
+	if p.config.Endpoint != "https://my-resource.openai.azure.com" {
+		t.Errorf("Endpoint = %q, want %q", p.config.Endpoint, "https://my-resource.openai.azure.com")
+	}
+
+	if p.config.APIKey.Expose() != "my-api-key" {
+		t.Errorf("APIKey = %q, want %q", p.config.APIKey.Expose(), "my-api-key")
+	}
+}
+
+func TestNewWithCredential(t *testing.T) {
+	cred := &mockCredential{token: "mock-token"}
+	p := NewWithCredential("https://my-resource.openai.azure.com", cred)
+
+	if p.config.TokenCredential == nil {
+		t.Error("TokenCredential is nil")
+	}
+}
+
+func TestNewWithOptions(t *testing.T) {
+	customClient := &http.Client{Timeout: 5 * time.Second}
+	p := New("https://test.openai.azure.com", "test-key",
+		WithHTTPClient(customClient),
+		WithAPIVersion("2024-06-01"),
+		WithDeploymentID("my-deployment"),
+		WithTimeout(30*time.Second),
+		WithHeader("X-Custom-Header", "custom-value"),
+	)
+
+	if p.config.HTTPClient != customClient {
+		t.Error("HTTPClient not set correctly")
+	}
+
+	if p.config.APIVersion != "2024-06-01" {
+		t.Errorf("APIVersion = %q, want %q", p.config.APIVersion, "2024-06-01")
+	}
+
+	if p.config.DeploymentID != "my-deployment" {
+		t.Errorf("DeploymentID = %q, want %q", p.config.DeploymentID, "my-deployment")
+	}
+
+	if p.config.Timeout != 30*time.Second {
+		t.Errorf("Timeout = %v, want %v", p.config.Timeout, 30*time.Second)
+	}
+
+	if p.config.Headers.Get("X-Custom-Header") != "custom-value" {
+		t.Errorf("Custom header not set correctly")
+	}
+}
+
+func TestWithUseOpenAIEndpoint(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key", WithOpenAIEndpoint())
+
+	if !p.config.UseOpenAIEndpoint {
+		t.Error("UseOpenAIEndpoint = false, want true")
+	}
+}
+
+func TestBuildChatURLModelInference(t *testing.T) {
+	p := New("https://my-resource.models.ai.azure.com", "test-key")
+
+	url, err := p.buildChatURL("gpt-4o")
+	if err != nil {
+		t.Fatalf("buildChatURL() error = %v", err)
+	}
+
+	expected := "https://my-resource.models.ai.azure.com/models/chat/completions?api-version=2024-05-01-preview"
+	if url != expected {
+		t.Errorf("buildChatURL() = %q, want %q", url, expected)
+	}
+}
+
+func TestBuildChatURLAzureOpenAI(t *testing.T) {
+	p := New("https://my-resource.openai.azure.com", "test-key",
+		WithOpenAIEndpoint(),
+		WithDeploymentID("gpt-4o-deployment"),
+	)
+
+	url, err := p.buildChatURL("gpt-4o")
+	if err != nil {
+		t.Fatalf("buildChatURL() error = %v", err)
+	}
+
+	expected := "https://my-resource.openai.azure.com/openai/deployments/gpt-4o-deployment/chat/completions?api-version=2024-10-21"
+	if url != expected {
+		t.Errorf("buildChatURL() = %q, want %q", url, expected)
+	}
+}
+
+func TestBuildChatURLAzureOpenAIUsesModelAsDeployment(t *testing.T) {
+	p := New("https://my-resource.openai.azure.com", "test-key",
+		WithOpenAIEndpoint(),
+	)
+
+	url, err := p.buildChatURL("my-model")
+	if err != nil {
+		t.Fatalf("buildChatURL() error = %v", err)
+	}
+
+	expected := "https://my-resource.openai.azure.com/openai/deployments/my-model/chat/completions?api-version=2024-10-21"
+	if url != expected {
+		t.Errorf("buildChatURL() = %q, want %q", url, expected)
+	}
+}
+
+func TestBuildChatURLAzureOpenAINoDeployment(t *testing.T) {
+	p := New("https://my-resource.openai.azure.com", "test-key",
+		WithOpenAIEndpoint(),
+	)
+
+	// Empty model and no deployment should error
+	_, err := p.buildChatURL("")
+	if err != ErrDeploymentRequired {
+		t.Errorf("buildChatURL() error = %v, want ErrDeploymentRequired", err)
+	}
+}
+
+func TestBuildEmbeddingsURLModelInference(t *testing.T) {
+	p := New("https://my-resource.models.ai.azure.com", "test-key")
+
+	url, err := p.buildEmbeddingsURL("text-embedding-3-large")
+	if err != nil {
+		t.Fatalf("buildEmbeddingsURL() error = %v", err)
+	}
+
+	expected := "https://my-resource.models.ai.azure.com/models/embeddings?api-version=2024-05-01-preview"
+	if url != expected {
+		t.Errorf("buildEmbeddingsURL() = %q, want %q", url, expected)
+	}
+}
+
+func TestBuildEmbeddingsURLAzureOpenAI(t *testing.T) {
+	p := New("https://my-resource.openai.azure.com", "test-key",
+		WithOpenAIEndpoint(),
+		WithDeploymentID("embedding-deployment"),
+	)
+
+	url, err := p.buildEmbeddingsURL("text-embedding-3-large")
+	if err != nil {
+		t.Fatalf("buildEmbeddingsURL() error = %v", err)
+	}
+
+	expected := "https://my-resource.openai.azure.com/openai/deployments/embedding-deployment/embeddings?api-version=2024-10-21"
+	if url != expected {
+		t.Errorf("buildEmbeddingsURL() = %q, want %q", url, expected)
+	}
+}
+
+func TestBuildHeadersWithAPIKey(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-api-key-123")
+	headers, err := p.buildHeaders(context.Background())
+
+	if err != nil {
+		t.Fatalf("buildHeaders() error = %v", err)
+	}
+
+	apiKey := headers.Get("api-key")
+	if apiKey != "test-api-key-123" {
+		t.Errorf("api-key = %q, want %q", apiKey, "test-api-key-123")
+	}
+
+	contentType := headers.Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", contentType, "application/json")
+	}
+}
+
+func TestBuildHeadersWithTokenCredential(t *testing.T) {
+	cred := &mockCredential{token: "mock-bearer-token"}
+	p := NewWithCredential("https://test.openai.azure.com", cred)
+
+	headers, err := p.buildHeaders(context.Background())
+	if err != nil {
+		t.Fatalf("buildHeaders() error = %v", err)
+	}
+
+	auth := headers.Get("Authorization")
+	if auth != "Bearer mock-bearer-token" {
+		t.Errorf("Authorization = %q, want %q", auth, "Bearer mock-bearer-token")
+	}
+}
+
+func TestBuildHeadersWithCustomHeaders(t *testing.T) {
+	p := New("https://test.openai.azure.com", "test-key",
+		WithHeader("X-Custom-One", "value1"),
+		WithHeader("X-Custom-Two", "value2"),
+	)
+	headers, err := p.buildHeaders(context.Background())
+	if err != nil {
+		t.Fatalf("buildHeaders() error = %v", err)
+	}
+
+	if headers.Get("X-Custom-One") != "value1" {
+		t.Errorf("X-Custom-One = %q, want %q", headers.Get("X-Custom-One"), "value1")
+	}
+
+	if headers.Get("X-Custom-Two") != "value2" {
+		t.Errorf("X-Custom-Two = %q, want %q", headers.Get("X-Custom-Two"), "value2")
+	}
+}
+
+// mockCredential implements TokenCredential for testing.
+type mockCredential struct {
+	token string
+	err   error
+}
+
+func (m *mockCredential) GetToken(ctx context.Context, options TokenRequestOptions) (AccessToken, error) {
+	if m.err != nil {
+		return AccessToken{}, m.err
+	}
+	return AccessToken{
+		Token:     m.token,
+		ExpiresOn: time.Now().Add(time.Hour),
+	}, nil
+}

--- a/providers/azurefoundry/register.go
+++ b/providers/azurefoundry/register.go
@@ -1,0 +1,14 @@
+package azurefoundry
+
+import (
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers"
+)
+
+func init() {
+	providers.Register("azurefoundry", func(apiKey string) core.Provider {
+		// When using registry, endpoint must be set via environment
+		// or use NewFromEnv/New directly for full configuration
+		return New("", apiKey)
+	})
+}

--- a/providers/azurefoundry/streaming.go
+++ b/providers/azurefoundry/streaming.go
@@ -18,37 +18,37 @@ import (
 
 // azureStreamChunk represents a single SSE chunk from Azure.
 type azureStreamChunk struct {
-	ID                string               `json:"id"`
-	Object            string               `json:"object"`
-	Created           int64                `json:"created"`
-	Model             string               `json:"model"`
-	Choices           []azureStreamChoice  `json:"choices"`
-	Usage             *azureUsage          `json:"usage,omitempty"`
-	SystemFingerprint string               `json:"system_fingerprint,omitempty"`
+	ID                string              `json:"id"`
+	Object            string              `json:"object"`
+	Created           int64               `json:"created"`
+	Model             string              `json:"model"`
+	Choices           []azureStreamChoice `json:"choices"`
+	Usage             *azureUsage         `json:"usage,omitempty"`
+	SystemFingerprint string              `json:"system_fingerprint,omitempty"`
 }
 
 // azureStreamChoice represents a choice in a streaming response.
 type azureStreamChoice struct {
-	Index                int                   `json:"index"`
-	Delta                azureStreamDelta      `json:"delta"`
-	FinishReason         *string               `json:"finish_reason,omitempty"`
-	ContentFilterResults *azureContentFilters  `json:"content_filter_results,omitempty"`
+	Index                int                  `json:"index"`
+	Delta                azureStreamDelta     `json:"delta"`
+	FinishReason         *string              `json:"finish_reason,omitempty"`
+	ContentFilterResults *azureContentFilters `json:"content_filter_results,omitempty"`
 }
 
 // azureStreamDelta represents the incremental content in a streaming choice.
 type azureStreamDelta struct {
-	Role      string                 `json:"role,omitempty"`
-	Content   string                 `json:"content,omitempty"`
-	ToolCalls []azureStreamToolCall  `json:"tool_calls,omitempty"`
-	Refusal   string                 `json:"refusal,omitempty"`
+	Role      string                `json:"role,omitempty"`
+	Content   string                `json:"content,omitempty"`
+	ToolCalls []azureStreamToolCall `json:"tool_calls,omitempty"`
+	Refusal   string                `json:"refusal,omitempty"`
 }
 
 // azureStreamToolCall represents a tool call fragment in streaming.
 type azureStreamToolCall struct {
-	Index    int                    `json:"index"`
-	ID       string                 `json:"id,omitempty"`
-	Type     string                 `json:"type,omitempty"`
-	Function azureStreamFunction    `json:"function,omitempty"`
+	Index    int                 `json:"index"`
+	ID       string              `json:"id,omitempty"`
+	Type     string              `json:"type,omitempty"`
+	Function azureStreamFunction `json:"function,omitempty"`
 }
 
 // azureStreamFunction represents function details in a streaming tool call.

--- a/providers/azurefoundry/streaming.go
+++ b/providers/azurefoundry/streaming.go
@@ -1,0 +1,257 @@
+package azurefoundry
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/toolcalls"
+)
+
+// Streaming response types for Azure SSE protocol.
+// Azure uses the same SSE format as OpenAI.
+
+// azureStreamChunk represents a single SSE chunk from Azure.
+type azureStreamChunk struct {
+	ID                string               `json:"id"`
+	Object            string               `json:"object"`
+	Created           int64                `json:"created"`
+	Model             string               `json:"model"`
+	Choices           []azureStreamChoice  `json:"choices"`
+	Usage             *azureUsage          `json:"usage,omitempty"`
+	SystemFingerprint string               `json:"system_fingerprint,omitempty"`
+}
+
+// azureStreamChoice represents a choice in a streaming response.
+type azureStreamChoice struct {
+	Index                int                   `json:"index"`
+	Delta                azureStreamDelta      `json:"delta"`
+	FinishReason         *string               `json:"finish_reason,omitempty"`
+	ContentFilterResults *azureContentFilters  `json:"content_filter_results,omitempty"`
+}
+
+// azureStreamDelta represents the incremental content in a streaming choice.
+type azureStreamDelta struct {
+	Role      string                 `json:"role,omitempty"`
+	Content   string                 `json:"content,omitempty"`
+	ToolCalls []azureStreamToolCall  `json:"tool_calls,omitempty"`
+	Refusal   string                 `json:"refusal,omitempty"`
+}
+
+// azureStreamToolCall represents a tool call fragment in streaming.
+type azureStreamToolCall struct {
+	Index    int                    `json:"index"`
+	ID       string                 `json:"id,omitempty"`
+	Type     string                 `json:"type,omitempty"`
+	Function azureStreamFunction    `json:"function,omitempty"`
+}
+
+// azureStreamFunction represents function details in a streaming tool call.
+type azureStreamFunction struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
+}
+
+// toolCallAssembler accumulates streaming tool call fragments.
+type toolCallAssembler struct {
+	asm *toolcalls.Assembler
+}
+
+// newToolCallAssembler creates a new tool call assembler.
+func newToolCallAssembler() *toolCallAssembler {
+	return &toolCallAssembler{
+		asm: toolcalls.NewAssembler(toolcalls.Config{}),
+	}
+}
+
+// addFragment processes a streaming tool call fragment.
+func (a *toolCallAssembler) addFragment(tc azureStreamToolCall) {
+	a.asm.AddFragment(toolcalls.Fragment{
+		Index:     tc.Index,
+		ID:        tc.ID,
+		Name:      tc.Function.Name,
+		Arguments: tc.Function.Arguments,
+	})
+}
+
+// finalize validates and returns the assembled tool calls.
+func (a *toolCallAssembler) finalize() ([]core.ToolCall, error) {
+	calls, err := a.asm.Finalize()
+	if err != nil {
+		if errors.Is(err, toolcalls.ErrInvalidJSON) {
+			return nil, ErrToolArgsInvalidJSON
+		}
+		return nil, err
+	}
+	return calls, nil
+}
+
+// processSSEStream reads the SSE stream and emits chunks.
+// This replaces the placeholder implementation in client_chat.go.
+func (p *AzureFoundry) processSSEStream(
+	ctx context.Context,
+	resp *http.Response,
+	model core.ModelID,
+) (*core.ChatStream, error) {
+	// Create channels
+	chunkCh := make(chan core.ChatChunk, 100)
+	errCh := make(chan error, 1)
+	finalCh := make(chan *core.ChatResponse, 1)
+
+	// Start goroutine to process SSE stream
+	go p.readSSEStream(ctx, resp.Body, model, chunkCh, errCh, finalCh)
+
+	return &core.ChatStream{
+		Ch:    chunkCh,
+		Err:   errCh,
+		Final: finalCh,
+	}, nil
+}
+
+// readSSEStream reads and processes the SSE stream from Azure.
+func (p *AzureFoundry) readSSEStream(
+	ctx context.Context,
+	body io.ReadCloser,
+	requestModel core.ModelID,
+	chunkCh chan<- core.ChatChunk,
+	errCh chan<- error,
+	finalCh chan<- *core.ChatResponse,
+) {
+	defer body.Close()
+	defer close(chunkCh)
+	defer close(errCh)
+	defer close(finalCh)
+
+	reader := bufio.NewReader(body)
+	assembler := newToolCallAssembler()
+
+	var responseID string
+	var responseModel string
+	var usage *azureUsage
+	var contentFiltered bool
+	var contentBuilder strings.Builder
+
+	for {
+		// Check for context cancellation
+		select {
+		case <-ctx.Done():
+			errCh <- ctx.Err()
+			return
+		default:
+		}
+
+		// Read line
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			errCh <- newNetworkError(err)
+			return
+		}
+
+		// Trim whitespace
+		line = strings.TrimSpace(line)
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, ":") {
+			continue
+		}
+
+		// Process data lines
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+
+		// Check for done signal
+		if payload == "[DONE]" {
+			break
+		}
+
+		// Parse chunk
+		var chunk azureStreamChunk
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			errCh <- newDecodeError(err)
+			return
+		}
+
+		// Capture metadata
+		if chunk.ID != "" {
+			responseID = chunk.ID
+		}
+		if chunk.Model != "" {
+			responseModel = chunk.Model
+		}
+		if chunk.Usage != nil {
+			usage = chunk.Usage
+		}
+
+		// Process choices
+		for _, choice := range chunk.Choices {
+			// Check for content filtering
+			if choice.ContentFilterResults != nil && choice.ContentFilterResults.IsFiltered() {
+				contentFiltered = true
+			}
+
+			// Emit content delta
+			if choice.Delta.Content != "" {
+				contentBuilder.WriteString(choice.Delta.Content)
+				select {
+				case chunkCh <- core.ChatChunk{Delta: choice.Delta.Content}:
+				case <-ctx.Done():
+					errCh <- ctx.Err()
+					return
+				}
+			}
+
+			// Accumulate tool calls
+			for _, tc := range choice.Delta.ToolCalls {
+				assembler.addFragment(tc)
+			}
+		}
+	}
+
+	// Check if content was filtered
+	if contentFiltered {
+		errCh <- ErrContentFiltered
+		return
+	}
+
+	// Finalize tool calls
+	toolCalls, err := assembler.finalize()
+	if err != nil {
+		errCh <- err
+		return
+	}
+
+	// Use request model if response model not provided
+	finalModel := responseModel
+	if finalModel == "" {
+		finalModel = string(requestModel)
+	}
+
+	// Build final response
+	finalResp := &core.ChatResponse{
+		ID:        responseID,
+		Model:     core.ModelID(finalModel),
+		Output:    contentBuilder.String(),
+		ToolCalls: toolCalls,
+	}
+
+	if usage != nil {
+		finalResp.Usage = core.TokenUsage{
+			PromptTokens:     usage.PromptTokens,
+			CompletionTokens: usage.CompletionTokens,
+			TotalTokens:      usage.TotalTokens,
+		}
+	}
+
+	finalCh <- finalResp
+}

--- a/providers/azurefoundry/streaming_test.go
+++ b/providers/azurefoundry/streaming_test.go
@@ -1,0 +1,561 @@
+package azurefoundry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+)
+
+// Helper to create SSE response.
+func sseResponse(events ...string) string {
+	var sb strings.Builder
+	for _, e := range events {
+		sb.WriteString("data: ")
+		sb.WriteString(e)
+		sb.WriteString("\n\n")
+	}
+	return sb.String()
+}
+
+func TestStreamChatSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify API key header
+		if r.Header.Get("api-key") == "" {
+			t.Error("api-key header not set")
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		// Send chunks
+		fmt.Fprint(w, sseResponse(
+			`{"id":"chatcmpl-123","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":""}}]}`,
+			`{"id":"chatcmpl-123","model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}`,
+			`{"id":"chatcmpl-123","model":"gpt-4o","choices":[{"index":0,"delta":{"content":" world"}}]}`,
+			`{"id":"chatcmpl-123","model":"gpt-4o","choices":[{"index":0,"delta":{"content":"!"}}],"usage":{"prompt_tokens":10,"completion_tokens":3,"total_tokens":13}}`,
+			"[DONE]",
+		))
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	stream, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: "Hi"},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("StreamChat() error = %v", err)
+	}
+
+	// Collect deltas
+	var deltas []string
+	for chunk := range stream.Ch {
+		deltas = append(deltas, chunk.Delta)
+	}
+
+	// Check for errors
+	select {
+	case err := <-stream.Err:
+		if err != nil {
+			t.Fatalf("Stream error: %v", err)
+		}
+	default:
+	}
+
+	// Get final response
+	final := <-stream.Final
+	if final == nil {
+		t.Fatal("Final response is nil")
+	}
+
+	// Verify deltas
+	expected := []string{"Hello", " world", "!"}
+	if len(deltas) != len(expected) {
+		t.Errorf("len(deltas) = %d, want %d", len(deltas), len(expected))
+	}
+	for i, d := range deltas {
+		if i < len(expected) && d != expected[i] {
+			t.Errorf("deltas[%d] = %q, want %q", i, d, expected[i])
+		}
+	}
+
+	// Verify final response
+	if final.ID != "chatcmpl-123" {
+		t.Errorf("ID = %q, want %q", final.ID, "chatcmpl-123")
+	}
+	if final.Model != "gpt-4o" {
+		t.Errorf("Model = %q, want %q", final.Model, "gpt-4o")
+	}
+	if final.Usage.TotalTokens != 13 {
+		t.Errorf("Usage.TotalTokens = %d, want 13", final.Usage.TotalTokens)
+	}
+}
+
+func TestStreamChatWithToolCalls(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		// Tool call fragments
+		fmt.Fprint(w, sseResponse(
+			`{"id":"chatcmpl-456","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_abc","type":"function","function":{"name":"get_weather","arguments":""}}]}}]}`,
+			`{"id":"chatcmpl-456","model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"loc"}}]}}]}`,
+			`{"id":"chatcmpl-456","model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ation\":"}}]}}]}`,
+			`{"id":"chatcmpl-456","model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"NYC\"}"}}]}}]}`,
+			"[DONE]",
+		))
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	stream, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model: "gpt-4o",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: "Weather?"},
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("StreamChat() error = %v", err)
+	}
+
+	// Drain chunks
+	for range stream.Ch {
+	}
+
+	// Check for errors
+	select {
+	case err := <-stream.Err:
+		if err != nil {
+			t.Fatalf("Stream error: %v", err)
+		}
+	default:
+	}
+
+	// Get final response
+	final := <-stream.Final
+	if final == nil {
+		t.Fatal("Final response is nil")
+	}
+
+	if len(final.ToolCalls) != 1 {
+		t.Fatalf("len(ToolCalls) = %d, want 1", len(final.ToolCalls))
+	}
+
+	tc := final.ToolCalls[0]
+	if tc.ID != "call_abc" {
+		t.Errorf("ToolCalls[0].ID = %q, want %q", tc.ID, "call_abc")
+	}
+	if tc.Name != "get_weather" {
+		t.Errorf("ToolCalls[0].Name = %q, want %q", tc.Name, "get_weather")
+	}
+	if string(tc.Arguments) != `{"location":"NYC"}` {
+		t.Errorf("ToolCalls[0].Arguments = %s, want %s", tc.Arguments, `{"location":"NYC"}`)
+	}
+}
+
+func TestStreamChatMultipleToolCalls(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, sseResponse(
+			`{"id":"chatcmpl-789","model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"func1","arguments":"{}"}}]}}]}`,
+			`{"id":"chatcmpl-789","model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_2","type":"function","function":{"name":"func2","arguments":"{}"}}]}}]}`,
+			"[DONE]",
+		))
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	stream, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    "gpt-4o",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Test"}},
+	})
+
+	if err != nil {
+		t.Fatalf("StreamChat() error = %v", err)
+	}
+
+	for range stream.Ch {
+	}
+
+	select {
+	case err := <-stream.Err:
+		if err != nil {
+			t.Fatalf("Stream error: %v", err)
+		}
+	default:
+	}
+
+	final := <-stream.Final
+	if len(final.ToolCalls) != 2 {
+		t.Fatalf("len(ToolCalls) = %d, want 2", len(final.ToolCalls))
+	}
+
+	if final.ToolCalls[0].Name != "func1" {
+		t.Errorf("ToolCalls[0].Name = %q, want func1", final.ToolCalls[0].Name)
+	}
+	if final.ToolCalls[1].Name != "func2" {
+		t.Errorf("ToolCalls[1].Name = %q, want func2", final.ToolCalls[1].Name)
+	}
+}
+
+func TestStreamChatInvalidToolCallJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, sseResponse(
+			`{"id":"chatcmpl-bad","model":"gpt-4o","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_bad","type":"function","function":{"name":"broken","arguments":"{invalid"}}]}}]}`,
+			"[DONE]",
+		))
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	stream, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    "gpt-4o",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Test"}},
+	})
+
+	if err != nil {
+		t.Fatalf("StreamChat() error = %v", err)
+	}
+
+	for range stream.Ch {
+	}
+
+	// Should get error
+	streamErr := <-stream.Err
+	if !errors.Is(streamErr, ErrToolArgsInvalidJSON) {
+		t.Errorf("expected ErrToolArgsInvalidJSON, got %v", streamErr)
+	}
+}
+
+func TestStreamChatError400(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":{"message":"Bad request"}}`))
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	_, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    "gpt-4o",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Test"}},
+	})
+
+	if !errors.Is(err, core.ErrBadRequest) {
+		t.Errorf("expected ErrBadRequest, got %v", err)
+	}
+}
+
+func TestStreamChatError429(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":{"message":"Rate limited"}}`))
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	_, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    "gpt-4o",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Test"}},
+	})
+
+	if !errors.Is(err, core.ErrRateLimited) {
+		t.Errorf("expected ErrRateLimited, got %v", err)
+	}
+}
+
+func TestStreamChatContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		// Send first chunk
+		fmt.Fprint(w, sseResponse(
+			`{"id":"chatcmpl-cancel","model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"}}]}`,
+		))
+		w.(http.Flusher).Flush()
+
+		// Wait to simulate slow stream
+		time.Sleep(100 * time.Millisecond)
+
+		fmt.Fprint(w, sseResponse(
+			`{"id":"chatcmpl-cancel","model":"gpt-4o","choices":[{"index":0,"delta":{"content":" world"}}]}`,
+			"[DONE]",
+		))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	p := New(server.URL, "test-key")
+	stream, err := p.StreamChat(ctx, &core.ChatRequest{
+		Model:    "gpt-4o",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Test"}},
+	})
+
+	if err != nil {
+		t.Fatalf("StreamChat() error = %v", err)
+	}
+
+	// Read first chunk then cancel
+	<-stream.Ch
+	cancel()
+
+	// Channels should close
+	timeout := time.After(500 * time.Millisecond)
+	select {
+	case <-timeout:
+		t.Error("Channels did not close after context cancellation")
+	case _, ok := <-stream.Ch:
+		if ok {
+			// Drain remaining
+			for range stream.Ch {
+			}
+		}
+	}
+}
+
+func TestStreamChatEmptyStream(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, sseResponse(
+			`{"id":"chatcmpl-empty","model":"gpt-4o","choices":[{"index":0,"delta":{"role":"assistant"}}]}`,
+			"[DONE]",
+		))
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	stream, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    "gpt-4o",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Test"}},
+	})
+
+	if err != nil {
+		t.Fatalf("StreamChat() error = %v", err)
+	}
+
+	// No content chunks expected
+	count := 0
+	for range stream.Ch {
+		count++
+	}
+
+	if count != 0 {
+		t.Errorf("Expected 0 chunks, got %d", count)
+	}
+
+	select {
+	case err := <-stream.Err:
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	default:
+	}
+
+	final := <-stream.Final
+	if final == nil {
+		t.Error("Final response is nil")
+	}
+}
+
+func TestStreamChatChannelsClosed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, sseResponse(
+			`{"id":"chatcmpl-close","model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hi"}}]}`,
+			"[DONE]",
+		))
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	stream, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    "gpt-4o",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Test"}},
+	})
+
+	if err != nil {
+		t.Fatalf("StreamChat() error = %v", err)
+	}
+
+	// Drain Ch channel
+	for range stream.Ch {
+	}
+
+	// Drain Err channel (may have 0 or 1 value)
+	for range stream.Err {
+	}
+
+	// Drain Final channel (should have exactly 1 value)
+	for range stream.Final {
+	}
+
+	// Verify all channels are now closed (second receive returns false)
+	_, chOpen := <-stream.Ch
+	_, errOpen := <-stream.Err
+	_, finalOpen := <-stream.Final
+
+	if chOpen {
+		t.Error("Ch channel not closed")
+	}
+	if errOpen {
+		t.Error("Err channel not closed")
+	}
+	if finalOpen {
+		t.Error("Final channel not closed")
+	}
+}
+
+func TestStreamChatContentFiltered(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, sseResponse(
+			`{"id":"chatcmpl-filtered","model":"gpt-4o","choices":[{"index":0,"delta":{"content":"Hello"},"content_filter_results":{"hate":{"filtered":true,"severity":"high"}}}]}`,
+			"[DONE]",
+		))
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	stream, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    "gpt-4o",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Test"}},
+	})
+
+	if err != nil {
+		t.Fatalf("StreamChat() error = %v", err)
+	}
+
+	// Drain chunks
+	for range stream.Ch {
+	}
+
+	// Should get content filtered error
+	streamErr := <-stream.Err
+	if !errors.Is(streamErr, ErrContentFiltered) {
+		t.Errorf("expected ErrContentFiltered, got %v", streamErr)
+	}
+}
+
+func TestToolCallAssemblerEmpty(t *testing.T) {
+	a := newToolCallAssembler()
+	calls, err := a.finalize()
+
+	if err != nil {
+		t.Errorf("finalize() error = %v", err)
+	}
+	if calls != nil {
+		t.Errorf("finalize() = %v, want nil", calls)
+	}
+}
+
+func TestToolCallAssemblerSingleCall(t *testing.T) {
+	a := newToolCallAssembler()
+
+	a.addFragment(azureStreamToolCall{
+		Index: 0,
+		ID:    "call_1",
+		Function: azureStreamFunction{
+			Name:      "test",
+			Arguments: `{"key":`,
+		},
+	})
+
+	a.addFragment(azureStreamToolCall{
+		Index: 0,
+		Function: azureStreamFunction{
+			Arguments: `"value"}`,
+		},
+	})
+
+	calls, err := a.finalize()
+	if err != nil {
+		t.Fatalf("finalize() error = %v", err)
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("len(calls) = %d, want 1", len(calls))
+	}
+
+	if calls[0].ID != "call_1" {
+		t.Errorf("ID = %q, want call_1", calls[0].ID)
+	}
+
+	if string(calls[0].Arguments) != `{"key":"value"}` {
+		t.Errorf("Arguments = %s, want %s", calls[0].Arguments, `{"key":"value"}`)
+	}
+}
+
+func TestToolCallAssemblerInvalidJSON(t *testing.T) {
+	a := newToolCallAssembler()
+
+	a.addFragment(azureStreamToolCall{
+		Index: 0,
+		ID:    "call_bad",
+		Function: azureStreamFunction{
+			Name:      "broken",
+			Arguments: `{invalid`,
+		},
+	})
+
+	_, err := a.finalize()
+	if !errors.Is(err, ErrToolArgsInvalidJSON) {
+		t.Errorf("expected ErrToolArgsInvalidJSON, got %v", err)
+	}
+}
+
+func TestStreamChatUsesModelFromRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		// Response doesn't include model
+		fmt.Fprint(w, sseResponse(
+			`{"id":"chatcmpl-nomodel","choices":[{"index":0,"delta":{"content":"Hi"}}]}`,
+			"[DONE]",
+		))
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "test-key")
+	stream, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    "my-custom-model",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Test"}},
+	})
+
+	if err != nil {
+		t.Fatalf("StreamChat() error = %v", err)
+	}
+
+	for range stream.Ch {
+	}
+	for range stream.Err {
+	}
+
+	final := <-stream.Final
+	if final.Model != "my-custom-model" {
+		t.Errorf("Model = %q, want my-custom-model", final.Model)
+	}
+}

--- a/providers/azurefoundry/token.go
+++ b/providers/azurefoundry/token.go
@@ -1,0 +1,78 @@
+package azurefoundry
+
+import (
+	"context"
+	"time"
+)
+
+// DefaultScope is the OAuth2 scope for Azure Cognitive Services.
+// This is used when acquiring tokens via Entra ID authentication.
+const DefaultScope = "https://cognitiveservices.azure.com/.default"
+
+// TokenCredential provides access tokens for Azure Entra ID authentication.
+// This interface is designed to be compatible with azure-sdk-for-go's azcore.TokenCredential,
+// allowing direct use of Azure SDK credentials:
+//
+//	cred, err := azidentity.NewDefaultAzureCredential(nil)
+//	provider := azurefoundry.NewWithCredential(endpoint, cred)
+//
+// Users can also implement this interface directly for custom token providers.
+type TokenCredential interface {
+	// GetToken returns an access token for the specified scopes.
+	// The token should be cached and refreshed as needed.
+	GetToken(ctx context.Context, options TokenRequestOptions) (AccessToken, error)
+}
+
+// TokenRequestOptions configures token acquisition.
+type TokenRequestOptions struct {
+	// Scopes specifies the required OAuth2 scopes for the token.
+	// For Azure AI Foundry, use []string{DefaultScope}.
+	Scopes []string
+}
+
+// AccessToken represents an Azure access token with expiration.
+type AccessToken struct {
+	// Token is the bearer token string to use in Authorization header.
+	Token string
+
+	// ExpiresOn indicates when the token expires.
+	// Implementations should refresh tokens before expiration.
+	ExpiresOn time.Time
+}
+
+// tokenCache wraps a TokenCredential with caching to avoid unnecessary token refreshes.
+// It stores the last acquired token and only refreshes when expired or near expiration.
+type tokenCache struct {
+	credential TokenCredential
+	token      *AccessToken
+	buffer     time.Duration // refresh this much before expiry
+}
+
+// newTokenCache creates a token cache with a 5-minute buffer before expiration.
+func newTokenCache(credential TokenCredential) *tokenCache {
+	return &tokenCache{
+		credential: credential,
+		buffer:     5 * time.Minute,
+	}
+}
+
+// getToken returns a cached token or acquires a new one if expired.
+func (c *tokenCache) getToken(ctx context.Context) (string, error) {
+	now := time.Now()
+
+	// Return cached token if still valid (with buffer)
+	if c.token != nil && c.token.ExpiresOn.Add(-c.buffer).After(now) {
+		return c.token.Token, nil
+	}
+
+	// Acquire new token
+	token, err := c.credential.GetToken(ctx, TokenRequestOptions{
+		Scopes: []string{DefaultScope},
+	})
+	if err != nil {
+		return "", err
+	}
+
+	c.token = &token
+	return token.Token, nil
+}


### PR DESCRIPTION
## Summary

- Add new Azure AI Foundry provider supporting both Model Inference API and Azure OpenAI Service endpoints
- Implement chat completions with streaming support via SSE
- Add embeddings with configurable dimensions and encoding formats (float/base64)
- Support 45+ models including OpenAI, Meta Llama, Mistral, Cohere, DeepSeek, Microsoft Phi

## Test plan

- [x] All 218 unit tests pass
- [x] Provider implements core.Provider and core.EmbeddingProvider interfaces
- [x] URL building verified for both Model Inference and Azure OpenAI endpoints
- [x] Error handling tested with Azure-specific error codes
- [x] Streaming tested with tool call assembly and content filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)