### PR TITLE
docs(readme): update model references and examples to latest models

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ func main() {
     // Create a client
     client := core.NewClient(provider)
 
-    // Send a chat request (using latest Claude Sonnet 4.6)
-    resp, err := client.Chat("claude-sonnet-4-6").
+    // Send a chat request (using latest Claude Sonnet 5)
+    resp, err := client.Chat("claude-sonnet-5").
         System("You are a helpful assistant.").
         User("What is the capital of France?").
         GetResponse(context.Background())
@@ -154,8 +154,8 @@ func main() {
     // Create a client
     client := core.NewClient(provider)
 
-    // Send a chat request
-    resp, err := client.Chat("gemini-2.5-flash").
+    // Send a chat request (using latest Gemini 3.6 Flash)
+    resp, err := client.Chat("gemini-3.6-flash").
         System("You are a helpful assistant.").
         User("What is the capital of France?").
         GetResponse(context.Background())
@@ -205,8 +205,8 @@ func main() {
     // Create a client
     client := core.NewClient(provider)
 
-    // Send a chat request using Grok 4
-    resp, err := client.Chat(xai.ModelGrok4).
+    // Send a chat request using Grok 4.5
+    resp, err := client.Chat(xai.ModelGrok45).
         System("You are a helpful assistant.").
         User("What is the capital of France?").
         GetResponse(context.Background())
@@ -256,8 +256,8 @@ func main() {
     // Create a client
     client := core.NewClient(provider)
 
-    // Send a chat request using GLM-4.7
-    resp, err := client.Chat(zai.ModelGLM47).
+    // Send a chat request using GLM-5.2
+    resp, err := client.Chat(zai.ModelGLM52).
         System("You are a helpful assistant.").
         User("What is the capital of France?").
         GetResponse(context.Background())
@@ -274,8 +274,8 @@ func main() {
 Z.ai GLM models with thinking support:
 
 ```go
-// Use thinking mode with GLM-4.7 (enabled by default)
-resp, err := client.Chat(zai.ModelGLM47).
+// Use thinking mode with GLM-5.2 (enabled by default)
+resp, err := client.Chat(zai.ModelGLM52).
     User("Solve this step by step: What is 15% of 240?").
     ReasoningEffort(core.ReasoningEffortHigh).
     GetResponse(ctx)
@@ -592,7 +592,7 @@ provider := openai.New(os.Getenv("OPENAI_API_KEY"))
 
 // Generate an image
 resp, err := provider.GenerateImage(ctx, &core.ImageGenerateRequest{
-    Model:   openai.ModelGPTImage1,
+    Model:   openai.ModelGPTImage2,
     Prompt:  "A serene mountain landscape at sunset",
     Size:    core.ImageSize1024x1024,
     Quality: core.ImageQualityHigh,
@@ -640,19 +640,20 @@ resp, _ := provider.EditImage(ctx, &core.ImageEditRequest{
 
 | Model | Description |
 |-------|-------------|
-| `gpt-image-1.5` | Latest GPT Image model |
+| `gpt-image-2` | Latest GPT Image model |
+| `gpt-image-1.5` | GPT Image 1.5 |
 | `gpt-image-1` | Standard GPT Image |
 | `gpt-image-1-mini` | Fast, cost-effective |
 | `dall-e-3` | High quality (deprecated May 2026) |
 | `dall-e-2` | Lower cost, inpainting (deprecated May 2026) |
 
-### Using the Responses API (GPT-5.4)
+### Using the Responses API (GPT-5.6)
 
 GPT-5+ models automatically use OpenAI's Responses API, which provides advanced features like reasoning, built-in tools, and response chaining.
 
 ```go
-// GPT-5.4 uses the Responses API automatically
-resp, err := client.Chat("gpt-5.4").
+// GPT-5.6 uses the Responses API automatically
+resp, err := client.Chat("gpt-5.6").
     Instructions("You are a helpful research assistant.").
     User("What are the latest developments in quantum computing?").
     ReasoningEffort(core.ReasoningEffortHigh).
@@ -673,7 +674,7 @@ if resp.Reasoning != nil {
 }
 
 // Response chaining - continue from a previous response
-followUp, err := client.Chat("gpt-5.4").
+followUp, err := client.Chat("gpt-5.6").
     ContinueFrom(resp.ID).
     User("Can you elaborate on the most promising approach?").
     GetResponse(ctx)
@@ -694,16 +695,16 @@ iris keys set ollama  # Only needed for Ollama Cloud
 iris chat --provider openai --model gpt-4o --prompt "Hello, world!"
 
 # Chat with Anthropic Claude
-iris chat --provider anthropic --model claude-sonnet-4-6 --prompt "Hello, world!"
+iris chat --provider anthropic --model claude-sonnet-5 --prompt "Hello, world!"
 
 # Chat with Google Gemini
-iris chat --provider gemini --model gemini-2.5-flash --prompt "Hello, world!"
+iris chat --provider gemini --model gemini-3.6-flash --prompt "Hello, world!"
 
 # Chat with xAI Grok
-iris chat --provider xai --model grok-4 --prompt "Hello, world!"
+iris chat --provider xai --model grok-4.5 --prompt "Hello, world!"
 
 # Chat with Z.ai GLM
-iris chat --provider zai --model glm-4.7-flash --prompt "Hello, world!"
+iris chat --provider zai --model glm-5.2 --prompt "Hello, world!"
 
 # Chat with local Ollama (no API key needed)
 iris chat --provider ollama --model llama3.2 --prompt "Hello, world!"
@@ -713,7 +714,7 @@ iris chat --provider openai --model gpt-5 --prompt "Explain quantum entanglement
 
 # Stream responses
 iris chat --provider openai --model gpt-4o --prompt "Tell me a story" --stream
-iris chat --provider anthropic --model claude-sonnet-4-6 --prompt "Tell me a story" --stream
+iris chat --provider anthropic --model claude-sonnet-5 --prompt "Tell me a story" --stream
 
 # Get JSON output
 iris chat --provider openai --model gpt-4o --prompt "Hello" --json
@@ -753,7 +754,7 @@ Iris looks for configuration at `~/.iris/config.yaml`:
 
 ```yaml
 default_provider: openai
-default_model: gpt-5.4  # or gpt-4o for older models
+default_model: gpt-5.6  # or gpt-4o for older models
 
 providers:
   openai:
@@ -821,6 +822,8 @@ See [docs/SECURITY.md](docs/SECURITY.md) for comprehensive security documentatio
 
 | Model ID | Features |
 |----------|----------|
+| `grok-4.5` | Chat, Streaming, Tools, Reasoning (latest) |
+| `grok-4.3` | Chat, Streaming, Tools, Reasoning |
 | `grok-4.20-multi-agent-beta-0309` | Chat, Streaming, Tools, Reasoning (multi-agent beta) |
 | `grok-4.20-beta-0309-reasoning` | Chat, Streaming, Tools, Reasoning (beta) |
 | `grok-4.20-beta-0309-non-reasoning` | Chat, Streaming, Tools (beta) |
@@ -833,12 +836,14 @@ See [docs/SECURITY.md](docs/SECURITY.md) for comprehensive security documentatio
 | `grok-3` | Chat, Streaming, Tools, Reasoning |
 | `grok-3-mini` | Chat, Streaming, Tools, Reasoning (exposes reasoning_content) |
 | `grok-code-fast` | Chat, Streaming, Tools (code-optimized) |
+| `grok-build-0.1` | Chat, Streaming, Tools, Reasoning (build/agentic) |
 
 ### Z.ai GLM Models
 
 | Model ID | Features |
 |----------|----------|
-| `glm-5.1` | Chat, Streaming, Tools, Thinking (latest) |
+| `glm-5.2` | Chat, Streaming, Tools, Thinking (latest) |
+| `glm-5.1` | Chat, Streaming, Tools, Thinking |
 | `glm-5` | Chat, Streaming, Tools, Thinking |
 | `glm-5-turbo` | Chat, Streaming, Tools, Thinking |
 | `glm-5v-turbo` | Chat, Streaming, Tools, Thinking, Vision |
@@ -871,6 +876,11 @@ See [docs/SECURITY.md](docs/SECURITY.md) for comprehensive security documentatio
 
 | Model ID | Features |
 |----------|----------|
+| `gemini-3.6-flash` | Chat, Streaming, Tools, Reasoning (thinkingLevel, latest) |
+| `gemini-3.5-flash` | Chat, Streaming, Tools, Reasoning (thinkingLevel) |
+| `gemini-3.5-flash-lite` | Chat, Streaming, Tools, Reasoning (thinkingLevel) |
+| `gemini-3.1-pro-preview` | Chat, Streaming, Tools, Reasoning (thinkingLevel) |
+| `gemini-3.1-flash-lite` | Chat, Streaming, Tools, Reasoning (thinkingLevel) |
 | `gemini-3.1-flash-image-preview` | Chat, Streaming, Image Generation |
 | `gemini-3-pro-preview` | Chat, Streaming, Tools, Reasoning (thinkingLevel) |
 | `gemini-3-flash-preview` | Chat, Streaming, Tools, Reasoning (thinkingLevel) |

--- a/docs/changes/2026-07-28_v0.13.0_provider-model-catalog-update.md
+++ b/docs/changes/2026-07-28_v0.13.0_provider-model-catalog-update.md
@@ -13,6 +13,10 @@ affected_components:
   - providers/xai/models.go
   - providers/zai/models.go
   - providers/zai/models_test.go
+  - README.md
+  - examples/chat/responses-api/main.go
+  - examples/chat/xai-streaming/main.go
+  - examples/chat/zai-reasoning/main.go
 related_frds: []
 ---
 
@@ -258,3 +262,57 @@ intentionally not added:
 - `go vet` on the changed providers is clean. Pre-existing `gosec` G704 warnings
   in `providers/{xai,zai}/client.go` and `providers/xai/streaming.go` are
   unrelated to this change (untouched files).
+
+## Revision: 2026-07-28 01:17 UTC
+
+Documentation and examples follow-up to the catalog update above. No Go source
+in `providers/` or `core/` changed in this revision; only user-facing docs and
+example programs were updated to reference the newly added flagship models.
+
+### README.md
+
+- Provider quick-start snippets bumped to the newest flagship per provider:
+  - Anthropic example: `claude-sonnet-4-6` → `claude-sonnet-5`.
+  - Gemini example: `gemini-2.5-flash` → `gemini-3.6-flash`.
+  - xAI example: `xai.ModelGrok4` → `xai.ModelGrok45`.
+  - Z.ai examples (basic + thinking): `zai.ModelGLM47` → `zai.ModelGLM52`.
+- Responses API section retitled "GPT-5.4" → "GPT-5.6" and its `gpt-5.4`
+  snippets updated to `gpt-5.6`.
+- Image generation example: `openai.ModelGPTImage1` → `openai.ModelGPTImage2`.
+- CLI usage examples updated: `claude-sonnet-4-6` → `claude-sonnet-5`,
+  `gemini-2.5-flash` → `gemini-3.6-flash`, `grok-4` → `grok-4.5`,
+  `glm-4.7-flash` → `glm-5.2`.
+- Config sample `default_model: gpt-5.4` → `gpt-5.6`.
+- Model tables extended with the new entries:
+  - xAI Grok: added `grok-4.5` (latest), `grok-4.3`, `grok-build-0.1`.
+  - Z.ai GLM: added `glm-5.2` (latest); moved the "(latest)" tag off `glm-5.1`.
+  - Gemini: added `gemini-3.6-flash` (latest), `gemini-3.5-flash`,
+    `gemini-3.5-flash-lite`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`.
+  - Image models: added `gpt-image-2` (latest).
+
+### Example programs
+
+- `examples/chat/responses-api/main.go`: `openai.ModelGPT54` → `openai.ModelGPT56`
+  (the trailing `openai.ModelGPT4o` completions example is intentionally kept to
+  contrast the Chat Completions path).
+- `examples/chat/xai-streaming/main.go`: `xai.ModelGrok4` → `xai.ModelGrok45`.
+- `examples/chat/zai-reasoning/main.go`: `zai.ModelGLM47` → `zai.ModelGLM52`.
+
+### Intentionally left unchanged
+
+- Generic OpenAI feature demos on `gpt-4o` / `gpt-4o-mini` (streaming, tools,
+  structured output, batch, conversation, system-message) — these remain the
+  clearest Chat Completions examples and both models are still supported.
+- Model choices that are pedagogically specific: `grok-3-mini` (only model
+  exposing `reasoning_content`), the Gemini 2.5 `thinkingBudget` reasoning
+  snippet, and `*-flash` cost/speed demos.
+- CLI `defaultModel(provider)` defaults in `cli/commands/init.go` and the
+  README's "default for CLI" table annotations — unchanged to avoid a behavior
+  change; the tables' default markers stay consistent with the code.
+
+### Testing Notes (revision)
+
+- `go build ./...` succeeds; changed example programs build individually.
+- `go test ./...` passes (full suite; no test expectations affected by this
+  revision).
+- `gofmt -l` and `go vet` clean on the changed example files.

--- a/examples/chat/responses-api/main.go
+++ b/examples/chat/responses-api/main.go
@@ -1,7 +1,7 @@
 // Example: OpenAI Responses API
 //
 // This example demonstrates the new Responses API features available
-// with newer OpenAI models like GPT-5.4, including:
+// with newer OpenAI models like GPT-5.6, including:
 // - Reasoning with configurable effort levels
 // - Built-in tools (web search, code interpreter)
 // - Response chaining (continuing from previous responses)
@@ -41,9 +41,9 @@ func main() {
 	defer cancel()
 
 	// Example 1: Basic Responses API usage
-	// GPT-5.4 automatically uses the Responses API
+	// GPT-5.6 automatically uses the Responses API
 	fmt.Println("=== Example 1: Basic Responses API ===")
-	resp, err := client.Chat(openai.ModelGPT54).
+	resp, err := client.Chat(openai.ModelGPT56).
 		Instructions("You are a helpful assistant.").
 		User("What is the capital of France?").
 		GetResponse(ctx)
@@ -59,7 +59,7 @@ func main() {
 
 	// Example 2: Using reasoning with high effort
 	fmt.Println("=== Example 2: Reasoning with High Effort ===")
-	resp, err = client.Chat(openai.ModelGPT54).
+	resp, err = client.Chat(openai.ModelGPT56).
 		Instructions("You are a math tutor. Show your reasoning.").
 		User("What is 15% of 240?").
 		ReasoningEffort(core.ReasoningEffortHigh).
@@ -81,7 +81,7 @@ func main() {
 
 	// Example 3: Using built-in web search
 	fmt.Println("=== Example 3: Built-in Web Search ===")
-	resp, err = client.Chat(openai.ModelGPT54).
+	resp, err = client.Chat(openai.ModelGPT56).
 		Instructions("Use web search to find current information.").
 		User("What are the top news stories today?").
 		WebSearch().
@@ -97,7 +97,7 @@ func main() {
 
 	// Example 4: Response chaining
 	fmt.Println("=== Example 4: Response Chaining ===")
-	firstResp, err := client.Chat(openai.ModelGPT54).
+	firstResp, err := client.Chat(openai.ModelGPT56).
 		Instructions("You are a storyteller.").
 		User("Start a short story about a robot.").
 		GetResponse(ctx)
@@ -111,7 +111,7 @@ func main() {
 	fmt.Println()
 
 	// Continue from the previous response
-	secondResp, err := client.Chat(openai.ModelGPT54).
+	secondResp, err := client.Chat(openai.ModelGPT56).
 		ContinueFrom(firstResp.ID).
 		User("Continue the story with an unexpected twist.").
 		GetResponse(ctx)
@@ -126,7 +126,7 @@ func main() {
 
 	// Example 5: Streaming with Responses API
 	fmt.Println("=== Example 5: Streaming with Responses API ===")
-	stream, err := client.Chat(openai.ModelGPT54).
+	stream, err := client.Chat(openai.ModelGPT56).
 		Instructions("You are a poet.").
 		User("Write a haiku about programming.").
 		Stream(ctx)

--- a/examples/chat/xai-streaming/main.go
+++ b/examples/chat/xai-streaming/main.go
@@ -35,8 +35,8 @@ func main() {
 	fmt.Println("Streaming response from Grok:")
 	fmt.Println("---")
 
-	// Start streaming request with grok-4
-	stream, err := client.Chat(xai.ModelGrok4).
+	// Start streaming request with grok-4.5
+	stream, err := client.Chat(xai.ModelGrok45).
 		User("Write a short poem about space exploration. Make it 4 lines.").
 		Stream(ctx)
 

--- a/examples/chat/zai-reasoning/main.go
+++ b/examples/chat/zai-reasoning/main.go
@@ -19,8 +19,8 @@ func main() {
 	p := zai.New(apiKey)
 	c := core.NewClient(p)
 
-	// Use GLM-4.7 with thinking enabled
-	resp, err := c.Chat(zai.ModelGLM47).
+	// Use GLM-5.2 with thinking enabled
+	resp, err := c.Chat(zai.ModelGLM52).
 		System("You are a helpful assistant. Think step by step.").
 		User("What is 15% of 240?").
 		ReasoningEffort(core.ReasoningEffortHigh).


### PR DESCRIPTION
## Summary

Follow-up to #34 (the model catalog update, already merged). Points the README and example programs at the newly added flagship models.

## README

- Provider quick-start snippets → newest flagship: `claude-sonnet-5`, `gemini-3.6-flash`, `grok-4.5`, `glm-5.2`.
- Responses API section retitled to GPT-5.6; snippets use `gpt-5.6`.
- Image generation example → `gpt-image-2`.
- CLI usage examples and the `default_model` config sample refreshed to current models.
- Model tables extended: xAI (`grok-4.5`, `grok-4.3`, `grok-build-0.1`), Z.ai (`glm-5.2`), Gemini (`gemini-3.6-flash`, `gemini-3.5-flash`/`-lite`, `gemini-3.1-pro-preview`, `gemini-3.1-flash-lite`), Image (`gpt-image-2`).

## Examples

- `examples/chat/responses-api` → `openai.ModelGPT56`
- `examples/chat/xai-streaming` → `xai.ModelGrok45`
- `examples/chat/zai-reasoning` → `zai.ModelGLM52`

## Deliberately unchanged

Generic `gpt-4o` / `gpt-4o-mini` Chat Completions demos (streaming, tools, structured output, batch, conversation) and pedagogically specific choices (`grok-3-mini` reasoning_content demo, the Gemini 2.5 `thinkingBudget` snippet). CLI `defaultModel` defaults were left as-is to avoid a behavior change, so the tables' "default for CLI" markers stay consistent with the code.

## Testing

- `go build ./...` and `go test ./...` pass
- Changed example programs build individually; `gofmt`/`go vet` clean

The `docs/changes/` catalog-update record gains a revision section covering this doc/examples pass.