### PR TITLE
fix(providers): update Perplexity tool format to flat structure

### DIFF
--- a/providers/perplexity/mapping.go
+++ b/providers/perplexity/mapping.go
@@ -47,12 +47,10 @@ func mapTools(irisTools []core.Tool) []perplexityTool {
 		}
 
 		result[i] = perplexityTool{
-			Type: "function",
-			Function: perplexityFunction{
-				Name:        t.Name(),
-				Description: t.Description(),
-				Parameters:  params,
-			},
+			Type:        "function",
+			Name:        t.Name(),
+			Description: t.Description(),
+			Parameters:  params,
 		}
 	}
 	return result

--- a/providers/perplexity/mapping_test.go
+++ b/providers/perplexity/mapping_test.go
@@ -68,15 +68,15 @@ func TestMapTools(t *testing.T) {
 		if result[0].Type != "function" {
 			t.Errorf("result[0].Type = %q, want %q", result[0].Type, "function")
 		}
-		if result[0].Function.Name != "get_weather" {
-			t.Errorf("result[0].Function.Name = %q, want %q", result[0].Function.Name, "get_weather")
+		if result[0].Name != "get_weather" {
+			t.Errorf("result[0].Name = %q, want %q", result[0].Name, "get_weather")
 		}
-		if result[0].Function.Description != "Get weather for a city" {
-			t.Errorf("result[0].Function.Description = %q, want %q", result[0].Function.Description, "Get weather for a city")
+		if result[0].Description != "Get weather for a city" {
+			t.Errorf("result[0].Description = %q, want %q", result[0].Description, "Get weather for a city")
 		}
 
-		if result[1].Function.Name != "search" {
-			t.Errorf("result[1].Function.Name = %q, want %q", result[1].Function.Name, "search")
+		if result[1].Name != "search" {
+			t.Errorf("result[1].Name = %q, want %q", result[1].Name, "search")
 		}
 	})
 }

--- a/providers/perplexity/types.go
+++ b/providers/perplexity/types.go
@@ -55,13 +55,10 @@ type perplexityMessage struct {
 }
 
 // perplexityTool represents a tool definition in the Perplexity format.
+// Perplexity uses a flat structure with name, description, and parameters
+// at the same level as type (not nested inside a "function" wrapper).
 type perplexityTool struct {
-	Type     string             `json:"type"`
-	Function perplexityFunction `json:"function"`
-}
-
-// perplexityFunction represents a function definition for Perplexity tools.
-type perplexityFunction struct {
+	Type        string          `json:"type"`
 	Name        string          `json:"name"`
 	Description string          `json:"description"`
 	Parameters  json.RawMessage `json:"parameters"`


### PR DESCRIPTION
## Summary
- Perplexity's API changed (~March 18) to require a flat tool definition format (`type`, `name`, `description`, `parameters` at the top level) instead of the OpenAI-compatible nested format (`type` + `function` wrapper)
- This has been causing `TestPerplexity_ChatCompletion_WithTools` to fail in nightly CI since March 18 with: `Tool parameters must be a JSON object`
- Updates `perplexityTool` struct, `mapTools`, and unit tests to use the new format

## Test plan
- [x] All unit tests pass locally (`go test ./... -count=1`)
- [x] `go vet ./...` clean
- [ ] CI integration tests pass with Perplexity tool calling

🤖 Generated with [Claude Code](https://claude.com/claude-code)