### PR TITLE
feat(ollama): implement core.EmbeddingProvider via /api/embed

### DIFF
--- a/docs/changes/2026-07-29_v0.14.0_ollama-embeddings-provider.md
+++ b/docs/changes/2026-07-29_v0.14.0_ollama-embeddings-provider.md
@@ -1,0 +1,248 @@
+---
+date: 2026-07-29
+version: v0.14.0
+feature: Ollama embeddings provider
+product: iris
+change_type: feature
+affected_components:
+  - providers/ollama/embeddings.go
+  - providers/ollama/embeddings_test.go
+  - providers/ollama/provider.go
+related_frds: []
+---
+
+## Summary
+
+The Ollama provider now implements `core.EmbeddingProvider`, generating single and
+batched embeddings through Ollama's native `POST /api/embed` endpoint. `Supports`
+now reports `core.FeatureEmbeddings`, and a compile-time assertion guarantees the
+interface stays implemented. This unblocks downstream consumers (e.g. Cortex) that
+type-assert the Ollama provider to `core.EmbeddingProvider` before starting.
+
+## Motivation
+
+Cortex documents Ollama as a supported embedding provider, but Cortex v0.2.0 (which
+depends on Iris v0.13.0) failed to start when configured with `embedding.provider:
+ollama`. Cortex calls `llm.NewEmbeddingProvider("ollama")`, which constructs an
+`*ollama.Ollama` and asserts it implements `core.EmbeddingProvider`. In v0.13.0 the
+Ollama provider implemented only `core.Provider` (chat operations) and did not
+implement `CreateEmbeddings`, so the assertion failed with:
+
+```
+provider ollama does not support embeddings
+```
+
+No request ever reached Ollama. This change makes the assertion succeed and lets
+Ollama serve embeddings (e.g. `nomic-embed-text`).
+
+## What Changed
+
+### New Additions
+
+- `providers/ollama/embeddings.go`
+  - `func (p *Ollama) CreateEmbeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error)` —
+    generates embeddings via `POST {BaseURL}/api/embed`, sending all inputs as one
+    batch and preserving input order, IDs, and metadata in the response.
+  - `ollamaEmbedRequest` — internal request body for `/api/embed`
+    (`model`, `input`, optional `truncate`, optional `dimensions`).
+  - `ollamaEmbedResponse` — internal response body
+    (`model`, `embeddings`, `prompt_eval_count`, optional inline `error`).
+  - `buildEmbedRequest` / `mapEmbedResponse` — internal request/response mappers.
+  - `const embedPath = "/api/embed"`.
+  - `var _ core.EmbeddingProvider = (*Ollama)(nil)` — compile-time interface assertion.
+- `providers/ollama/embeddings_test.go` — table of behavior tests (single input,
+  batch order, ID/metadata passthrough, dimensions/truncation mapping, field
+  omission, HTTP error normalization, malformed response, context cancellation,
+  `Supports(FeatureEmbeddings)`).
+
+### Modifications
+
+- `providers/ollama/provider.go` — `Supports` now returns `true` for
+  `core.FeatureEmbeddings`.
+
+  Before:
+
+  ```go
+  case core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling, core.FeatureReasoning:
+  ```
+
+  After:
+
+  ```go
+  case core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling, core.FeatureReasoning, core.FeatureEmbeddings:
+  ```
+
+### Removals
+
+N/A — no public API was removed or made internal.
+
+## Technical Specification
+
+### Data Schemas / Types
+
+Request body sent to `POST /api/embed`:
+
+```go
+type ollamaEmbedRequest struct {
+	Model      string   `json:"model"`               // required; the embedding model, e.g. "nomic-embed-text"
+	Input      []string `json:"input"`               // all EmbeddingRequest.Input texts, in order, as one batch
+	Truncate   *bool    `json:"truncate,omitempty"`  // maps EmbeddingRequest.Truncation; omitted when nil
+	Dimensions *int     `json:"dimensions,omitempty"` // maps EmbeddingRequest.Dimensions; omitted when nil
+}
+```
+
+Response body parsed from `POST /api/embed`:
+
+```go
+type ollamaEmbedResponse struct {
+	Model           string      `json:"model"`
+	Embeddings      [][]float32 `json:"embeddings"`
+	PromptEvalCount int         `json:"prompt_eval_count,omitempty"`
+	Error           string      `json:"error,omitempty"`
+}
+```
+
+Mapping to `core.EmbeddingResponse`:
+
+- `Embeddings[i]` → `Vectors[i].Vector`, with `Vectors[i].Index = i`.
+- `req.Input[i].ID` and `req.Input[i].Metadata` are copied onto `Vectors[i]`.
+- `prompt_eval_count` → both `Usage.PromptTokens` and `Usage.TotalTokens`
+  (Ollama reports a single prompt token count for embeddings).
+- Response `model` is used; if empty, the request model is echoed back.
+
+Fields on `core.EmbeddingRequest` that the native `/api/embed` endpoint does not
+support (`EncodingFormat`, `OutputDType`, `InputType`, `User`) are intentionally
+not sent. Ollama returns float vectors only; base64 output is not available on this
+endpoint.
+
+### API Endpoints
+
+N/A — no Iris daemon HTTP endpoints changed. The provider calls Ollama's upstream
+`POST /api/embed`.
+
+### CLI Interface
+
+N/A — no CLI commands changed.
+
+### Go Package API
+
+`*ollama.Ollama` now satisfies `core.EmbeddingProvider`:
+
+```go
+CreateEmbeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error)
+```
+
+Usage contract: send one request with all inputs; the returned `Vectors` slice is
+aligned by index to `req.Input`. Errors are returned as `*core.ProviderError` for
+HTTP failures (with normalized sentinels, e.g. `core.ErrBadRequest` for 404 model-
+not-found, `core.ErrNetwork` for transport failures). Context cancellation is
+honored via `http.NewRequestWithContext`.
+
+### Configuration
+
+No new configuration. Embeddings use the same `BaseURL`, `HTTPClient`, headers, and
+optional API key as chat requests. For local Ollama, point the provider at
+`http://localhost:11434` (the default) or set `OLLAMA_HOST`.
+
+## Usage Examples
+
+### Example: single and batch embeddings via Ollama
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/ollama"
+)
+
+func main() {
+	p := ollama.NewLocal() // uses OLLAMA_HOST or http://localhost:11434
+
+	dims := 768
+	resp, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "nomic-embed-text",
+		Input: []core.EmbeddingInput{
+			{Text: "Why is the sky blue?", ID: "doc-1"},
+			{Text: "Why is the grass green?", ID: "doc-2"},
+		},
+		Dimensions: &dims,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, v := range resp.Vectors {
+		fmt.Printf("index=%d id=%s dims=%d\n", v.Index, v.ID, len(v.Vector))
+	}
+	fmt.Printf("prompt tokens: %d\n", resp.Usage.PromptTokens)
+}
+```
+
+### Example: capability negotiation (how Cortex uses it)
+
+```go
+var provider core.Provider = ollama.NewLocal()
+
+if provider.Supports(core.FeatureEmbeddings) {
+	embedder := provider.(core.EmbeddingProvider) // now succeeds; previously panicked/failed
+	_ = embedder
+}
+```
+
+### Example: error case (model not pulled)
+
+```go
+_, err := p.CreateEmbeddings(ctx, &core.EmbeddingRequest{
+	Model: "nomic-embed-text",
+	Input: []core.EmbeddingInput{{Text: "hello"}},
+})
+// err is *core.ProviderError{Provider: "ollama", Status: 404, ...}
+// errors.Is(err, core.ErrBadRequest) == true
+```
+
+## Integration Notes
+
+Cortex v0.2.0 with `embedding.provider: ollama` now starts and can ingest/search
+using `nomic-embed-text`. Consumers should bump their Iris dependency to v0.14.0.
+No code changes are required on the consumer side beyond the version bump — the
+existing `NewEmbeddingProvider("ollama")` path now returns a working embedder.
+
+## Breaking Changes & Migration
+
+None. This is purely additive: a new method and an additional supported feature. No
+existing signatures or behavior changed.
+
+## Deferred / Out of Scope
+
+- Base64 (`encoding_format`) and non-float output dtypes are not supported by
+  Ollama's `/api/embed` and are not mapped.
+- `InputType` (query/document retrieval optimization) and `User` are not sent.
+- The provider's `Models()` list was not extended with embedding models; Ollama
+  models are dynamic and any pulled model may be used regardless of the example
+  list.
+
+## Testing Notes
+
+New tests in `providers/ollama/embeddings_test.go` (all passing, `-race` clean):
+
+- `TestCreateEmbeddings_SingleInput` — request shape, path, and response mapping.
+- `TestCreateEmbeddings_BatchPreservesOrder` — batched inputs, index alignment.
+- `TestCreateEmbeddings_PreservesIDAndMetadata` — ID/metadata passthrough.
+- `TestCreateEmbeddings_MapsDimensionsAndTruncation` — request field mapping.
+- `TestCreateEmbeddings_OmitsDimensionsAndTruncationWhenUnset` — omitempty behavior.
+- `TestCreateEmbeddings_HTTPError` — 404 normalizes to `*core.ProviderError` /
+  `core.ErrBadRequest`.
+- `TestCreateEmbeddings_MalformedResponse` — non-JSON body returns an error.
+- `TestCreateEmbeddings_ContextCancellation` — cancelled context returns an error.
+- `TestProviderSupports_Embeddings` — `Supports(core.FeatureEmbeddings)` is true.
+
+Run with:
+
+```
+go test -race ./providers/ollama/
+```

--- a/providers/ollama/embeddings.go
+++ b/providers/ollama/embeddings.go
@@ -1,0 +1,129 @@
+package ollama
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/petal-labs/iris/core"
+)
+
+// embedPath is the Ollama native embeddings endpoint.
+const embedPath = "/api/embed"
+
+// ollamaEmbedRequest is the request body for the Ollama /api/embed endpoint.
+type ollamaEmbedRequest struct {
+	Model      string   `json:"model"`
+	Input      []string `json:"input"`
+	Truncate   *bool    `json:"truncate,omitempty"`
+	Dimensions *int     `json:"dimensions,omitempty"`
+}
+
+// ollamaEmbedResponse is the response body from the Ollama /api/embed endpoint.
+type ollamaEmbedResponse struct {
+	Model           string      `json:"model"`
+	Embeddings      [][]float32 `json:"embeddings"`
+	PromptEvalCount int         `json:"prompt_eval_count,omitempty"`
+	Error           string      `json:"error,omitempty"`
+}
+
+// CreateEmbeddings generates embeddings for the given input texts using the
+// Ollama /api/embed endpoint. All inputs are sent as a single batch and the
+// returned vectors preserve input order, IDs, and metadata.
+func (p *Ollama) CreateEmbeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	ollamaReq := buildEmbedRequest(req)
+
+	body, err := json.Marshal(ollamaReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	url := p.config.BaseURL + embedPath
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	for key, values := range p.buildHeaders() {
+		for _, v := range values {
+			httpReq.Header.Add(key, v)
+		}
+	}
+
+	resp, err := p.config.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, &core.ProviderError{
+			Provider: "ollama",
+			Code:     "network_error",
+			Message:  err.Error(),
+			Err:      core.ErrNetwork,
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, parseErrorResponse(resp)
+	}
+
+	var embedResp ollamaEmbedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&embedResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if embedResp.Error != "" {
+		return nil, mapOllamaError(resp.StatusCode, embedResp.Error)
+	}
+
+	return mapEmbedResponse(&embedResp, req), nil
+}
+
+// buildEmbedRequest converts a core embedding request into the Ollama format.
+func buildEmbedRequest(req *core.EmbeddingRequest) *ollamaEmbedRequest {
+	inputs := make([]string, len(req.Input))
+	for i, input := range req.Input {
+		inputs[i] = input.Text
+	}
+
+	return &ollamaEmbedRequest{
+		Model:      string(req.Model),
+		Input:      inputs,
+		Truncate:   req.Truncation,
+		Dimensions: req.Dimensions,
+	}
+}
+
+// mapEmbedResponse converts an Ollama embed response into the core format,
+// preserving input order and carrying through each input's ID and metadata.
+func mapEmbedResponse(resp *ollamaEmbedResponse, req *core.EmbeddingRequest) *core.EmbeddingResponse {
+	vectors := make([]core.EmbeddingVector, len(resp.Embeddings))
+	for i, emb := range resp.Embeddings {
+		vec := core.EmbeddingVector{
+			Index:  i,
+			Vector: emb,
+		}
+		if i < len(req.Input) {
+			vec.ID = req.Input[i].ID
+			vec.Metadata = req.Input[i].Metadata
+		}
+		vectors[i] = vec
+	}
+
+	model := core.ModelID(resp.Model)
+	if model == "" {
+		model = req.Model
+	}
+
+	return &core.EmbeddingResponse{
+		Vectors: vectors,
+		Model:   model,
+		Usage: core.EmbeddingUsage{
+			PromptTokens: resp.PromptEvalCount,
+			TotalTokens:  resp.PromptEvalCount,
+		},
+	}
+}
+
+// Compile-time check that Ollama implements EmbeddingProvider.
+var _ core.EmbeddingProvider = (*Ollama)(nil)

--- a/providers/ollama/embeddings_test.go
+++ b/providers/ollama/embeddings_test.go
@@ -1,0 +1,323 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestCreateEmbeddings_SingleInput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/embed" {
+			t.Errorf("Path = %q, want /api/embed", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Content-Type header incorrect")
+		}
+
+		var req ollamaEmbedRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Failed to decode request: %v", err)
+		}
+		if req.Model != "nomic-embed-text" {
+			t.Errorf("Model = %q, want nomic-embed-text", req.Model)
+		}
+		if len(req.Input) != 1 || req.Input[0] != "hello world" {
+			t.Errorf("Input = %v, want [hello world]", req.Input)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(ollamaEmbedResponse{
+			Model:           "nomic-embed-text",
+			Embeddings:      [][]float32{{0.1, 0.2, 0.3}},
+			PromptEvalCount: 8,
+		})
+	}))
+	defer server.Close()
+
+	p := New(WithBaseURL(server.URL))
+
+	resp, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "nomic-embed-text",
+		Input: []core.EmbeddingInput{{Text: "hello world"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateEmbeddings() error = %v", err)
+	}
+
+	if len(resp.Vectors) != 1 {
+		t.Fatalf("len(Vectors) = %d, want 1", len(resp.Vectors))
+	}
+	if resp.Vectors[0].Index != 0 {
+		t.Errorf("Vectors[0].Index = %d, want 0", resp.Vectors[0].Index)
+	}
+	if len(resp.Vectors[0].Vector) != 3 {
+		t.Errorf("len(Vector) = %d, want 3", len(resp.Vectors[0].Vector))
+	}
+	if resp.Vectors[0].Vector[0] != 0.1 {
+		t.Errorf("Vector[0] = %v, want 0.1", resp.Vectors[0].Vector[0])
+	}
+	if resp.Model != "nomic-embed-text" {
+		t.Errorf("Model = %q, want nomic-embed-text", resp.Model)
+	}
+	if resp.Usage.PromptTokens != 8 {
+		t.Errorf("Usage.PromptTokens = %d, want 8", resp.Usage.PromptTokens)
+	}
+	if resp.Usage.TotalTokens != 8 {
+		t.Errorf("Usage.TotalTokens = %d, want 8", resp.Usage.TotalTokens)
+	}
+}
+
+func TestCreateEmbeddings_BatchPreservesOrder(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollamaEmbedRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Failed to decode request: %v", err)
+		}
+		if len(req.Input) != 3 {
+			t.Errorf("len(Input) = %d, want 3", len(req.Input))
+		}
+		if req.Input[0] != "one" || req.Input[1] != "two" || req.Input[2] != "three" {
+			t.Errorf("Input = %v, want [one two three]", req.Input)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(ollamaEmbedResponse{
+			Model: "nomic-embed-text",
+			Embeddings: [][]float32{
+				{0.1},
+				{0.2},
+				{0.3},
+			},
+			PromptEvalCount: 6,
+		})
+	}))
+	defer server.Close()
+
+	p := New(WithBaseURL(server.URL))
+
+	resp, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "nomic-embed-text",
+		Input: []core.EmbeddingInput{
+			{Text: "one"},
+			{Text: "two"},
+			{Text: "three"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateEmbeddings() error = %v", err)
+	}
+
+	if len(resp.Vectors) != 3 {
+		t.Fatalf("len(Vectors) = %d, want 3", len(resp.Vectors))
+	}
+	want := []float32{0.1, 0.2, 0.3}
+	for i, vec := range resp.Vectors {
+		if vec.Index != i {
+			t.Errorf("Vectors[%d].Index = %d, want %d", i, vec.Index, i)
+		}
+		if len(vec.Vector) != 1 || vec.Vector[0] != want[i] {
+			t.Errorf("Vectors[%d].Vector = %v, want [%v]", i, vec.Vector, want[i])
+		}
+	}
+}
+
+func TestCreateEmbeddings_PreservesIDAndMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(ollamaEmbedResponse{
+			Model: "nomic-embed-text",
+			Embeddings: [][]float32{
+				{0.1},
+				{0.2},
+			},
+			PromptEvalCount: 4,
+		})
+	}))
+	defer server.Close()
+
+	p := New(WithBaseURL(server.URL))
+
+	resp, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "nomic-embed-text",
+		Input: []core.EmbeddingInput{
+			{Text: "first", ID: "id-1", Metadata: map[string]string{"source": "doc1"}},
+			{Text: "second", ID: "id-2", Metadata: map[string]string{"source": "doc2"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateEmbeddings() error = %v", err)
+	}
+
+	if resp.Vectors[0].ID != "id-1" {
+		t.Errorf("Vectors[0].ID = %q, want id-1", resp.Vectors[0].ID)
+	}
+	if resp.Vectors[1].ID != "id-2" {
+		t.Errorf("Vectors[1].ID = %q, want id-2", resp.Vectors[1].ID)
+	}
+	if resp.Vectors[0].Metadata["source"] != "doc1" {
+		t.Errorf("Vectors[0].Metadata[source] = %q, want doc1", resp.Vectors[0].Metadata["source"])
+	}
+	if resp.Vectors[1].Metadata["source"] != "doc2" {
+		t.Errorf("Vectors[1].Metadata[source] = %q, want doc2", resp.Vectors[1].Metadata["source"])
+	}
+}
+
+func TestCreateEmbeddings_MapsDimensionsAndTruncation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ollamaEmbedRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("Failed to decode request: %v", err)
+		}
+		if req.Dimensions == nil || *req.Dimensions != 768 {
+			t.Errorf("Dimensions = %v, want 768", req.Dimensions)
+		}
+		if req.Truncate == nil || *req.Truncate != true {
+			t.Errorf("Truncate = %v, want true", req.Truncate)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(ollamaEmbedResponse{
+			Model:           "nomic-embed-text",
+			Embeddings:      [][]float32{{0.1, 0.2}},
+			PromptEvalCount: 2,
+		})
+	}))
+	defer server.Close()
+
+	p := New(WithBaseURL(server.URL))
+
+	dims := 768
+	truncate := true
+	_, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model:      "nomic-embed-text",
+		Input:      []core.EmbeddingInput{{Text: "hello"}},
+		Dimensions: &dims,
+		Truncation: &truncate,
+	})
+	if err != nil {
+		t.Fatalf("CreateEmbeddings() error = %v", err)
+	}
+}
+
+func TestCreateEmbeddings_OmitsDimensionsAndTruncationWhenUnset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var raw map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+			t.Fatalf("Failed to decode request: %v", err)
+		}
+		if _, ok := raw["dimensions"]; ok {
+			t.Error("dimensions should be omitted when unset")
+		}
+		if _, ok := raw["truncate"]; ok {
+			t.Error("truncate should be omitted when unset")
+		}
+
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(ollamaEmbedResponse{
+			Model:      "nomic-embed-text",
+			Embeddings: [][]float32{{0.1}},
+		})
+	}))
+	defer server.Close()
+
+	p := New(WithBaseURL(server.URL))
+
+	_, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "nomic-embed-text",
+		Input: []core.EmbeddingInput{{Text: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateEmbeddings() error = %v", err)
+	}
+}
+
+func TestCreateEmbeddings_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(ollamaErrorResponse{
+			Error: `model "nomic-embed-text" not found, try pulling it first`,
+		})
+	}))
+	defer server.Close()
+
+	p := New(WithBaseURL(server.URL))
+
+	_, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "nomic-embed-text",
+		Input: []core.EmbeddingInput{{Text: "hello"}},
+	})
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	var provErr *core.ProviderError
+	if !errors.As(err, &provErr) {
+		t.Fatalf("Expected ProviderError, got %T", err)
+	}
+	if provErr.Status != http.StatusNotFound {
+		t.Errorf("Status = %d, want %d", provErr.Status, http.StatusNotFound)
+	}
+	if provErr.Provider != "ollama" {
+		t.Errorf("Provider = %q, want ollama", provErr.Provider)
+	}
+	if !errors.Is(provErr, core.ErrBadRequest) {
+		t.Errorf("Expected ErrBadRequest for 404, got %v", provErr.Err)
+	}
+}
+
+func TestCreateEmbeddings_MalformedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("this is not json"))
+	}))
+	defer server.Close()
+
+	p := New(WithBaseURL(server.URL))
+
+	_, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "nomic-embed-text",
+		Input: []core.EmbeddingInput{{Text: "hello"}},
+	})
+	if err == nil {
+		t.Fatal("Expected error for malformed response, got nil")
+	}
+}
+
+func TestCreateEmbeddings_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	p := New(WithBaseURL(server.URL))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := p.CreateEmbeddings(ctx, &core.EmbeddingRequest{
+		Model: "nomic-embed-text",
+		Input: []core.EmbeddingInput{{Text: "hello"}},
+	})
+	if err == nil {
+		t.Fatal("Expected error for cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) && !errors.Is(err, core.ErrNetwork) {
+		t.Errorf("Expected context.Canceled or ErrNetwork, got %v", err)
+	}
+}
+
+func TestProviderSupports_Embeddings(t *testing.T) {
+	p := New()
+	if !p.Supports(core.FeatureEmbeddings) {
+		t.Error("Supports(FeatureEmbeddings) = false, want true")
+	}
+}

--- a/providers/ollama/provider.go
+++ b/providers/ollama/provider.go
@@ -102,7 +102,7 @@ func (p *Ollama) Models() []core.ModelInfo {
 // Supports reports whether the provider supports the given feature.
 func (p *Ollama) Supports(feature core.Feature) bool {
 	switch feature {
-	case core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling, core.FeatureReasoning:
+	case core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling, core.FeatureReasoning, core.FeatureEmbeddings:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Problem

Cortex v0.2.0 (depending on Iris v0.13.0) cannot start when configured with `embedding.provider: ollama`, exiting with:

```
provider ollama does not support embeddings
```

Cortex calls `llm.NewEmbeddingProvider("ollama")`, which constructs an `*ollama.Ollama` and type-asserts it to `core.EmbeddingProvider`. The assertion failed because the Ollama provider implemented only `core.Provider` (chat) and neither implemented `CreateEmbeddings` nor reported `core.FeatureEmbeddings`.

## Change

- Implement `CreateEmbeddings` on `*ollama.Ollama` against Ollama's native `POST /api/embed`.
- Send all `EmbeddingRequest.Input` entries as a single batch; map returned vectors to `EmbeddingResponse.Vectors` in input order, preserving input IDs and metadata.
- Map the request's `Model`, `Dimensions`, and `Truncation` options; map `prompt_eval_count` into embedding usage.
- Report `core.FeatureEmbeddings` from `Supports`.
- Add compile-time assertion `var _ core.EmbeddingProvider = (*Ollama)(nil)`.
- Normalize HTTP and transport errors to `*core.ProviderError`; honor context cancellation.

Purely additive — no existing signatures or behavior change.

## Tests

New `providers/ollama/embeddings_test.go` (all passing, `-race` clean):

- Single-input request shape and response mapping
- Batch input order / index alignment
- ID and metadata passthrough
- Dimensions and truncation request mapping (+ omitempty when unset)
- HTTP 404 normalizes to `core.ErrBadRequest`
- Malformed response returns an error
- Context cancellation returns an error
- `Supports(core.FeatureEmbeddings)` is true

```
go test -race ./providers/ollama/
```

## Docs

Adds `docs/changes/2026-07-29_v0.14.0_ollama-embeddings-provider.md` per the repo documentation policy.