### PR TITLE
chore(ci): change integration tests from daily to weekly

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -3,8 +3,8 @@ name: Integration Tests
 on:
   workflow_dispatch:
   schedule:
-    # Run nightly at 2 AM UTC
-    - cron: "0 2 * * *"
+    # Run weekly on Sunday at 2 AM UTC
+    - cron: "0 2 * * 0"
 
 jobs:
   integration:


### PR DESCRIPTION
## Summary

- Changed integration test schedule from daily (nightly at 2 AM UTC) to weekly (Sunday at 2 AM UTC)
- Reduces API credit consumption

## Test plan

- [x] Workflow syntax is valid
- Manual trigger via `workflow_dispatch` remains available for on-demand runs

Generated with [Claude Code](https://claude.ai/code)