### PR TITLE
feat(providers): add latest models from models.dev

### DIFF
--- a/docs/changes/2026-07-28_v0.13.0_provider-model-catalog-update.md
+++ b/docs/changes/2026-07-28_v0.13.0_provider-model-catalog-update.md
@@ -1,0 +1,260 @@
+---
+date: 2026-07-28
+version: v0.13.0
+feature: Provider model catalog update to latest models.dev data
+product: iris
+change_type: feature
+affected_components:
+  - providers/anthropic/models.go
+  - providers/anthropic/provider_test.go
+  - providers/openai/models.go
+  - providers/gemini/models.go
+  - providers/gemini/provider_test.go
+  - providers/xai/models.go
+  - providers/zai/models.go
+  - providers/zai/models_test.go
+related_frds: []
+---
+
+## Summary
+
+Updated the static model catalogs for the OpenAI, Anthropic, Google Gemini, xAI,
+and Z.ai providers to add the latest flagship models published on
+[models.dev](https://models.dev/api.json). This adds the Claude 5 family (plus
+Opus 4.8), the GPT-5.6 / GPT-5.5 / GPT-5.3-codex series (plus o3-pro and
+gpt-image-2), Gemini 3.6 / 3.5 / 3.1 preview models, Grok 4.5 / 4.3 / Build 0.1,
+and GLM-5.2. Existing models were left in place; this is purely additive.
+
+## Motivation
+
+Iris ships a curated, hand-maintained list of supported models per provider so
+that `Provider.Models()` and `GetModelInfo()` report accurate capabilities
+(chat, streaming, tool calling, reasoning, image generation) and the correct API
+endpoint (Chat Completions vs Responses). Providers have released newer flagship
+models since the last sync (commit `51aeaa0`, May 2026); this change brings the
+catalog current with the models.dev dataset while preserving the repository's
+established curation scope (chat / reasoning / image flagships — no embeddings,
+TTS, video, or dated snapshots).
+
+## What Changed
+
+### New Additions
+
+**OpenAI** (`providers/openai/models.go`) — all reasoning models use the
+Responses API (`core.APIEndpointResponses`) with `FeatureReasoning`,
+`FeatureBuiltInTools`, and `FeatureResponseChain`:
+
+| Constant | Model ID | Notes |
+|---|---|---|
+| `ModelGPT56` | `gpt-5.6` | Latest flagship |
+| `ModelGPT56Luna` | `gpt-5.6-luna` | GPT-5.6 variant |
+| `ModelGPT56Sol` | `gpt-5.6-sol` | GPT-5.6 variant |
+| `ModelGPT56Terra` | `gpt-5.6-terra` | GPT-5.6 variant |
+| `ModelGPT55` | `gpt-5.5` | |
+| `ModelGPT55Pro` | `gpt-5.5-pro` | |
+| `ModelGPT53Codex` | `gpt-5.3-codex` | |
+| `ModelGPT53CodexSpark` | `gpt-5.3-codex-spark` | |
+| `ModelO3Pro` | `o3-pro` | Reasoning (o-series) |
+| `ModelGPTImage2` | `gpt-image-2` | Image generation only |
+
+**Anthropic** (`providers/anthropic/models.go`) — Chat Completions style catalog
+entries with `FeatureReasoning`. Thinking pseudo-variants follow the existing
+per-generation convention for Opus/Sonnet:
+
+| Constant | Model ID |
+|---|---|
+| `ModelClaudeOpus5` | `claude-opus-5` |
+| `ModelClaudeOpus5Thinking` | `claude-opus-5-thinking` |
+| `ModelClaudeSonnet5` | `claude-sonnet-5` |
+| `ModelClaudeSonnet5Thinking` | `claude-sonnet-5-thinking` |
+| `ModelClaudeFable5` | `claude-fable-5` |
+| `ModelClaudeOpus48` | `claude-opus-4-8` |
+| `ModelClaudeOpus48Thinking` | `claude-opus-4-8-thinking` |
+
+**Google Gemini** (`providers/gemini/models.go`) — chat/reasoning models:
+
+| Constant | Model ID |
+|---|---|
+| `ModelGemini36Flash` | `gemini-3.6-flash` |
+| `ModelGemini35Flash` | `gemini-3.5-flash` |
+| `ModelGemini35FlashLite` | `gemini-3.5-flash-lite` |
+| `ModelGemini31Pro` | `gemini-3.1-pro-preview` |
+| `ModelGemini31FlashLite` | `gemini-3.1-flash-lite` |
+
+**xAI** (`providers/xai/models.go`) — Chat Completions endpoint:
+
+| Constant | Model ID | Reasoning |
+|---|---|---|
+| `ModelGrok45` | `grok-4.5` | yes |
+| `ModelGrok43` | `grok-4.3` | yes |
+| `ModelGrokBuild01` | `grok-build-0.1` | yes |
+
+**Z.ai** (`providers/zai/models.go`):
+
+| Constant | Model ID | Reasoning |
+|---|---|---|
+| `ModelGLM52` | `glm-5.2` | yes |
+
+### Modifications
+
+- `providers/gemini/models.go` — `isGemini3Model(model string) bool` was changed
+  from an explicit four-model equality check to a prefix check:
+
+  **Before:**
+  ```go
+  func isGemini3Model(model string) bool {
+      return model == string(ModelGemini3Pro) || model == string(ModelGemini3Flash) ||
+          model == string(ModelGemini3ProImage) || model == string(ModelGemini31FlashImagePreview)
+  }
+  ```
+
+  **After:**
+  ```go
+  func isGemini3Model(model string) bool {
+      return strings.HasPrefix(model, "gemini-3")
+  }
+  ```
+
+  This ensures all Gemini 3.x families (3, 3.1, 3.5, 3.6) use the Gemini 3
+  `thinkingLevel` reasoning control rather than the Gemini 2.5 `thinkingBudget`.
+  A `strings` import was added to the file. Behavior for previously-listed
+  Gemini 3 models is unchanged.
+
+- Test expectations updated to match the new catalog sizes:
+  - `providers/anthropic/provider_test.go`: `Models()` count 11 → 18.
+  - `providers/gemini/provider_test.go`: `Models()` count 9 → 14.
+  - `providers/zai/models_test.go`: `len(models)` 19 → 20.
+
+### Removals
+
+N/A — no models were removed. Existing constants (including models no longer
+listed on models.dev, e.g. `dall-e-2`, `gpt-5-codex`) were retained to avoid
+breaking downstream references.
+
+## Technical Specification
+
+### Data Schemas / Types
+
+No type changes. New entries use the existing `core.ModelInfo` shape:
+
+```go
+type ModelInfo struct {
+    ID           ModelID     `json:"id"`
+    DisplayName  string      `json:"display_name"`
+    Capabilities []Feature   `json:"capabilities"`
+    APIEndpoint  APIEndpoint `json:"api_endpoint,omitempty"` // defaults to completions
+}
+```
+
+Capability mapping applied to the new models (derived from the models.dev
+`reasoning` / `tool_call` / `structured_output` / `modalities.output` fields):
+
+- Reasoning chat models → `FeatureChat`, `FeatureChatStreaming`,
+  `FeatureToolCalling`, `FeatureReasoning` (OpenAI/o-series additionally get
+  `FeatureBuiltInTools` and `FeatureResponseChain` on the Responses API).
+- Image models (`gpt-image-2`) → `FeatureImageGeneration` only.
+
+### API Endpoints
+
+N/A — no daemon/API endpoints changed. Provider routing is unchanged:
+`OpenAI.shouldUseResponsesAPI` reads `GetModelInfo(id).GetAPIEndpoint()`, so the
+new GPT-5.6/5.5/5.3/o3-pro entries (declared as `APIEndpointResponses`)
+automatically route to the Responses API.
+
+### CLI Interface
+
+N/A — no CLI surface changed.
+
+### Go Package API
+
+New exported `core.ModelID` constants per provider package (see the tables
+above). All are additive; no existing exported identifier changed signature.
+
+Usage contract is unchanged: pass a constant (or its string ID) as
+`core.ChatRequest.Model`, or look it up via the provider's
+`GetModelInfo(id core.ModelID) *core.ModelInfo`.
+
+### Configuration
+
+N/A — no configuration fields, environment variables, or overlay schema changed.
+
+## Usage Examples
+
+### Example: Using a newly added flagship model
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/petal-labs/iris/providers/anthropic"
+    "github.com/petal-labs/iris/providers/openai"
+    "github.com/petal-labs/iris/core"
+)
+
+func main() {
+    // Anthropic Claude Opus 5
+    ant := anthropic.New("") // reads ANTHROPIC_API_KEY
+    if info := anthropic.GetModelInfo(anthropic.ModelClaudeOpus5); info != nil {
+        fmt.Printf("%s reasoning=%v\n", info.DisplayName,
+            info.HasCapability(core.FeatureReasoning))
+    }
+    _ = ant
+
+    // OpenAI GPT-5.6 (routes through the Responses API automatically)
+    oai := openai.New("") // reads OPENAI_API_KEY
+    resp, err := oai.Chat(context.Background(), &core.ChatRequest{
+        Model:    openai.ModelGPT56,
+        Messages: []core.Message{{Role: core.RoleUser, Content: "Hello"}},
+    })
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(resp.Output)
+}
+```
+
+### Example: Error case — unknown model returns nil
+
+```go
+if info := openai.GetModelInfo("gpt-9-does-not-exist"); info == nil {
+    fmt.Println("model not in catalog") // GetModelInfo returns nil for unknown IDs
+}
+```
+
+## Integration Notes
+
+- The catalogs remain hand-maintained (`providers/<name>/models.go`), not the
+  output of the `cmd/gen-models` generator (which writes `models_gen.go`). This
+  change edits the hand-maintained files directly, consistent with prior syncs.
+- Data source: `https://models.dev/api.json` (mirror of the
+  `sst/models.dev` GitHub repository).
+
+## Breaking Changes & Migration
+
+None. All changes are additive except the `isGemini3Model` refactor, which is
+behavior-preserving for existing models and only extends coverage to the new
+Gemini 3.x entries.
+
+## Deferred / Out of Scope
+
+Per the chosen "curated flagships" scope, the following models.dev entries were
+intentionally not added:
+
+- Embeddings (`text-embedding-3-*`, `gemini-embedding-*`), TTS, video
+  (`veo-*`, `grok-imagine-*`), realtime, and dated snapshot IDs
+  (e.g. `gpt-4o-2024-08-06`, `claude-opus-4-5-20251101`).
+- Pruning of stale repo models no longer on models.dev (deferred to avoid a
+  breaking change).
+
+## Testing Notes
+
+- `go build ./...` succeeds.
+- `go test ./...` passes (full suite). Updated count assertions in the Anthropic,
+  Gemini, and Z.ai provider tests.
+- `gofmt -l` reports no formatting issues on the changed files.
+- `go vet` on the changed providers is clean. Pre-existing `gosec` G704 warnings
+  in `providers/{xai,zai}/client.go` and `providers/xai/streaming.go` are
+  unrelated to this change (untouched files).

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -5,7 +5,18 @@ import "github.com/petal-labs/iris/core"
 
 // Model constants for Anthropic Claude models.
 const (
-	// Claude 4.7 series (latest)
+	// Claude 5 series (latest)
+	ModelClaudeOpus5           core.ModelID = "claude-opus-5"
+	ModelClaudeOpus5Thinking   core.ModelID = "claude-opus-5-thinking"
+	ModelClaudeSonnet5         core.ModelID = "claude-sonnet-5"
+	ModelClaudeSonnet5Thinking core.ModelID = "claude-sonnet-5-thinking"
+	ModelClaudeFable5          core.ModelID = "claude-fable-5"
+
+	// Claude 4.8 series
+	ModelClaudeOpus48         core.ModelID = "claude-opus-4-8"
+	ModelClaudeOpus48Thinking core.ModelID = "claude-opus-4-8-thinking"
+
+	// Claude 4.7 series
 	ModelClaudeOpus47 core.ModelID = "claude-opus-4-7"
 
 	// Claude 4.6 series
@@ -27,7 +38,79 @@ const (
 
 // models is the static list of supported models.
 var models = []core.ModelInfo{
-	// Claude 4.7 series (latest)
+	// Claude 5 series (latest)
+	{
+		ID:          ModelClaudeOpus5,
+		DisplayName: "Claude Opus 5",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
+	{
+		ID:          ModelClaudeOpus5Thinking,
+		DisplayName: "Claude Opus 5 (Thinking)",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
+	{
+		ID:          ModelClaudeSonnet5,
+		DisplayName: "Claude Sonnet 5",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
+	{
+		ID:          ModelClaudeSonnet5Thinking,
+		DisplayName: "Claude Sonnet 5 (Thinking)",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
+	{
+		ID:          ModelClaudeFable5,
+		DisplayName: "Claude Fable 5",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
+	// Claude 4.8 series
+	{
+		ID:          ModelClaudeOpus48,
+		DisplayName: "Claude Opus 4.8",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
+	{
+		ID:          ModelClaudeOpus48Thinking,
+		DisplayName: "Claude Opus 4.8 (Thinking)",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
+	// Claude 4.7 series
 	{
 		ID:          ModelClaudeOpus47,
 		DisplayName: "Claude Opus 4.7",

--- a/providers/anthropic/provider_test.go
+++ b/providers/anthropic/provider_test.go
@@ -72,8 +72,8 @@ func TestModels(t *testing.T) {
 	p := New("test-key")
 	models := p.Models()
 
-	if len(models) != 11 {
-		t.Errorf("Models() count = %d, want 11", len(models))
+	if len(models) != 18 {
+		t.Errorf("Models() count = %d, want 18", len(models))
 	}
 
 	// Verify model IDs
@@ -83,6 +83,13 @@ func TestModels(t *testing.T) {
 	}
 
 	expected := []core.ModelID{
+		ModelClaudeOpus5,
+		ModelClaudeOpus5Thinking,
+		ModelClaudeSonnet5,
+		ModelClaudeSonnet5Thinking,
+		ModelClaudeFable5,
+		ModelClaudeOpus48,
+		ModelClaudeOpus48Thinking,
 		ModelClaudeOpus47,
 		ModelClaudeSonnet46,
 		ModelClaudeSonnet46Thinking,

--- a/providers/gemini/models.go
+++ b/providers/gemini/models.go
@@ -1,11 +1,24 @@
 // Package gemini provides a Google Gemini API provider implementation for Iris.
 package gemini
 
-import "github.com/petal-labs/iris/core"
+import (
+	"strings"
+
+	"github.com/petal-labs/iris/core"
+)
 
 // Model constants for Google Gemini models.
 const (
+	// Gemini 3.6 series (preview, latest)
+	ModelGemini36Flash core.ModelID = "gemini-3.6-flash"
+
+	// Gemini 3.5 series (preview)
+	ModelGemini35Flash     core.ModelID = "gemini-3.5-flash"
+	ModelGemini35FlashLite core.ModelID = "gemini-3.5-flash-lite"
+
 	// Gemini 3.1 series (preview)
+	ModelGemini31Pro               core.ModelID = "gemini-3.1-pro-preview"
+	ModelGemini31FlashLite         core.ModelID = "gemini-3.1-flash-lite"
 	ModelGemini31FlashImagePreview core.ModelID = "gemini-3.1-flash-image-preview"
 
 	// Gemini 3 series (preview)
@@ -27,7 +40,59 @@ const (
 
 // models is the static list of supported models.
 var models = []core.ModelInfo{
+	// Gemini 3.6 series (preview, latest)
+	{
+		ID:          ModelGemini36Flash,
+		DisplayName: "Gemini 3.6 Flash",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
+	// Gemini 3.5 series (preview)
+	{
+		ID:          ModelGemini35Flash,
+		DisplayName: "Gemini 3.5 Flash",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
+	{
+		ID:          ModelGemini35FlashLite,
+		DisplayName: "Gemini 3.5 Flash Lite",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
 	// Gemini 3.1 series (preview)
+	{
+		ID:          ModelGemini31Pro,
+		DisplayName: "Gemini 3.1 Pro Preview",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
+	{
+		ID:          ModelGemini31FlashLite,
+		DisplayName: "Gemini 3.1 Flash Lite",
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
 	{
 		ID:          ModelGemini31FlashImagePreview,
 		DisplayName: "Gemini 3.1 Flash Image Preview",
@@ -133,7 +198,8 @@ func GetModelInfo(id core.ModelID) *core.ModelInfo {
 }
 
 // isGemini3Model returns true if the model is a Gemini 3 series model.
+// This covers the 3, 3.1, 3.5, and 3.6 preview families, all of which use
+// the thinkingLevel reasoning control rather than Gemini 2.5's thinkingBudget.
 func isGemini3Model(model string) bool {
-	return model == string(ModelGemini3Pro) || model == string(ModelGemini3Flash) ||
-		model == string(ModelGemini3ProImage) || model == string(ModelGemini31FlashImagePreview)
+	return strings.HasPrefix(model, "gemini-3")
 }

--- a/providers/gemini/provider_test.go
+++ b/providers/gemini/provider_test.go
@@ -63,8 +63,8 @@ func TestModels(t *testing.T) {
 	p := New("test-key")
 	models := p.Models()
 
-	if len(models) != 9 {
-		t.Errorf("Models() count = %d, want 9", len(models))
+	if len(models) != 14 {
+		t.Errorf("Models() count = %d, want 14", len(models))
 	}
 
 	// Verify model IDs
@@ -74,6 +74,11 @@ func TestModels(t *testing.T) {
 	}
 
 	expected := []core.ModelID{
+		ModelGemini36Flash,
+		ModelGemini35Flash,
+		ModelGemini35FlashLite,
+		ModelGemini31Pro,
+		ModelGemini31FlashLite,
 		ModelGemini31FlashImagePreview,
 		ModelGemini3Pro,
 		ModelGemini3Flash,

--- a/providers/openai/models.go
+++ b/providers/openai/models.go
@@ -5,7 +5,21 @@ import "github.com/petal-labs/iris/core"
 
 // Model constants for OpenAI models.
 const (
-	// GPT-5.4 series (latest)
+	// GPT-5.6 series (latest)
+	ModelGPT56      core.ModelID = "gpt-5.6"
+	ModelGPT56Luna  core.ModelID = "gpt-5.6-luna"
+	ModelGPT56Sol   core.ModelID = "gpt-5.6-sol"
+	ModelGPT56Terra core.ModelID = "gpt-5.6-terra"
+
+	// GPT-5.5 series
+	ModelGPT55    core.ModelID = "gpt-5.5"
+	ModelGPT55Pro core.ModelID = "gpt-5.5-pro"
+
+	// GPT-5.3 series
+	ModelGPT53Codex      core.ModelID = "gpt-5.3-codex"
+	ModelGPT53CodexSpark core.ModelID = "gpt-5.3-codex-spark"
+
+	// GPT-5.4 series
 	ModelGPT54     core.ModelID = "gpt-5.4"
 	ModelGPT54Pro  core.ModelID = "gpt-5.4-pro"
 	ModelGPT54Mini core.ModelID = "gpt-5.4-mini"
@@ -52,11 +66,13 @@ const (
 	ModelO4Mini             core.ModelID = "o4-mini"
 	ModelO4MiniDeepResearch core.ModelID = "o4-mini-deep-research"
 	ModelO3                 core.ModelID = "o3"
+	ModelO3Pro              core.ModelID = "o3-pro"
 	ModelO3Mini             core.ModelID = "o3-mini"
 	ModelO1                 core.ModelID = "o1"
 	ModelO1Pro              core.ModelID = "o1-pro"
 
 	// Image generation models
+	ModelGPTImage2          core.ModelID = "gpt-image-2"
 	ModelGPTImage15         core.ModelID = "gpt-image-1.5"
 	ModelGPTImage1          core.ModelID = "gpt-image-1"
 	ModelGPTImage1Mini      core.ModelID = "gpt-image-1-mini"
@@ -67,7 +83,114 @@ const (
 
 // models is the static list of supported models.
 var models = []core.ModelInfo{
-	// GPT-5.4 series (latest - Responses API with reasoning and built-in tools)
+	// GPT-5.6 series (latest - Responses API with reasoning and built-in tools)
+	{
+		ID:          ModelGPT56,
+		DisplayName: "GPT-5.6",
+		APIEndpoint: core.APIEndpointResponses,
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+			core.FeatureBuiltInTools,
+			core.FeatureResponseChain,
+		},
+	},
+	{
+		ID:          ModelGPT56Luna,
+		DisplayName: "GPT-5.6 Luna",
+		APIEndpoint: core.APIEndpointResponses,
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+			core.FeatureBuiltInTools,
+			core.FeatureResponseChain,
+		},
+	},
+	{
+		ID:          ModelGPT56Sol,
+		DisplayName: "GPT-5.6 Sol",
+		APIEndpoint: core.APIEndpointResponses,
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+			core.FeatureBuiltInTools,
+			core.FeatureResponseChain,
+		},
+	},
+	{
+		ID:          ModelGPT56Terra,
+		DisplayName: "GPT-5.6 Terra",
+		APIEndpoint: core.APIEndpointResponses,
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+			core.FeatureBuiltInTools,
+			core.FeatureResponseChain,
+		},
+	},
+	// GPT-5.5 series (Responses API with reasoning and built-in tools)
+	{
+		ID:          ModelGPT55,
+		DisplayName: "GPT-5.5",
+		APIEndpoint: core.APIEndpointResponses,
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+			core.FeatureBuiltInTools,
+			core.FeatureResponseChain,
+		},
+	},
+	{
+		ID:          ModelGPT55Pro,
+		DisplayName: "GPT-5.5 Pro",
+		APIEndpoint: core.APIEndpointResponses,
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+			core.FeatureBuiltInTools,
+			core.FeatureResponseChain,
+		},
+	},
+	// GPT-5.3 series (Responses API with reasoning and built-in tools)
+	{
+		ID:          ModelGPT53Codex,
+		DisplayName: "GPT-5.3 Codex",
+		APIEndpoint: core.APIEndpointResponses,
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+			core.FeatureBuiltInTools,
+			core.FeatureResponseChain,
+		},
+	},
+	{
+		ID:          ModelGPT53CodexSpark,
+		DisplayName: "GPT-5.3 Codex Spark",
+		APIEndpoint: core.APIEndpointResponses,
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+			core.FeatureBuiltInTools,
+			core.FeatureResponseChain,
+		},
+	},
+	// GPT-5.4 series (Responses API with reasoning and built-in tools)
 	{
 		ID:          ModelGPT54,
 		DisplayName: "GPT-5.4",
@@ -441,6 +564,19 @@ var models = []core.ModelInfo{
 		},
 	},
 	{
+		ID:          ModelO3Pro,
+		DisplayName: "o3-pro",
+		APIEndpoint: core.APIEndpointResponses,
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+			core.FeatureBuiltInTools,
+			core.FeatureResponseChain,
+		},
+	},
+	{
 		ID:          ModelO3Mini,
 		DisplayName: "o3-mini",
 		APIEndpoint: core.APIEndpointResponses,
@@ -478,6 +614,13 @@ var models = []core.ModelInfo{
 		},
 	},
 	// Image generation models
+	{
+		ID:          ModelGPTImage2,
+		DisplayName: "GPT Image 2",
+		Capabilities: []core.Feature{
+			core.FeatureImageGeneration,
+		},
+	},
 	{
 		ID:          ModelGPTImage15,
 		DisplayName: "GPT Image 1.5",

--- a/providers/xai/models.go
+++ b/providers/xai/models.go
@@ -5,6 +5,12 @@ import "github.com/petal-labs/iris/core"
 
 // Model constants for xAI Grok models.
 const (
+	// Grok 4.5 series (latest)
+	ModelGrok45 core.ModelID = "grok-4.5"
+
+	// Grok 4.3 series
+	ModelGrok43 core.ModelID = "grok-4.3"
+
 	// Grok 4.20 series (multi-agent beta)
 	ModelGrok420MultiAgentBeta   core.ModelID = "grok-4.20-multi-agent-beta-0309"
 	ModelGrok420BetaReasoning    core.ModelID = "grok-4.20-beta-0309-reasoning"
@@ -26,10 +32,37 @@ const (
 
 	// Grok Code
 	ModelGrokCodeFast core.ModelID = "grok-code-fast"
+
+	// Grok Build
+	ModelGrokBuild01 core.ModelID = "grok-build-0.1"
 )
 
 // models is the static list of supported models.
 var models = []core.ModelInfo{
+	// Grok 4.5 series (latest)
+	{
+		ID:          ModelGrok45,
+		DisplayName: "Grok 4.5",
+		APIEndpoint: core.APIEndpointCompletions,
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
+	// Grok 4.3 series
+	{
+		ID:          ModelGrok43,
+		DisplayName: "Grok 4.3",
+		APIEndpoint: core.APIEndpointCompletions,
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
 	// Grok 4.20 series (multi-agent beta)
 	{
 		ID:          ModelGrok420MultiAgentBeta,
@@ -160,6 +193,18 @@ var models = []core.ModelInfo{
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
+		},
+	},
+	// Grok Build
+	{
+		ID:          ModelGrokBuild01,
+		DisplayName: "Grok Build 0.1",
+		APIEndpoint: core.APIEndpointCompletions,
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
 		},
 	},
 }

--- a/providers/zai/models.go
+++ b/providers/zai/models.go
@@ -5,6 +5,7 @@ import "github.com/petal-labs/iris/core"
 // Model constants for Z.ai GLM models.
 const (
 	// GLM-5 series (latest)
+	ModelGLM52      core.ModelID = "glm-5.2"
 	ModelGLM51      core.ModelID = "glm-5.1"
 	ModelGLM5       core.ModelID = "glm-5"
 	ModelGLM5Turbo  core.ModelID = "glm-5-turbo"
@@ -39,6 +40,17 @@ const (
 // models is the static list of supported models.
 var models = []core.ModelInfo{
 	// GLM-5 series (latest)
+	{
+		ID:          ModelGLM52,
+		DisplayName: "GLM-5.2",
+		APIEndpoint: core.APIEndpointCompletions,
+		Capabilities: []core.Feature{
+			core.FeatureChat,
+			core.FeatureChatStreaming,
+			core.FeatureToolCalling,
+			core.FeatureReasoning,
+		},
+	},
 	{
 		ID:          ModelGLM51,
 		DisplayName: "GLM-5.1",

--- a/providers/zai/models_test.go
+++ b/providers/zai/models_test.go
@@ -79,8 +79,8 @@ func TestModelCapabilities(t *testing.T) {
 }
 
 func TestModelsCount(t *testing.T) {
-	if len(models) != 19 {
-		t.Errorf("len(models) = %d, want 19", len(models))
+	if len(models) != 20 {
+		t.Errorf("len(models) = %d, want 20", len(models))
 	}
 }
 


### PR DESCRIPTION
## Summary

Syncs the curated per-provider model catalogs with the current [models.dev](https://models.dev/api.json) dataset. Additive only — no existing models were removed.

| Provider | Added |
|---|---|
| OpenAI | `gpt-5.6` (+luna/sol/terra), `gpt-5.5`/`-pro`, `gpt-5.3-codex`/`-spark`, `o3-pro`, `gpt-image-2` |
| Anthropic | `claude-opus-5` (+thinking), `claude-sonnet-5` (+thinking), `claude-fable-5`, `claude-opus-4-8` (+thinking) |
| Gemini | `gemini-3.6-flash`, `gemini-3.5-flash`/`-lite`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite` |
| xAI | `grok-4.5`, `grok-4.3`, `grok-build-0.1` |
| Z.ai | `glm-5.2` |

Perplexity was already current.

## Notable change

`isGemini3Model` was refactored from a fixed four-model equality list to a `strings.HasPrefix(model, "gemini-3")` check, so all Gemini 3.x families (3, 3.1, 3.5, 3.6) correctly use the `thinkingLevel` reasoning control instead of Gemini 2.5's `thinkingBudget`. Behavior for previously-listed models is unchanged.

New OpenAI reasoning models are declared with `APIEndpointResponses`, so `shouldUseResponsesAPI` routes them to the Responses API automatically.

## Testing

- `go build ./...` succeeds
- `go test ./...` passes (updated `Models()` count assertions for Anthropic 11→18, Gemini 9→14, Z.ai 19→20)
- `gofmt -l` clean on changed files

## Scope

Follows the repo's existing "curated flagships" convention: chat / reasoning / image models only. Embeddings, TTS, video, realtime, and dated snapshots were intentionally left out. Stale models no longer on models.dev were retained to avoid breaking references.

A `docs/changes/` record was added per the repository documentation policy.