### PR TITLE
feat(core): add execution timeout for LLM calls

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -821,11 +821,11 @@ func wrapStreamWithTelemetry(
 					select {
 					case err, ok := <-stream.Err:
 						if ok {
-							finalErr = err
 							out := err
 							if mapErr != nil {
 								out = mapErr(err)
 							}
+							finalErr = out
 							errCh <- out
 						}
 					default:
@@ -834,11 +834,11 @@ func wrapStreamWithTelemetry(
 				}
 			case err, ok := <-stream.Err:
 				if ok {
-					finalErr = err
 					out := err
 					if mapErr != nil {
 						out = mapErr(err)
 					}
+					finalErr = out
 					errCh <- out
 				}
 				// If Err closed without value, continue to wait for Final

--- a/core/client.go
+++ b/core/client.go
@@ -573,9 +573,15 @@ retryLoop:
 // Stream executes the chat request and returns a streaming response.
 // It applies validation and telemetry.
 //
-// Note: The Timeout() setting is NOT applied to streaming requests because
-// the context must outlive this method call. For streaming with timeouts,
-// create the context externally:
+// The effective execution timeout (see effectiveTimeout for precedence) is
+// applied to the context used to establish the stream. The derived timeout
+// context is NOT cancelled when Stream returns; it stays alive until the
+// stream completes (successfully or with an error) or the deadline fires,
+// so the timeout does not truncate an in-flight stream prematurely.
+//
+// A caller-supplied ctx deadline is never remapped to ErrTimeout — only a
+// deadline applied internally by Iris is. To apply a timeout externally
+// instead:
 //
 //	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 //	defer cancel()
@@ -583,6 +589,20 @@ retryLoop:
 func (b *ChatBuilder) Stream(ctx context.Context) (*ChatStream, error) {
 	if err := b.validate(); err != nil {
 		return nil, err
+	}
+
+	// Apply the effective execution timeout (see effectiveTimeout for precedence).
+	// cancel is intentionally NOT deferred here: on success it is handed to
+	// wrapStreamWithTelemetry via onDone, which fires it exactly once when the
+	// stream completes or the deadline fires. On a setup error we cancel
+	// immediately below.
+	var (
+		cancel  context.CancelFunc
+		timeout time.Duration
+	)
+	if d := b.effectiveTimeout(ctx); d > 0 {
+		ctx, cancel = context.WithTimeout(ctx, d)
+		timeout = d
 	}
 
 	start := time.Now()
@@ -602,6 +622,13 @@ func (b *ChatBuilder) Stream(ctx context.Context) (*ChatStream, error) {
 
 	stream, err := b.client.provider.StreamChat(ctx, &b.req)
 	if err != nil {
+		if cancel != nil {
+			cancel()
+		}
+		// Map an Iris-applied deadline to a legible typed error.
+		if timeout > 0 && errors.Is(err, context.DeadlineExceeded) {
+			err = newTimeoutError(timeout)
+		}
 		// Emit telemetry end on immediate error
 		endEvent := RequestEndEvent{
 			Provider: providerID,
@@ -618,8 +645,25 @@ func (b *ChatBuilder) Stream(ctx context.Context) (*ChatStream, error) {
 		return nil, err
 	}
 
+	// onDone releases the timeout context exactly once, when the stream
+	// completes (success or error) or the deadline fires — never when
+	// Stream itself returns.
+	onDone := func() {
+		if cancel != nil {
+			cancel()
+		}
+	}
+	// mapErr remaps a mid-stream Iris-applied deadline to ErrTimeout while
+	// leaving caller-supplied deadlines and all other errors untouched.
+	mapErr := func(e error) error {
+		if timeout > 0 && errors.Is(e, context.DeadlineExceeded) {
+			return newTimeoutError(timeout)
+		}
+		return e
+	}
+
 	// Wrap the stream to emit telemetry when it completes
-	return wrapStreamWithTelemetry(ctx, stream, b.client.telemetry, providerID, b.req.Model, start), nil
+	return wrapStreamWithTelemetry(ctx, stream, b.client.telemetry, providerID, b.req.Model, start, onDone, mapErr), nil
 }
 
 // MessageBuilder provides a fluent API for building multimodal messages.
@@ -735,6 +779,11 @@ func (b *ChatBuilder) UserWithFileID(text, fileID string) *ChatBuilder {
 }
 
 // wrapStreamWithTelemetry wraps a ChatStream to emit telemetry on completion.
+// onDone, if non-nil, is invoked exactly once when the stream completes
+// (successfully or with an error) — used by Stream to release an
+// Iris-applied timeout context without truncating an in-flight stream.
+// mapErr, if non-nil, remaps errors forwarded on the returned Err channel
+// (e.g. a mid-stream Iris-applied deadline into ErrTimeout).
 func wrapStreamWithTelemetry(
 	ctx context.Context,
 	stream *ChatStream,
@@ -742,6 +791,8 @@ func wrapStreamWithTelemetry(
 	provider string,
 	model ModelID,
 	start time.Time,
+	onDone func(),
+	mapErr func(error) error,
 ) *ChatStream {
 	finalCh := make(chan *ChatResponse, 1)
 	errCh := make(chan error, 1)
@@ -749,6 +800,9 @@ func wrapStreamWithTelemetry(
 	go func() {
 		defer close(finalCh)
 		defer close(errCh)
+		if onDone != nil {
+			defer onDone()
+		}
 
 		var finalResp *ChatResponse
 		var finalErr error
@@ -768,7 +822,11 @@ func wrapStreamWithTelemetry(
 					case err, ok := <-stream.Err:
 						if ok {
 							finalErr = err
-							errCh <- err
+							out := err
+							if mapErr != nil {
+								out = mapErr(err)
+							}
+							errCh <- out
 						}
 					default:
 					}
@@ -777,7 +835,11 @@ func wrapStreamWithTelemetry(
 			case err, ok := <-stream.Err:
 				if ok {
 					finalErr = err
-					errCh <- err
+					out := err
+					if mapErr != nil {
+						out = mapErr(err)
+					}
+					errCh <- out
 				}
 				// If Err closed without value, continue to wait for Final
 			}

--- a/core/client.go
+++ b/core/client.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -487,13 +488,15 @@ func (b *ChatBuilder) GetResponse(ctx context.Context) (*ChatResponse, error) {
 		return nil, err
 	}
 
-	// Apply timeout if set and context has no deadline
-	if b.timeout > 0 {
-		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
-			var cancel context.CancelFunc
-			ctx, cancel = context.WithTimeout(ctx, b.timeout)
-			defer cancel()
-		}
+	// Apply the effective execution timeout (see effectiveTimeout for precedence).
+	// timedOut records that any resulting DeadlineExceeded is Iris-owned and
+	// should surface as ErrTimeout rather than a raw context error.
+	var timedOut time.Duration
+	if d := b.effectiveTimeout(ctx); d > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, d)
+		defer cancel()
+		timedOut = d
 	}
 
 	start := time.Now()
@@ -536,6 +539,11 @@ retryLoop:
 		case <-time.After(delay):
 			continue
 		}
+	}
+
+	// Map an Iris-applied deadline to a legible typed error.
+	if timedOut > 0 && err != nil && errors.Is(err, context.DeadlineExceeded) {
+		err = newTimeoutError(timedOut)
 	}
 
 	// Emit telemetry end

--- a/core/client.go
+++ b/core/client.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+// DefaultTimeout is the execution timeout applied to chat and streaming calls
+// when neither the caller's context nor a per-call Timeout() supplies one.
+// Disable it per client with WithTimeout(0).
+const DefaultTimeout = 120 * time.Second
+
 // Provider is the interface that LLM providers must implement.
 // Providers SHOULD be safe for concurrent calls.
 // If a provider cannot be concurrent-safe, it MUST document this.
@@ -46,6 +51,7 @@ type Client struct {
 	telemetry      TelemetryHook
 	retry          RetryPolicy
 	warningHandler WarningHandler
+	timeout        time.Duration
 }
 
 // ClientOption configures a Client.
@@ -62,6 +68,7 @@ func NewClient(p Provider, opts ...ClientOption) *Client {
 		telemetry:      NoopTelemetryHook{},
 		retry:          DefaultRetryPolicy(),
 		warningHandler: func(string) {},
+		timeout:        DefaultTimeout,
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -94,6 +101,15 @@ func WithWarningHandler(h WarningHandler) ClientOption {
 		if h != nil {
 			c.warningHandler = h
 		}
+	}
+}
+
+// WithTimeout sets the default execution timeout applied to chat and streaming
+// calls when the caller's context has no deadline of its own and no per-call
+// Timeout() is set. Pass 0 to disable the default and allow unbounded calls.
+func WithTimeout(d time.Duration) ClientOption {
+	return func(c *Client) {
+		c.timeout = d
 	}
 }
 
@@ -428,6 +444,19 @@ func (b *ChatBuilder) ToolError(assistantResp *ChatResponse, callID string, err 
 		Content: err.Error(),
 		IsError: true,
 	}})
+}
+
+// effectiveTimeout resolves the timeout to apply for this call, or 0 for none.
+// Precedence: an existing ctx deadline wins (returns 0, no wrapping); then a
+// per-call builder timeout; then the client default.
+func (b *ChatBuilder) effectiveTimeout(ctx context.Context) time.Duration {
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		return 0
+	}
+	if b.timeout > 0 {
+		return b.timeout
+	}
+	return b.client.timeout
 }
 
 // validate checks that the request is valid.

--- a/core/errors.go
+++ b/core/errors.go
@@ -1,8 +1,10 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"time"
 )
 
 // ProviderError represents an error returned by a provider with full context.
@@ -54,3 +56,15 @@ var (
 	ErrModelRequired = errors.New("model required: pass a model ID to Client.Chat(), e.g., client.Chat(\"gpt-4\")")
 	ErrNoMessages    = errors.New("no messages: add at least one message using .System(), .User(), or .Assistant()")
 )
+
+// ErrTimeout indicates an Iris-imposed execution timeout elapsed before the
+// provider call completed. It wraps context.DeadlineExceeded, so
+// errors.Is(err, context.DeadlineExceeded) also holds.
+var ErrTimeout = errors.New("execution timeout")
+
+// newTimeoutError builds a timeout error carrying the elapsed budget. The
+// returned error satisfies errors.Is for both ErrTimeout and
+// context.DeadlineExceeded.
+func newTimeoutError(d time.Duration) error {
+	return fmt.Errorf("iris: %w after %s: %w", ErrTimeout, d, context.DeadlineExceeded)
+}

--- a/core/errors_test.go
+++ b/core/errors_test.go
@@ -1,8 +1,11 @@
 package core
 
 import (
+	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestProviderErrorImplementsError(t *testing.T) {
@@ -240,6 +243,20 @@ func TestErrorChaining(t *testing.T) {
 	}
 	if pe.Provider != "openai" {
 		t.Errorf("Provider = %v, want openai", pe.Provider)
+	}
+}
+
+func TestNewTimeoutError(t *testing.T) {
+	err := newTimeoutError(120 * time.Second)
+
+	if !errors.Is(err, ErrTimeout) {
+		t.Errorf("errors.Is(err, ErrTimeout) = false, want true")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("errors.Is(err, context.DeadlineExceeded) = false, want true")
+	}
+	if !strings.Contains(err.Error(), "2m0s") {
+		t.Errorf("err.Error() = %q, want it to contain the duration", err.Error())
 	}
 }
 

--- a/core/timeout_test.go
+++ b/core/timeout_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -49,5 +50,65 @@ func TestEffectiveTimeoutPrecedence(t *testing.T) {
 	b3 := c.Chat("m")
 	if got := b3.effectiveTimeout(context.Background()); got != 30*time.Second {
 		t.Errorf("client default = %v, want 30s", got)
+	}
+}
+
+// noRetryPolicy is a retry policy that never retries.
+type noRetryPolicy struct{}
+
+func (noRetryPolicy) NextDelay(attempt int, err error) (time.Duration, bool) {
+	return 0, false
+}
+
+// blockingProvider blocks Chat until ctx is cancelled, then returns ctx.Err().
+type blockingProvider struct{}
+
+func (blockingProvider) ID() string { return "blocking" }
+func (blockingProvider) Models() []ModelInfo { return nil }
+func (blockingProvider) Supports(feature Feature) bool { return false }
+func (blockingProvider) Chat(ctx context.Context, _ *ChatRequest) (*ChatResponse, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+func (blockingProvider) StreamChat(ctx context.Context, _ *ChatRequest) (*ChatStream, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestGetResponseTimesOutWithErrTimeout(t *testing.T) {
+	c := NewClient(blockingProvider{}, WithTimeout(50*time.Millisecond),
+		WithRetryPolicy(noRetryPolicy{}))
+
+	_, err := c.Chat("m").User("hi").GetResponse(context.Background())
+
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("err = %v, want ErrTimeout", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want it to wrap DeadlineExceeded", err)
+	}
+}
+
+func TestGetResponseCallerDeadlineNotRemapped(t *testing.T) {
+	c := NewClient(blockingProvider{}, WithRetryPolicy(noRetryPolicy{}))
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := c.Chat("m").User("hi").GetResponse(ctx)
+
+	if errors.Is(err, ErrTimeout) {
+		t.Errorf("caller deadline was remapped to ErrTimeout; want raw context error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestGetResponseDisabledTimeoutDoesNotFire(t *testing.T) {
+	c := NewClient(&mockProvider{}, WithTimeout(0))
+	// mockProvider returns promptly; assert no ErrTimeout on the happy path.
+	_, err := c.Chat("m").User("hi").GetResponse(context.Background())
+	if errors.Is(err, ErrTimeout) {
+		t.Errorf("unexpected ErrTimeout with timeout disabled: %v", err)
 	}
 }

--- a/core/timeout_test.go
+++ b/core/timeout_test.go
@@ -63,8 +63,8 @@ func (noRetryPolicy) NextDelay(attempt int, err error) (time.Duration, bool) {
 // blockingProvider blocks Chat until ctx is cancelled, then returns ctx.Err().
 type blockingProvider struct{}
 
-func (blockingProvider) ID() string { return "blocking" }
-func (blockingProvider) Models() []ModelInfo { return nil }
+func (blockingProvider) ID() string                    { return "blocking" }
+func (blockingProvider) Models() []ModelInfo           { return nil }
 func (blockingProvider) Supports(feature Feature) bool { return false }
 func (blockingProvider) Chat(ctx context.Context, _ *ChatRequest) (*ChatResponse, error) {
 	<-ctx.Done()
@@ -110,5 +110,51 @@ func TestGetResponseDisabledTimeoutDoesNotFire(t *testing.T) {
 	_, err := c.Chat("m").User("hi").GetResponse(context.Background())
 	if errors.Is(err, ErrTimeout) {
 		t.Errorf("unexpected ErrTimeout with timeout disabled: %v", err)
+	}
+}
+
+// fastStreamProvider emits one chunk then closes immediately.
+type fastStreamProvider struct{}
+
+func (fastStreamProvider) ID() string                    { return "faststream" }
+func (fastStreamProvider) Models() []ModelInfo           { return nil }
+func (fastStreamProvider) Supports(feature Feature) bool { return false }
+func (fastStreamProvider) Chat(context.Context, *ChatRequest) (*ChatResponse, error) {
+	return nil, ErrNotSupported
+}
+func (fastStreamProvider) StreamChat(_ context.Context, _ *ChatRequest) (*ChatStream, error) {
+	ch := make(chan ChatChunk, 1)
+	errc := make(chan error)
+	final := make(chan *ChatResponse, 1)
+	ch <- ChatChunk{Delta: "hello"}
+	close(ch)
+	final <- &ChatResponse{Output: "hello"}
+	close(final)
+	close(errc)
+	return &ChatStream{Ch: ch, Err: errc, Final: final}, nil
+}
+
+func TestStreamFastCompletesNotCancelled(t *testing.T) {
+	c := NewClient(fastStreamProvider{}, WithTimeout(50*time.Millisecond))
+	stream, err := c.Chat("m").User("hi").Stream(context.Background())
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	resp, err := DrainStream(context.Background(), stream)
+	if err != nil {
+		t.Fatalf("DrainStream error = %v", err)
+	}
+	if resp.Output != "hello" {
+		t.Errorf("Output = %q, want %q", resp.Output, "hello")
+	}
+}
+
+func TestStreamStalledTimesOut(t *testing.T) {
+	// blockingProvider.StreamChat blocks until ctx cancels, then returns ctx.Err()
+	// as a setup error (StreamChat returns error, not a stream).
+	c := NewClient(blockingProvider{}, WithTimeout(50*time.Millisecond))
+	_, err := c.Chat("m").User("hi").Stream(context.Background())
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("Stream() err = %v, want ErrTimeout", err)
 	}
 }

--- a/core/timeout_test.go
+++ b/core/timeout_test.go
@@ -1,0 +1,53 @@
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewClientDefaultTimeout(t *testing.T) {
+	c := NewClient(&mockProvider{})
+	if c.timeout != DefaultTimeout {
+		t.Errorf("default timeout = %v, want %v", c.timeout, DefaultTimeout)
+	}
+}
+
+func TestWithTimeoutOverridesDefault(t *testing.T) {
+	c := NewClient(&mockProvider{}, WithTimeout(5*time.Second))
+	if c.timeout != 5*time.Second {
+		t.Errorf("timeout = %v, want 5s", c.timeout)
+	}
+}
+
+func TestWithTimeoutZeroDisables(t *testing.T) {
+	c := NewClient(&mockProvider{}, WithTimeout(0))
+	if c.timeout != 0 {
+		t.Errorf("timeout = %v, want 0 (disabled)", c.timeout)
+	}
+}
+
+func TestEffectiveTimeoutPrecedence(t *testing.T) {
+	c := NewClient(&mockProvider{}, WithTimeout(30*time.Second))
+
+	// Caller ctx has a deadline -> 0 (caller wins).
+	ctxWithDeadline, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	b1 := c.Chat("m")
+	if got := b1.effectiveTimeout(ctxWithDeadline); got != 0 {
+		t.Errorf("with caller deadline = %v, want 0", got)
+	}
+
+	// Builder timeout set -> builder wins over client default.
+	b2 := c.Chat("m")
+	b2.timeout = 10 * time.Second
+	if got := b2.effectiveTimeout(context.Background()); got != 10*time.Second {
+		t.Errorf("builder override = %v, want 10s", got)
+	}
+
+	// Neither -> client default.
+	b3 := c.Chat("m")
+	if got := b3.effectiveTimeout(context.Background()); got != 30*time.Second {
+		t.Errorf("client default = %v, want 30s", got)
+	}
+}

--- a/core/timeout_test.go
+++ b/core/timeout_test.go
@@ -158,3 +158,51 @@ func TestStreamStalledTimesOut(t *testing.T) {
 		t.Fatalf("Stream() err = %v, want ErrTimeout", err)
 	}
 }
+
+// midStreamTimeoutProvider establishes a real stream (StreamChat returns a
+// nil setup error), then blocks until ctx's deadline fires and reports
+// ctx.Err() on Err — unlike blockingProvider, which fails synchronously
+// during StreamChat setup. This exercises the mid-stream path: the deadline
+// error is received inside wrapStreamWithTelemetry's goroutine (off
+// stream.Err), passed through mapErr, and onDone fires cancel() when the
+// goroutine exits.
+type midStreamTimeoutProvider struct{}
+
+func (midStreamTimeoutProvider) ID() string                    { return "midstreamtimeout" }
+func (midStreamTimeoutProvider) Models() []ModelInfo           { return nil }
+func (midStreamTimeoutProvider) Supports(feature Feature) bool { return false }
+func (midStreamTimeoutProvider) Chat(context.Context, *ChatRequest) (*ChatResponse, error) {
+	return nil, ErrNotSupported
+}
+func (midStreamTimeoutProvider) StreamChat(ctx context.Context, _ *ChatRequest) (*ChatStream, error) {
+	ch := make(chan ChatChunk)
+	errc := make(chan error, 1)
+	final := make(chan *ChatResponse)
+	go func() {
+		<-ctx.Done()
+		errc <- ctx.Err()
+		// Give the telemetry-wrapping goroutine a moment to drain and
+		// forward this error before closing Ch. DrainStream watches Ch
+		// directly (it is passed through unwrapped) and treats its closure
+		// as the signal to stop looping; closing it prematurely relative to
+		// the wrapper's forwarding of Err would make the test's outcome
+		// depend on unrelated goroutine scheduling.
+		time.Sleep(5 * time.Millisecond)
+		close(ch)
+		close(errc)
+		close(final)
+	}()
+	return &ChatStream{Ch: ch, Err: errc, Final: final}, nil
+}
+
+func TestStreamMidStreamTimeout(t *testing.T) {
+	c := NewClient(midStreamTimeoutProvider{}, WithTimeout(50*time.Millisecond))
+	stream, err := c.Chat("m").User("hi").Stream(context.Background())
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	_, err = DrainStream(context.Background(), stream)
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("DrainStream err = %v, want ErrTimeout", err)
+	}
+}

--- a/core/timeout_test.go
+++ b/core/timeout_test.go
@@ -206,3 +206,37 @@ func TestStreamMidStreamTimeout(t *testing.T) {
 		t.Fatalf("DrainStream err = %v, want ErrTimeout", err)
 	}
 }
+
+// TestStreamCallerDeadlineNotRemapped is the streaming counterpart to
+// TestGetResponseCallerDeadlineNotRemapped: it proves that when the CALLER
+// supplies its own ctx deadline, Stream's mid-stream error is left as the
+// raw context error and is NOT remapped to ErrTimeout.
+//
+// The client's own default timeout is set large (30s) so it cannot fire
+// first. The caller's ctx carries a short 50ms deadline instead. Because a
+// caller-supplied deadline is present, effectiveTimeout(ctx) returns 0 (see
+// its precedence rule: caller ctx deadline wins), so Stream applies no
+// additional Iris timeout — timeout stays 0, and mapErr's
+// `timeout > 0 && errors.Is(e, context.DeadlineExceeded)` guard never
+// triggers, so mapErr returns the raw error unchanged.
+func TestStreamCallerDeadlineNotRemapped(t *testing.T) {
+	c := NewClient(midStreamTimeoutProvider{}, WithTimeout(30*time.Second))
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	stream, err := c.Chat("m").User("hi").Stream(ctx)
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+
+	// Drain with an unrelated background context so the error observed here
+	// can only have come from the stream's Err channel (via mapErr), not
+	// from DrainStream's own ctx.Done() check.
+	_, err = DrainStream(context.Background(), stream)
+	if errors.Is(err, ErrTimeout) {
+		t.Errorf("caller deadline was remapped to ErrTimeout; want raw context error: %v", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("err = %v, want context.DeadlineExceeded", err)
+	}
+}

--- a/docs/changes/2026-07-31_v0.14.0_core-execution-timeout.md
+++ b/docs/changes/2026-07-31_v0.14.0_core-execution-timeout.md
@@ -352,6 +352,25 @@ Migration / opt-out paths:
   and any `ChatBuilder.Timeout()` (see Precedence above), and Iris never
   remaps a caller-owned deadline to `ErrTimeout`.
 
+**The 120s default applies to streaming too, including helpers that stream on
+a bare `context.Background()`.** `Stream` runs through the same
+`effectiveTimeout` resolution as `GetResponse` (see Precedence above), so any
+code path that calls `Stream`/`StreamWithContext` with a context carrying no
+deadline of its own inherits the `120s` client default. Concretely,
+`core.Conversation.Stream(userMessage string)` (`core/memory.go`) calls
+`c.StreamWithContext(context.Background(), userMessage)` internally — it
+supplies no deadline — so a generation streamed via `Conversation.Stream` that
+runs longer than 120s is now truncated mid-stream with `core.ErrTimeout`
+(delivered on the returned `ChatStream`'s `Err` channel / from
+`DrainStream`), where previously it would have run unbounded. `Conversation`
+has no `Timeout()` passthrough of its own, so the only opt-outs are at the
+`core.Client` level: construct the client with `core.WithTimeout(0)` (disable
+entirely) or `core.WithTimeout(d)` with a larger `d`, or call
+`Conversation.StreamWithContext` directly with a caller-supplied context that
+either carries a longer deadline or none at all (a caller deadline always
+wins over the client default and is never remapped to `ErrTimeout`, per the
+Precedence rule above).
+
 No exported function, method, type, or field was removed or had its signature
 changed. `core.WithTimeout`, `core.DefaultTimeout`, and `core.ErrTimeout` are
 purely additive.

--- a/docs/changes/2026-07-31_v0.14.0_core-execution-timeout.md
+++ b/docs/changes/2026-07-31_v0.14.0_core-execution-timeout.md
@@ -1,0 +1,406 @@
+---
+date: 2026-07-31
+version: v0.14.0
+feature: Core-level LLM execution timeout
+product: iris
+change_type: feature
+affected_components:
+  - core/client.go
+  - core/errors.go
+  - core/timeout_test.go
+  - core/errors_test.go
+  - providers/openai/options.go
+  - providers/anthropic/options.go
+  - providers/gemini/options.go
+  - providers/xai/options.go
+  - providers/perplexity/options.go
+  - providers/ollama/options.go
+  - providers/huggingface/options.go
+  - providers/voyageai/options.go
+  - providers/zai/options.go
+  - providers/openai/client_responses_test.go
+related_frds:
+  - docs/superpowers/specs/2026-07-31-core-execution-timeout-design.md
+---
+
+## Summary
+
+Iris previously applied no execution timeout to LLM calls unless a caller manually
+supplied a context deadline; streaming had no timeout mechanism at all. This change
+centralizes a provider-agnostic execution timeout in `core`: a new `Client.timeout`
+field (default `120 * time.Second`, configurable via `core.WithTimeout`), a
+per-call `effectiveTimeout` resolution helper, and a typed `core.ErrTimeout`
+sentinel that a caller can detect with `errors.Is`. The timeout is applied inside
+both `GetResponse` (unary) and `Stream` (streaming), with the streaming case tying
+the derived timeout context's cancellation to the stream's actual lifetime rather
+than to when `Stream()` returns, so a long-but-healthy stream is never truncated.
+
+## Motivation
+
+Every provider except `azurefoundry` left its HTTP client on `http.DefaultClient`
+(`Timeout: 0`), and every provider's `WithTimeout` option / `Config.Timeout` field
+was dead code — set but never read. The only timeout path in `core` was
+`ChatBuilder.Timeout()`, which the caller had to opt into explicitly, and it was
+wired only for `GetResponse`; `Stream` had no timeout by design because a naive
+`defer cancel()` would have killed the stream the instant `Stream()` returned. In
+production, an application with its own short external timeout cancelled its
+context while Iris was still blocked inside a provider call. Iris produced no
+error of its own — it inherited the app's opaque cancellation — so the real
+failure (an Iris-side hang) was invisible to the caller. This change makes Iris
+fail fast with a legible, typed error before an external timeout can mask the
+underlying problem, and does so for every provider without per-provider
+duplication (see `docs/superpowers/specs/2026-07-31-core-execution-timeout-design.md`
+for the full design rationale, including rejected alternatives).
+
+## What Changed
+
+### New Additions
+
+- `core.DefaultTimeout` — `const DefaultTimeout = 120 * time.Second`. The
+  execution timeout applied when neither the caller's context nor a per-call
+  `Timeout()` supplies one.
+- `core.WithTimeout(d time.Duration) ClientOption` — sets the client's default
+  execution timeout. `WithTimeout(0)` disables it (restores unbounded behavior).
+- `Client.timeout time.Duration` — new unexported field on `core.Client`,
+  initialized to `DefaultTimeout` in `NewClient` and overridable via
+  `WithTimeout`.
+- `(b *ChatBuilder) effectiveTimeout(ctx context.Context) time.Duration` —
+  unexported helper that resolves the timeout to apply for a single call, or `0`
+  for "none applied."
+- `core.ErrTimeout` — `var ErrTimeout = errors.New("execution timeout")`.
+  Sentinel indicating an Iris-imposed execution timeout elapsed. Detectable via
+  `errors.Is(err, ErrTimeout)`.
+- `newTimeoutError(d time.Duration) error` — unexported constructor in
+  `core/errors.go` that builds an error wrapping both `ErrTimeout` and
+  `context.DeadlineExceeded`, with a message of the form
+  `iris: execution timeout after 2m0s: context deadline exceeded`.
+- `core/timeout_test.go` — new test file covering client default resolution,
+  `WithTimeout` override/disable, `effectiveTimeout` precedence, unary timeout
+  firing and error typing, caller-deadline non-remapping, disabled-timeout no-op,
+  and streaming (fast-complete-not-cancelled, stalled setup timeout, mid-stream
+  timeout).
+- `providers/openai/client_responses_test.go`: `TestGPT54MiniRoutesToResponsesAPI`
+  — new test asserting that a `gpt-5.4-mini` chat request is routed to the
+  `/responses` endpoint (Responses API) with `"model":"gpt-5.4-mini"` in the
+  request body, using an `httptest` mock server. This exercises the exact code
+  path the timeout changes needed to be verified against without live
+  credentials.
+
+### Modifications
+
+- `core/client.go` — `GetResponse` no longer does an inline
+  `if b.timeout > 0 { ctx, cancel = ... }` check against only the builder's own
+  timeout; it now calls `effectiveTimeout(ctx)` (which folds in the client
+  default and the caller-deadline check) and, when the applied deadline is the
+  cause of a `context.DeadlineExceeded`, remaps the error to `newTimeoutError(d)`.
+  `Stream` gains equivalent timeout handling: `effectiveTimeout(ctx)` is
+  evaluated before the context is handed to `provider.StreamChat`, and
+  `wrapStreamWithTelemetry` gained two new parameters, `onDone func()` and
+  `mapErr func(error) error`, so the derived timeout's `cancel` fires exactly
+  once when the stream's goroutine observes `Ch`/`Err`/`Final` all closing (or
+  the deadline fires on its own), and any resulting `context.DeadlineExceeded`
+  is remapped to `ErrTimeout` before being forwarded on the stream's `Err`
+  channel.
+- `providers/{openai,anthropic,gemini,xai,perplexity,ollama,huggingface,voyageai,zai}/options.go`
+  — the per-provider `WithTimeout(d) Option` function and the `Config.Timeout`
+  field each gained a `Deprecated:` Godoc note pointing callers at
+  `core.WithTimeout` (or a context deadline), stating that the option is inert
+  for that provider and retained only for API compatibility. No signatures
+  changed; behavior is unchanged (these were already no-ops before this
+  change — the fields are simply now documented as such).
+
+### Removals
+
+N/A — no public API, field, or capability was removed. All additions are
+purely additive; the deprecations above are documentation-only and change no
+signatures.
+
+## Technical Specification
+
+### Data Schemas / Types
+
+No new exported struct or schema types were added. The relevant additions are a
+constant, a function, an unexported struct field, an unexported method, and a
+sentinel error — all listed under New Additions above with exact signatures.
+
+### API Endpoints
+
+N/A — this change is entirely within the Go SDK (`core` package and provider
+option packages); it does not touch a daemon HTTP API.
+
+### CLI Interface
+
+N/A — this change does not add or modify any CLI command.
+
+### Go Package API
+
+Exact signatures (read from source, `core/client.go` and `core/errors.go`):
+
+```go
+// core/client.go
+
+// DefaultTimeout is the execution timeout applied to chat and streaming calls
+// when neither the caller's context nor a per-call Timeout() supplies one.
+// Disable it per client with WithTimeout(0).
+const DefaultTimeout = 120 * time.Second
+
+// WithTimeout sets the default execution timeout applied to chat and streaming
+// calls when the caller's context has no deadline of its own and no per-call
+// Timeout() is set. Pass 0 to disable the default and allow unbounded calls.
+func WithTimeout(d time.Duration) ClientOption
+
+// effectiveTimeout resolves the timeout to apply for this call, or 0 for none.
+// Precedence: an existing ctx deadline wins (returns 0, no wrapping); then a
+// per-call builder timeout; then the client default.
+func (b *ChatBuilder) effectiveTimeout(ctx context.Context) time.Duration
+
+// core/errors.go
+
+// ErrTimeout indicates an Iris-imposed execution timeout elapsed before the
+// provider call completed. It wraps context.DeadlineExceeded, so
+// errors.Is(err, context.DeadlineExceeded) also holds.
+var ErrTimeout = errors.New("execution timeout")
+
+// newTimeoutError builds a timeout error carrying the elapsed budget. The
+// returned error satisfies errors.Is for both ErrTimeout and
+// context.DeadlineExceeded.
+func newTimeoutError(d time.Duration) error
+```
+
+`Client.timeout` (unexported field, `time.Duration`) is set to `DefaultTimeout`
+in `NewClient` and can be changed only via `WithTimeout`. `ChatBuilder.Timeout(d
+time.Duration) *ChatBuilder` (pre-existing, unchanged signature) continues to set
+a per-call override consumed by `effectiveTimeout`.
+
+`wrapStreamWithTelemetry` (unexported, `core/client.go`) gained two trailing
+parameters:
+
+```go
+func wrapStreamWithTelemetry(
+	ctx context.Context,
+	stream *ChatStream,
+	hook TelemetryHook,
+	provider string,
+	model ModelID,
+	start time.Time,
+	onDone func(),
+	mapErr func(error) error,
+) *ChatStream
+```
+
+`onDone`, if non-nil, is invoked exactly once when the stream completes
+(successfully or with an error) — used by `Stream` to release the timeout
+context's `cancel` without truncating an in-flight stream. `mapErr`, if
+non-nil, remaps errors forwarded on the returned `Err` channel (used to turn a
+mid-stream Iris-applied `context.DeadlineExceeded` into `ErrTimeout`).
+
+### Configuration
+
+No `petalflow.yaml`/config-file or environment-variable fields were added. The
+only new "configuration surface" is programmatic: `core.WithTimeout(d)` passed
+as a `ClientOption` to `core.NewClient`.
+
+| Field | Type | Required | Default | Set via |
+|---|---|---|---|---|
+| Client execution timeout | `time.Duration` | optional | `core.DefaultTimeout` (120s) | `core.WithTimeout(d)` at `NewClient(...)` |
+| Per-call timeout override | `time.Duration` | optional | unset (falls through to client default) | `client.Chat(model).Timeout(d)` |
+
+Precedence when resolving the timeout actually applied to a given
+`GetResponse`/`Stream` call (implemented in `effectiveTimeout`):
+
+1. Caller's `ctx` already has a deadline → Iris applies nothing (caller owns
+   cancellation; no remapping to `ErrTimeout`).
+2. Else `ChatBuilder.Timeout()` if set (`> 0`).
+3. Else the client default (`c.timeout`; `120s` unless overridden or disabled
+   via `WithTimeout`).
+4. If the resolved value is `0` → no timeout is applied at all.
+
+## Usage Examples
+
+### Example: setting a client-wide default timeout
+
+```go
+client := core.NewClient(
+	openai.New(apiKey),
+	core.WithTimeout(30 * time.Second), // overrides the 120s default
+)
+
+resp, err := client.Chat("gpt-4o").User("Summarize this document").GetResponse(context.Background())
+if err != nil {
+	if errors.Is(err, core.ErrTimeout) {
+		log.Printf("request exceeded the 30s client timeout: %v", err)
+	}
+	return err
+}
+```
+
+### Example: per-call override
+
+```go
+client := core.NewClient(openai.New(apiKey)) // 120s default in effect
+
+// This one call gets a tighter 5s budget regardless of the client default.
+resp, err := client.Chat("gpt-4o-mini").
+	User("Quick classification: is this spam?").
+	Timeout(5 * time.Second).
+	GetResponse(context.Background())
+```
+
+### Example: disabling the timeout with WithTimeout(0)
+
+```go
+// Opt out of the 120s default entirely — calls run unbounded unless the
+// caller supplies its own context deadline.
+client := core.NewClient(openai.New(apiKey), core.WithTimeout(0))
+
+resp, err := client.Chat("gpt-4o").
+	User("Long-running batch analysis").
+	GetResponse(context.Background())
+```
+
+### Example: handling errors.Is(err, ErrTimeout)
+
+```go
+resp, err := client.Chat("gpt-4o").User("hello").GetResponse(ctx)
+if err != nil {
+	switch {
+	case errors.Is(err, core.ErrTimeout):
+		// Iris-imposed deadline elapsed (client default or Timeout()).
+		// errors.Is(err, context.DeadlineExceeded) is also true here.
+		return fmt.Errorf("iris timed out waiting on the provider: %w", err)
+	case errors.Is(err, context.DeadlineExceeded):
+		// A caller-supplied ctx deadline elapsed instead — NOT remapped to
+		// ErrTimeout, since the caller owns that cancellation.
+		return fmt.Errorf("caller context deadline exceeded: %w", err)
+	default:
+		return err
+	}
+}
+```
+
+### Example: streaming timeout (error case)
+
+```go
+stream, err := client.Chat("gpt-4o").
+	User("Write a very long story").
+	Timeout(2 * time.Second). // deliberately short, for illustration
+	Stream(context.Background())
+if err != nil {
+	// A timeout that fires before the stream is established surfaces here.
+	if errors.Is(err, core.ErrTimeout) {
+		log.Printf("stream setup timed out: %v", err)
+	}
+	return err
+}
+
+resp, err := core.DrainStream(context.Background(), stream)
+if err != nil {
+	// A timeout that fires mid-stream (after StreamChat returned
+	// successfully) surfaces here instead, on the stream's Err channel.
+	if errors.Is(err, core.ErrTimeout) {
+		log.Printf("stream timed out mid-flight: %v", err)
+	}
+	return err
+}
+```
+
+## Integration Notes
+
+- The timeout context wraps the entire retry loop in `GetResponse` (unchanged
+  budget semantics from before this change) — it is an overall budget across
+  attempts, not a per-attempt budget.
+- `retry.go` already treats `context.DeadlineExceeded` as non-retryable;
+  wrapping the error in `ErrTimeout` preserves that via `errors.Is`, so retry
+  behavior is unaffected.
+- For `Stream`, the timeout's `cancel` is deliberately **not** deferred in
+  `Stream()` itself. It is threaded through to `wrapStreamWithTelemetry` as
+  `onDone` and invoked exactly once when the stream's completion goroutine
+  observes the stream finishing (or the deadline firing on its own). This
+  preserves the `ChatStream` channel contract documented in
+  `core/streaming.go` ("on context cancellation, providers MUST terminate
+  promptly and close channels") without prematurely tearing down a healthy,
+  still-running stream the instant `Stream()` returns to the caller.
+- A caller-supplied `ctx` deadline is never remapped to `ErrTimeout` — only a
+  deadline that Iris itself applied (via the client default or
+  `ChatBuilder.Timeout()`) is. This is the mechanism by which Iris distinguishes
+  "I gave up" from "you gave up," which was the entire motivation for this
+  feature.
+- `azurefoundry`'s own `Config.Timeout` wiring is left untouched (not
+  deprecated) — it is the one provider that actually reads and applies its
+  `Timeout` field. It composes harmlessly with the new core-level deadline:
+  whichever of the two fires first wins, since both ultimately race against the
+  same underlying HTTP call.
+
+## Breaking Changes & Migration
+
+**Behavior change (not a signature/API break):** callers who previously set
+neither a `ctx` deadline nor `ChatBuilder.Timeout()`, and who made calls that
+ran longer than 120 seconds, previously blocked indefinitely (bounded only by
+the provider's own network stack). They will now receive `core.ErrTimeout`
+after 120 seconds instead. This is the intended fix described in Motivation.
+
+Migration / opt-out paths:
+
+- To restore the previous unbounded behavior for a given client:
+  `core.NewClient(provider, core.WithTimeout(0))`.
+- To use a different default than 120s:
+  `core.NewClient(provider, core.WithTimeout(5 * time.Minute))`.
+- To keep the 120s Iris default but override for a single call:
+  `client.Chat(model).Timeout(d).GetResponse(ctx)` (works for `Stream` too).
+- Callers who already pass a `context` with their own deadline are entirely
+  unaffected — the caller's deadline always wins over both the client default
+  and any `ChatBuilder.Timeout()` (see Precedence above), and Iris never
+  remaps a caller-owned deadline to `ErrTimeout`.
+
+No exported function, method, type, or field was removed or had its signature
+changed. `core.WithTimeout`, `core.DefaultTimeout`, and `core.ErrTimeout` are
+purely additive.
+
+## Deferred / Out of Scope
+
+- **Embeddings timeout:** the `EmbeddingProvider` path is not routed through
+  `core.Client`'s `GetResponse`/`Stream`/`effectiveTimeout` machinery, so this
+  change does not add a timeout to embedding calls (e.g.
+  `ollama.CreateEmbeddings`). Tracked as a follow-up; would mirror this design
+  with a small, analogous addition scoped to the embeddings call path.
+- **Idle/stall streaming timeout:** this change implements an overall deadline
+  for streaming (from `Stream()` call to full completion), not a "time to
+  first byte" / inter-chunk stall detector. A stream that receives occasional
+  chunks slower than the overall deadline allows will still time out even if
+  no single gap is anomalously long; a stream that never sends a first byte
+  is bounded only by the overall deadline, not by a shorter "nothing arrived
+  yet" threshold. Out of scope per the design doc.
+- **Live OpenAI round-trip verification:** the design explicitly defers any
+  live call against the real OpenAI API — credentials live in Azure Key Vault,
+  which is unreachable from the current dev/CI environment. Verification for
+  this change (including `TestGPT54MiniRoutesToResponsesAPI`) is via
+  `httptest` mock servers instead, which exercise the same request-shaping and
+  response-parsing code paths without a live network call.
+
+## Testing Notes
+
+Ran the two required verification commands from the repo root
+(`/Users/erikhoward/src/github/petal-labs/iris`, branch
+`feat/core-execution-timeout`):
+
+- `go test -race ./core/ ./providers/openai/` — **PASS**, no data races
+  reported. All tests in both packages passed, including the new/relevant
+  timeout-specific tests: `TestNewClientDefaultTimeout`,
+  `TestWithTimeoutOverridesDefault`, `TestWithTimeoutZeroDisables`,
+  `TestEffectiveTimeoutPrecedence`, `TestGetResponseTimesOutWithErrTimeout`,
+  `TestGetResponseCallerDeadlineNotRemapped`,
+  `TestGetResponseDisabledTimeoutDoesNotFire`,
+  `TestStreamFastCompletesNotCancelled`, `TestStreamStalledTimesOut`,
+  `TestStreamMidStreamTimeout` (all in `core/timeout_test.go`),
+  `TestNewTimeoutError` (in `core/errors_test.go`), and
+  `TestGPT54MiniRoutesToResponsesAPI` (in
+  `providers/openai/client_responses_test.go`).
+- `go build ./...` — succeeded with no errors across the full module.
+
+The streaming tests specifically validate the design's core race-safety
+requirement: `TestStreamFastCompletesNotCancelled` proves a fast stream is not
+prematurely cancelled by the timeout machinery, and `TestStreamMidStreamTimeout`
+/ `TestStreamStalledTimesOut` prove that both a setup-time and a mid-stream
+Iris-applied deadline correctly surface as `ErrTimeout` with `cancel` invoked
+exactly once (verified indirectly via the race detector finding no goroutine
+data races across repeated runs).

--- a/docs/superpowers/plans/2026-07-31-core-execution-timeout.md
+++ b/docs/superpowers/plans/2026-07-31-core-execution-timeout.md
@@ -1,0 +1,724 @@
+# Core-Level LLM Execution Timeout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Iris a provider-agnostic execution timeout so hung/slow LLM calls fail fast with a legible typed error instead of blocking until an external caller cancels them opaquely.
+
+**Architecture:** Centralize the timeout in `core` (not per-provider). A new `core.WithTimeout` Client option sets a default execution budget (120s) applied to both unary (`GetResponse`) and streaming (`Stream`) calls for every provider. The caller's own `context` deadline always wins; a per-call `ChatBuilder.Timeout()` overrides the client default. Expiry surfaces as `core.ErrTimeout` (wrapping `context.DeadlineExceeded`).
+
+**Tech Stack:** Go 1.24, standard library only (`context`, `errors`, `fmt`, `time`, `net/http/httptest` for tests).
+
+## Global Constraints
+
+- Module path: `github.com/petal-labs/iris` (go 1.24.0).
+- Default execution timeout: `DefaultTimeout = 120 * time.Second`.
+- `core.WithTimeout(0)` disables the default (unbounded, today's behavior).
+- Precedence (highest first): caller ctx already has a deadline → untouched; else `ChatBuilder.Timeout()`; else Client default.
+- API is additive only — no existing exported signature changes. New exports: `WithTimeout`, `DefaultTimeout`, `ErrTimeout`.
+- Only the Iris-applied deadline is remapped to `ErrTimeout`; a caller-owned deadline or `context.Canceled` is never remapped.
+- Conventional commits, subject ≤ 72 chars, no trailing period, no backticks/emoji.
+- Tests: Go standard `testing`, table-driven where natural. Use `filepath.Join` for any paths (none expected here).
+
+---
+
+### Task 1: Typed timeout error
+
+**Files:**
+- Modify: `core/errors.go`
+- Test: `core/errors_test.go`
+
+**Interfaces:**
+- Produces:
+  - `var ErrTimeout = errors.New("execution timeout")`
+  - `func newTimeoutError(d time.Duration) error` — returns an error where `errors.Is(err, ErrTimeout)` and `errors.Is(err, context.DeadlineExceeded)` are both true, message `iris: execution timeout after <d>: context deadline exceeded`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `core/errors_test.go`:
+
+```go
+func TestNewTimeoutError(t *testing.T) {
+	err := newTimeoutError(120 * time.Second)
+
+	if !errors.Is(err, ErrTimeout) {
+		t.Errorf("errors.Is(err, ErrTimeout) = false, want true")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("errors.Is(err, context.DeadlineExceeded) = false, want true")
+	}
+	if !strings.Contains(err.Error(), "2m0s") {
+		t.Errorf("err.Error() = %q, want it to contain the duration", err.Error())
+	}
+}
+```
+
+Ensure the test file imports `context`, `errors`, `strings`, `testing`, `time` (add any missing).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./core/ -run TestNewTimeoutError -v`
+Expected: FAIL — `undefined: newTimeoutError` (and `ErrTimeout`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `core/errors.go`, add `context` and `time` to the import block, then append:
+
+```go
+// ErrTimeout indicates an Iris-imposed execution timeout elapsed before the
+// provider call completed. It wraps context.DeadlineExceeded, so
+// errors.Is(err, context.DeadlineExceeded) also holds.
+var ErrTimeout = errors.New("execution timeout")
+
+// newTimeoutError builds a timeout error carrying the elapsed budget. The
+// returned error satisfies errors.Is for both ErrTimeout and
+// context.DeadlineExceeded.
+func newTimeoutError(d time.Duration) error {
+	return fmt.Errorf("iris: %w after %s: %w", ErrTimeout, d, context.DeadlineExceeded)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./core/ -run TestNewTimeoutError -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/errors.go core/errors_test.go
+git commit -m "feat(core): add ErrTimeout typed execution timeout error"
+```
+
+---
+
+### Task 2: Client timeout field, WithTimeout option, effectiveTimeout helper
+
+**Files:**
+- Modify: `core/client.go` (Client struct ~44-49; NewClient ~59-70; add option near other `With*` options ~72-98; add helper near `validate` ~433)
+- Test: `core/timeout_test.go` (new)
+
+**Interfaces:**
+- Consumes: `ErrTimeout`, `newTimeoutError` from Task 1 (not yet, used in Tasks 3-4).
+- Produces:
+  - `const DefaultTimeout = 120 * time.Second`
+  - `func WithTimeout(d time.Duration) ClientOption`
+  - new field `timeout time.Duration` on `Client`
+  - `func (b *ChatBuilder) effectiveTimeout(ctx context.Context) time.Duration` — returns 0 when ctx already has a deadline; else `b.timeout` if > 0; else `b.client.timeout`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `core/timeout_test.go`:
+
+```go
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestNewClientDefaultTimeout(t *testing.T) {
+	c := NewClient(&mockProvider{})
+	if c.timeout != DefaultTimeout {
+		t.Errorf("default timeout = %v, want %v", c.timeout, DefaultTimeout)
+	}
+}
+
+func TestWithTimeoutOverridesDefault(t *testing.T) {
+	c := NewClient(&mockProvider{}, WithTimeout(5*time.Second))
+	if c.timeout != 5*time.Second {
+		t.Errorf("timeout = %v, want 5s", c.timeout)
+	}
+}
+
+func TestWithTimeoutZeroDisables(t *testing.T) {
+	c := NewClient(&mockProvider{}, WithTimeout(0))
+	if c.timeout != 0 {
+		t.Errorf("timeout = %v, want 0 (disabled)", c.timeout)
+	}
+}
+
+func TestEffectiveTimeoutPrecedence(t *testing.T) {
+	c := NewClient(&mockProvider{}, WithTimeout(30*time.Second))
+
+	// Caller ctx has a deadline -> 0 (caller wins).
+	ctxWithDeadline, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	b1 := c.Chat("m")
+	if got := b1.effectiveTimeout(ctxWithDeadline); got != 0 {
+		t.Errorf("with caller deadline = %v, want 0", got)
+	}
+
+	// Builder timeout set -> builder wins over client default.
+	b2 := c.Chat("m")
+	b2.timeout = 10 * time.Second
+	if got := b2.effectiveTimeout(context.Background()); got != 10*time.Second {
+		t.Errorf("builder override = %v, want 10s", got)
+	}
+
+	// Neither -> client default.
+	b3 := c.Chat("m")
+	if got := b3.effectiveTimeout(context.Background()); got != 30*time.Second {
+		t.Errorf("client default = %v, want 30s", got)
+	}
+}
+```
+
+(`mockProvider` already exists in `core/client_test.go`, same package.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./core/ -run 'Timeout' -v`
+Expected: FAIL — `c.timeout undefined`, `DefaultTimeout undefined`, `WithTimeout undefined`, `effectiveTimeout undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `core/client.go`:
+
+Add the constant near the top of the file (after imports):
+
+```go
+// DefaultTimeout is the execution timeout applied to chat and streaming calls
+// when neither the caller's context nor a per-call Timeout() supplies one.
+// Disable it per client with WithTimeout(0).
+const DefaultTimeout = 120 * time.Second
+```
+
+Add the field to the `Client` struct:
+
+```go
+type Client struct {
+	provider       Provider
+	telemetry      TelemetryHook
+	retry          RetryPolicy
+	warningHandler WarningHandler
+	timeout        time.Duration
+}
+```
+
+Initialize it in `NewClient` before the option loop:
+
+```go
+	c := &Client{
+		provider:       p,
+		telemetry:      NoopTelemetryHook{},
+		retry:          DefaultRetryPolicy(),
+		warningHandler: func(string) {},
+		timeout:        DefaultTimeout,
+	}
+```
+
+Add the option alongside the other `With*` options:
+
+```go
+// WithTimeout sets the default execution timeout applied to chat and streaming
+// calls when the caller's context has no deadline of its own and no per-call
+// Timeout() is set. Pass 0 to disable the default and allow unbounded calls.
+func WithTimeout(d time.Duration) ClientOption {
+	return func(c *Client) {
+		c.timeout = d
+	}
+}
+```
+
+Add the helper near `validate` (around line 433):
+
+```go
+// effectiveTimeout resolves the timeout to apply for this call, or 0 for none.
+// Precedence: an existing ctx deadline wins (returns 0, no wrapping); then a
+// per-call builder timeout; then the client default.
+func (b *ChatBuilder) effectiveTimeout(ctx context.Context) time.Duration {
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		return 0
+	}
+	if b.timeout > 0 {
+		return b.timeout
+	}
+	return b.client.timeout
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./core/ -run 'Timeout' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/client.go core/timeout_test.go
+git commit -m "feat(core): add WithTimeout client option and precedence helper"
+```
+
+---
+
+### Task 3: Apply timeout in GetResponse (unary)
+
+**Files:**
+- Modify: `core/client.go` `GetResponse` (lines ~456-534, specifically the timeout block ~461-468 and the retry loop result ~489-510)
+- Test: `core/timeout_test.go` (append)
+
+**Interfaces:**
+- Consumes: `effectiveTimeout` (Task 2), `ErrTimeout` / `newTimeoutError` (Task 1).
+- Produces: `GetResponse` returns `newTimeoutError(d)` when the Iris-applied deadline elapsed.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `core/timeout_test.go`. Add a small blocking provider to the file:
+
+```go
+// blockingProvider blocks Chat until ctx is cancelled, then returns ctx.Err().
+type blockingProvider struct{}
+
+func (blockingProvider) ID() string { return "blocking" }
+func (blockingProvider) Chat(ctx context.Context, _ *ChatRequest) (*ChatResponse, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+func (blockingProvider) StreamChat(ctx context.Context, _ *ChatRequest) (*ChatStream, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestGetResponseTimesOutWithErrTimeout(t *testing.T) {
+	c := NewClient(blockingProvider{}, WithTimeout(50*time.Millisecond),
+		WithRetryPolicy(NewNoRetryPolicy()))
+
+	_, err := c.Chat("m").User("hi").GetResponse(context.Background())
+
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("err = %v, want ErrTimeout", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want it to wrap DeadlineExceeded", err)
+	}
+}
+
+func TestGetResponseCallerDeadlineNotRemapped(t *testing.T) {
+	c := NewClient(blockingProvider{}, WithRetryPolicy(NewNoRetryPolicy()))
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := c.Chat("m").User("hi").GetResponse(ctx)
+
+	if errors.Is(err, ErrTimeout) {
+		t.Errorf("caller deadline was remapped to ErrTimeout; want raw context error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestGetResponseDisabledTimeoutDoesNotFire(t *testing.T) {
+	c := NewClient(&mockProvider{}, WithTimeout(0))
+	// mockProvider returns promptly; assert no ErrTimeout on the happy path.
+	_, err := c.Chat("m").User("hi").GetResponse(context.Background())
+	if errors.Is(err, ErrTimeout) {
+		t.Errorf("unexpected ErrTimeout with timeout disabled: %v", err)
+	}
+}
+```
+
+Add `"errors"` to the test file imports. Verify the no-retry policy constructor name: run `rg -n "func NewNoRetryPolicy|NoRetry" core/retry.go`; if it differs (e.g. returns via `WithRetryPolicy(RetryPolicy)`), use the actual constructor. If none exists, replace `WithRetryPolicy(NewNoRetryPolicy())` with a policy of 0 retries using the real API found in `core/retry.go`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./core/ -run 'GetResponse' -v`
+Expected: FAIL — timeout never applied (blocks) or returns raw context error instead of `ErrTimeout`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the existing timeout block in `GetResponse` (currently lines ~461-468):
+
+```go
+	// Apply timeout if set and context has no deadline
+	if b.timeout > 0 {
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, b.timeout)
+			defer cancel()
+		}
+	}
+```
+
+with:
+
+```go
+	// Apply the effective execution timeout (see effectiveTimeout for precedence).
+	// timedOut records that any resulting DeadlineExceeded is Iris-owned and
+	// should surface as ErrTimeout rather than a raw context error.
+	var timedOut time.Duration
+	if d := b.effectiveTimeout(ctx); d > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, d)
+		defer cancel()
+		timedOut = d
+	}
+```
+
+Then, immediately after the retry loop ends (after the `retryLoop:` block, before the telemetry-end section), remap the error:
+
+```go
+	// Map an Iris-applied deadline to a legible typed error.
+	if timedOut > 0 && err != nil && errors.Is(err, context.DeadlineExceeded) {
+		err = newTimeoutError(timedOut)
+	}
+```
+
+Add `"errors"` to `core/client.go` imports if not already present (check the import block).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./core/ -run 'GetResponse' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full core suite (no regressions)**
+
+Run: `go test ./core/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/client.go core/timeout_test.go
+git commit -m "feat(core): apply execution timeout to unary GetResponse"
+```
+
+---
+
+### Task 4: Apply timeout in Stream without premature cancellation
+
+**Files:**
+- Modify: `core/client.go` `Stream` (~546-586) and `wrapStreamWithTelemetry` (~701-776)
+- Test: `core/timeout_test.go` (append)
+
+**Interfaces:**
+- Consumes: `effectiveTimeout` (Task 2), `newTimeoutError` (Task 1).
+- Produces: `wrapStreamWithTelemetry` gains two trailing params `onDone func()` and `mapErr func(error) error` (both nil-safe). `Stream` applies the effective timeout with `cancel` invoked only when the stream completes or the deadline fires.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `core/timeout_test.go`. Add a streaming mock whose behavior is controllable:
+
+```go
+// fastStreamProvider emits one chunk then closes immediately.
+type fastStreamProvider struct{}
+
+func (fastStreamProvider) ID() string { return "faststream" }
+func (fastStreamProvider) Chat(context.Context, *ChatRequest) (*ChatResponse, error) {
+	return nil, ErrNotSupported
+}
+func (fastStreamProvider) StreamChat(_ context.Context, _ *ChatRequest) (*ChatStream, error) {
+	ch := make(chan ChatChunk, 1)
+	errc := make(chan error)
+	final := make(chan *ChatResponse, 1)
+	ch <- ChatChunk{Delta: "hello"}
+	close(ch)
+	final <- &ChatResponse{Output: "hello"}
+	close(final)
+	close(errc)
+	return &ChatStream{Ch: ch, Err: errc, Final: final}, nil
+}
+
+func TestStreamFastCompletesNotCancelled(t *testing.T) {
+	c := NewClient(fastStreamProvider{}, WithTimeout(50*time.Millisecond))
+	stream, err := c.Chat("m").User("hi").Stream(context.Background())
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	resp, err := DrainStream(context.Background(), stream)
+	if err != nil {
+		t.Fatalf("DrainStream error = %v", err)
+	}
+	if resp.Output != "hello" {
+		t.Errorf("Output = %q, want %q", resp.Output, "hello")
+	}
+}
+
+func TestStreamStalledTimesOut(t *testing.T) {
+	// blockingProvider.StreamChat blocks until ctx cancels, then returns ctx.Err()
+	// as a setup error (StreamChat returns error, not a stream).
+	c := NewClient(blockingProvider{}, WithTimeout(50*time.Millisecond))
+	_, err := c.Chat("m").User("hi").Stream(context.Background())
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("Stream() err = %v, want ErrTimeout", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./core/ -run 'Stream' -v`
+Expected: FAIL — `TestStreamStalledTimesOut` blocks/returns raw context error; signature mismatch once Step 3 starts.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update `wrapStreamWithTelemetry` signature and body. Change the signature to add the two trailing params:
+
+```go
+func wrapStreamWithTelemetry(
+	ctx context.Context,
+	stream *ChatStream,
+	hook TelemetryHook,
+	provider string,
+	model ModelID,
+	start time.Time,
+	onDone func(),
+	mapErr func(error) error,
+) *ChatStream {
+```
+
+At the very top of the inner goroutine, add a deferred completion callback:
+
+```go
+	go func() {
+		defer close(finalCh)
+		defer close(errCh)
+		if onDone != nil {
+			defer onDone()
+		}
+```
+
+Where the goroutine forwards an error (`errCh <- err`, two sites at ~734 and ~743), map it first. Replace each `errCh <- err` with a mapped local:
+
+```go
+			if ok {
+				finalErr = err
+				out := err
+				if mapErr != nil {
+					out = mapErr(err)
+				}
+				errCh <- out
+			}
+```
+
+(Apply to both `case err, ok := <-stream.Err:` branches.)
+
+Now update `Stream` (~546-586). After `validate()` and before building `startEvent`, resolve the timeout and derive the context:
+
+```go
+	var (
+		cancel  context.CancelFunc
+		timeout time.Duration
+	)
+	if d := b.effectiveTimeout(ctx); d > 0 {
+		ctx, cancel = context.WithTimeout(ctx, d)
+		timeout = d
+	}
+```
+
+If `StreamChat` returns a setup error, cancel now and map it:
+
+```go
+	stream, err := b.client.provider.StreamChat(ctx, &b.req)
+	if err != nil {
+		if cancel != nil {
+			cancel()
+		}
+		if timeout > 0 && errors.Is(err, context.DeadlineExceeded) {
+			err = newTimeoutError(timeout)
+		}
+		// ... existing telemetry-end emission, then:
+		return nil, err
+	}
+```
+
+For the success path, pass `onDone`/`mapErr` into the wrapper so the timeout ctx is released when the stream ends and mid-stream deadline errors surface as `ErrTimeout`:
+
+```go
+	onDone := func() {
+		if cancel != nil {
+			cancel()
+		}
+	}
+	mapErr := func(e error) error {
+		if timeout > 0 && errors.Is(e, context.DeadlineExceeded) {
+			return newTimeoutError(timeout)
+		}
+		return e
+	}
+	return wrapStreamWithTelemetry(ctx, stream, b.client.telemetry, providerID, b.req.Model, start, onDone, mapErr), nil
+```
+
+- [ ] **Step 4: Update any other callers of wrapStreamWithTelemetry**
+
+Run: `rg -n "wrapStreamWithTelemetry" core/`
+For any call other than the one in `Stream`, pass `nil, nil` for the two new params. Expected: only the `Stream` caller exists.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./core/ -run 'Stream' -v`
+Expected: PASS.
+Run: `go test ./core/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/client.go core/timeout_test.go
+git commit -m "feat(core): apply execution timeout to streaming calls"
+```
+
+---
+
+### Task 5: Deprecate inert per-provider Config.Timeout
+
+**Files:**
+- Modify (doc comments only): `providers/openai/options.go`, `providers/anthropic/options.go`, `providers/gemini/options.go`, `providers/xai/options.go`, `providers/perplexity/options.go`, `providers/ollama/options.go`, `providers/huggingface/options.go`, `providers/voyageai/options.go`, `providers/zai/options.go`
+- Leave unchanged: `providers/azurefoundry/options.go` (its `Timeout` is actually wired).
+
+**Interfaces:**
+- Produces: no behavior change. Godoc `Deprecated:` markers on the inert `WithTimeout` option and `Config.Timeout` field in each listed provider.
+
+- [ ] **Step 1: Confirm which are inert**
+
+Run: `rg -n "config.Timeout|cfg.Timeout|p.config.Timeout" providers/ | rg -v azurefoundry`
+Expected: no read sites (only assignments in `options.go`), confirming they are dead everywhere except azurefoundry.
+
+- [ ] **Step 2: Add deprecation doc comments**
+
+For each listed provider's `WithTimeout` function, prepend a Godoc deprecation note. Example for `providers/openai/options.go`:
+
+```go
+// WithTimeout sets a per-request timeout.
+//
+// Deprecated: this option is currently inert for this provider and has no
+// effect on requests. Use core.WithTimeout on the Client (or a context
+// deadline) to bound execution. Retained for API compatibility.
+func WithTimeout(d time.Duration) Option {
+```
+
+And on the `Timeout` field in each `Config` struct:
+
+```go
+	// Timeout is retained for compatibility but is not applied by this provider.
+	//
+	// Deprecated: use core.WithTimeout on the Client instead.
+	Timeout time.Duration
+```
+
+Match each file's existing option type name (`Option` vs `ConfigOption`) and receiver exactly — read the file first.
+
+- [ ] **Step 3: Verify build and vet**
+
+Run: `go build ./... && go vet ./providers/...`
+Expected: success, no new warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add providers/*/options.go
+git commit -m "docs(providers): deprecate inert per-provider WithTimeout"
+```
+
+---
+
+### Task 6: Verify gpt-5.4-mini routes to the Responses API
+
+**Files:**
+- Test: `providers/openai/client_responses_test.go` (append)
+
+**Interfaces:**
+- Consumes: existing `New`, `WithBaseURL`, `ModelGPT54Mini`, `responsesResponse` (all in package `openai`).
+
+- [ ] **Step 1: Write the test**
+
+Append to `providers/openai/client_responses_test.go`:
+
+```go
+func TestGPT54MiniRoutesToResponsesAPI(t *testing.T) {
+	var gotPath, gotModel string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if m, ok := body["model"].(string); ok {
+			gotModel = m
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(responsesResponse{
+			ID:         "resp-54mini",
+			Model:      "gpt-5.4-mini",
+			Status:     "completed",
+			OutputText: "pong",
+			Output:     []responsesOutput{{Type: "message", Role: "assistant"}},
+			Usage:      &responsesUsage{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
+		})
+	}))
+	defer server.Close()
+
+	p := New("test-key", WithBaseURL(server.URL))
+	resp, err := p.Chat(context.Background(), &core.ChatRequest{
+		Model:    ModelGPT54Mini,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "ping"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+	if gotPath != "/responses" {
+		t.Errorf("request path = %q, want /responses", gotPath)
+	}
+	if gotModel != "gpt-5.4-mini" {
+		t.Errorf("request model = %q, want gpt-5.4-mini", gotModel)
+	}
+	if resp.Output != "pong" {
+		t.Errorf("Output = %q, want pong", resp.Output)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `go test ./providers/openai/ -run TestGPT54MiniRoutesToResponsesAPI -v`
+Expected: PASS — confirms the model is accepted, routed to `/responses`, sent with the correct model string, and its response parsed. (Note: this is a mock-server verification; a live OpenAI round-trip requires Azure Key Vault credentials unavailable in this environment.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add providers/openai/client_responses_test.go
+git commit -m "test(openai): verify gpt-5.4-mini routes to Responses API"
+```
+
+---
+
+### Task 7: Full verification + change doc
+
+**Files:**
+- Create: `docs/changes/2026-07-31_v{version}_core-execution-timeout.md` (resolve `{version}` from `go.mod`/`VERSION`; use `v0.0.0-dev` if none declared)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Run the whole suite with the race detector**
+
+Run: `go test -race ./core/ ./providers/openai/`
+Expected: PASS, no data races (validates the streaming goroutine + cancel handling).
+
+- [ ] **Step 2: Build everything**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 3: Write the change doc**
+
+Follow the repo `CLAUDE.md` change-doc structure (front matter + Summary, Motivation, What Changed, Technical Specification, Usage Examples, Integration Notes, Breaking Changes & Migration, Deferred / Out of Scope, Testing Notes). `product: iris`, `change_type: feature`. `affected_components` must list: `core/client.go`, `core/errors.go`, `core/timeout_test.go`, `core/errors_test.go`, and every `providers/*/options.go` touched, plus `providers/openai/client_responses_test.go`. Document `WithTimeout`, `DefaultTimeout`, `ErrTimeout`, precedence, streaming semantics, the 120s default behavior change with opt-out (`WithTimeout(0)`), and the embeddings deferral.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/changes/2026-07-31_v*_core-execution-timeout.md
+git commit -m "docs(core): add change doc for execution timeout"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Client option + default → Task 2. Precedence → Task 2 (`effectiveTimeout`) + Tasks 3/4. Unary timeout → Task 3. Streaming w/o premature cancel → Task 4. Typed error → Task 1 (used in 3/4). Deprecate per-provider field → Task 5. gpt-5.4-mini verification → Task 6. Tests → Tasks 1-4, 6. Change doc → Task 7. Embeddings deferral documented → Task 7 doc. All spec sections covered.
+
+**Placeholder scan:** No TBD/TODO. The one runtime lookup (`NewNoRetryPolicy` name and provider `Option` type names) is called out explicitly with a `rg` command and a fallback instruction, not left vague.
+
+**Type consistency:** `effectiveTimeout(ctx) time.Duration`, `WithTimeout(d) ClientOption`, `ErrTimeout`, `newTimeoutError(d) error`, and the extended `wrapStreamWithTelemetry(..., onDone func(), mapErr func(error) error)` are used consistently across tasks. `Client.timeout` field name consistent. `DefaultTimeout = 120s` consistent everywhere.

--- a/docs/superpowers/specs/2026-07-31-core-execution-timeout-design.md
+++ b/docs/superpowers/specs/2026-07-31-core-execution-timeout-design.md
@@ -1,0 +1,185 @@
+# Design: Core-Level LLM Execution Timeout
+
+- **Date:** 2026-07-31
+- **Status:** Approved
+- **Branch:** `feat/core-execution-timeout`
+
+## Problem
+
+Iris applies **no execution timeout** to LLM calls by default. Concretely:
+
+- Every provider defaults its HTTP client to `http.DefaultClient`, which has `Timeout: 0`
+  (`providers/openai/provider.go:45-50`).
+- OpenAI (and every other provider except `azurefoundry`) exposes a `WithTimeout` option whose
+  `Config.Timeout` field is **never read** — it is dead code (`providers/openai/options.go:79-84`).
+- The core only imposes a deadline in the non-streaming `GetResponse`, and only if the caller
+  explicitly calls `ChatBuilder.Timeout()` (`core/client.go:461-468`). Streaming has no core-level
+  timeout at all, by deliberate design (`core/client.go:539-545`).
+
+Result: a slow or hung provider call blocks indefinitely unless the caller happens to pass a
+`context` with a deadline. In the field, an application with its own short timeout window cancelled
+the context while Iris was still blocked in the OpenAI call. Iris produced no error of its own — it
+inherited the app's opaque cancellation, so the real failure was invisible.
+
+This is a single root cause: **no Iris-owned execution timeout → long call → external cancellation →
+opaque failure.**
+
+## Goals
+
+1. Iris fails fast with a **legible, typed error** before an external short timeout can mask it.
+2. The mechanism covers **all providers** (chat + streaming) without per-provider duplication.
+3. A **sensible default** is applied out of the box so a caller who configures nothing is still safe.
+4. No regression for callers who already pass a `context` deadline.
+
+## Non-Goals
+
+- The separate embeddings path (`EmbeddingProvider`) is **out of scope** — see Deferred.
+- Idle/stall ("time to first byte") streaming semantics are out of scope; streaming uses an overall
+  deadline (see Streaming below).
+- No live OpenAI round-trip verification — credentials live in Azure Key Vault, unreachable from the
+  dev/CI environment. Verification is via `httptest` mock servers.
+
+## Chosen Approach
+
+**Centralize the timeout in `core`.** This aligns with Iris's stated design principle that "Core
+never imports provider packages directly" — one provider-agnostic implementation covers all current
+and future providers. Rejected alternatives:
+
+- **Per-provider wiring** (the `azurefoundry` pattern): duplicates the same `context.WithTimeout`
+  block into every provider's chat/stream/embeddings methods — 10× the code and 10× the chance of
+  missing a path.
+- **`http.Client{Timeout: …}` default:** `http.Client.Timeout` aborts the whole request including a
+  mid-stream body read, which would truncate legitimately long streams. Wrong semantics for
+  streaming providers.
+
+## Design
+
+### 1. Client option and default
+
+```go
+// WithTimeout sets the default execution timeout applied to chat and streaming
+// calls when the caller's context has no deadline of its own. Pass 0 to disable
+// the default and allow calls to run without a timeout.
+func WithTimeout(d time.Duration) ClientOption
+```
+
+- Stored as a new field on `Client`: `timeout time.Duration`.
+- `NewClient` initializes it to `DefaultTimeout = 120 * time.Second`.
+- `WithTimeout(0)` explicitly disables the default (restores today's unbounded behavior).
+
+### 2. Precedence
+
+For every `GetResponse` and `Stream` call, resolve the effective timeout in this order:
+
+1. **Caller's `ctx` already has a deadline** → do nothing. The caller wins; no wrapping. (No regression.)
+2. Else **`ChatBuilder.Timeout()`** if set (> 0).
+3. Else the **Client default** (`c.timeout`, 120s unless overridden or disabled).
+4. If the resolved value is 0 → no timeout applied.
+
+A small helper centralizes this:
+
+```go
+// effectiveTimeout returns the timeout to apply, or 0 for "none".
+// Returns 0 when ctx already has a deadline (caller owns cancellation).
+func (b *ChatBuilder) effectiveTimeout(ctx context.Context) time.Duration
+```
+
+### 3. `GetResponse` (unary)
+
+Replace the current `if b.timeout > 0 { … }` block with a call through `effectiveTimeout`. The
+context is wrapped once and covers the whole retry loop (unchanged budget semantics — the deadline is
+an overall budget across attempts, matching existing behavior). On expiry, the returned error is
+mapped to `ErrTimeout` (see §5).
+
+### 4. `Stream` (streaming) — cancel tied to stream lifetime
+
+`provider.StreamChat(ctx, req)` returns a `*ChatStream` whose channels the caller drains *after*
+`Stream()` returns. A naive `defer cancel()` in `Stream()` would fire at method return and kill the
+stream immediately — which is exactly why streaming timeouts were skipped originally.
+
+Fix: when a timeout applies, create `ctx, cancel = context.WithTimeout(parent, d)`, pass the derived
+`ctx` to `StreamChat`, and hand `cancel` to a wrapper that invokes it when the stream terminates:
+
+- The existing `wrapStreamWithTelemetry` already observes stream completion. The timeout `cancel` is
+  invoked from the same completion point (all of `Ch`/`Err`/`Final` closed), OR the deadline fires on
+  its own.
+- Net effect: a fast/normal stream runs to completion and then `cancel` is called (releasing the
+  timer); a stalled stream is torn down when the deadline fires, and the caller observes `ErrTimeout`
+  on the `Err` channel / from `DrainStream`.
+
+This keeps the `ChatStream` channel contract intact ("on context cancellation, providers MUST
+terminate promptly and close channels", `core/streaming.go:10-13`).
+
+### 5. Typed error
+
+```go
+// ErrTimeout indicates an Iris-imposed execution timeout elapsed before the
+// provider call completed. It wraps context.DeadlineExceeded.
+var ErrTimeout = ...
+```
+
+- `errors.Is(err, ErrTimeout)` and `errors.Is(err, context.DeadlineExceeded)` both hold.
+- At the core boundary, when the applied timeout is the cause, map `context.DeadlineExceeded` →
+  `ErrTimeout` with a message like `iris: execution timeout after 120s`.
+- Distinguish from caller cancellation: a caller-owned deadline or `context.Canceled` is **not**
+  remapped — only the Iris-applied deadline surfaces as `ErrTimeout`.
+- `retry.go` already treats `context.DeadlineExceeded` as non-retryable; wrapping preserves that via
+  `errors.Is`.
+
+### 6. Deprecate dead per-provider `Config.Timeout`
+
+The per-provider `Config.Timeout` / `WithTimeout` are inert on every provider except `azurefoundry`.
+Mark them **deprecated** in doc comments, pointing callers to `core.WithTimeout`. No signatures
+change — non-breaking. `azurefoundry`'s own wiring is left as-is; it composes harmlessly with the
+core deadline (whichever is shorter wins).
+
+## Data Flow
+
+```
+client.Chat(model).User("…").GetResponse(ctx)
+  └─ effectiveTimeout(ctx):
+       ctx has deadline?  → 0  (no wrap)
+       builder.timeout>0? → builder.timeout
+       else               → client.timeout (120s default / 0 disabled)
+  └─ if >0: ctx, cancel = WithTimeout(ctx, d); defer cancel()
+  └─ retry loop → provider.Chat(ctx, req)
+  └─ on deadline: map DeadlineExceeded → ErrTimeout
+
+client.Chat(model).User("…").Stream(ctx)
+  └─ effectiveTimeout(ctx) → d
+  └─ if d>0: ctx, cancel = WithTimeout(ctx, d)   (cancel NOT deferred here)
+  └─ provider.StreamChat(ctx, req)
+  └─ wrapStream(…, cancel): invoke cancel when Ch/Err/Final all close
+  └─ on deadline: ErrTimeout delivered on Err channel
+```
+
+## Testing
+
+Table-driven tests in `core` using a mock provider that blocks on a controllable signal:
+
+- Unary: default (120s, shortened in test) fires → `ErrTimeout`; per-call `.Timeout()` override wins;
+  caller ctx deadline respected (not remapped to `ErrTimeout`); `WithTimeout(0)` disables (no timeout);
+  fast call under the deadline succeeds.
+- Streaming: a fast stream completes and is **not** cancelled prematurely; a stalled stream times out
+  and delivers `ErrTimeout` on `Err`; `cancel` is invoked exactly once (no goroutine leak).
+- Error typing: `errors.Is(err, ErrTimeout)` and `errors.Is(err, context.DeadlineExceeded)` both true;
+  a `context.Canceled` from the caller is not remapped.
+
+`gpt-5.4-mini` verification (`providers/openai`): an `httptest` server asserts the request lands on
+`/responses` (Responses API) with `"model":"gpt-5.4-mini"`, and a canned Responses payload is parsed
+into a `core.ChatResponse`. This exercises the exact code path the model uses, without live
+credentials.
+
+## Deferred / Out of Scope
+
+- **Embeddings timeout** (`EmbeddingProvider`): not routed through `core.Client`, so the core default
+  does not cover it. Tracked as a follow-up; would be a small addition mirroring this design.
+- **Idle/stall streaming timeout:** overall-deadline only for now.
+- **Live OpenAI round-trip:** must be run in an environment with Key Vault access.
+
+## Rollout / Compatibility
+
+- **Behavior change:** callers who set neither a ctx deadline nor a timeout, and who make calls longer
+  than 120s, will now receive `ErrTimeout` where they previously blocked. This is the intended fix.
+  Opt out with `core.WithTimeout(0)` or raise the value with `core.WithTimeout(d)`.
+- API is purely additive (`WithTimeout`, `ErrTimeout`, `DefaultTimeout`); no existing signatures change.

--- a/providers/anthropic/options.go
+++ b/providers/anthropic/options.go
@@ -25,7 +25,9 @@ type Config struct {
 	// Headers contains optional extra headers to include in requests.
 	Headers http.Header
 
-	// Timeout is the optional request timeout.
+	// Timeout is retained for compatibility but is not applied by this provider.
+	//
+	// Deprecated: use core.WithTimeout on the Client instead.
 	Timeout time.Duration
 
 	// FilesAPIBeta is the beta version for Files API. Defaults to DefaultFilesAPIBeta.
@@ -76,6 +78,10 @@ func WithHeader(key, value string) Option {
 }
 
 // WithTimeout sets the request timeout.
+//
+// Deprecated: this option is currently inert for this provider and has no
+// effect on requests. Use core.WithTimeout on the Client (or a context
+// deadline) to bound execution. Retained for API compatibility.
 func WithTimeout(d time.Duration) Option {
 	return func(c *Config) {
 		c.Timeout = d

--- a/providers/gemini/options.go
+++ b/providers/gemini/options.go
@@ -22,7 +22,9 @@ type Config struct {
 	// Headers contains optional extra headers to include in requests.
 	Headers http.Header
 
-	// Timeout is the optional request timeout.
+	// Timeout is retained for compatibility but is not applied by this provider.
+	//
+	// Deprecated: use core.WithTimeout on the Client instead.
 	Timeout time.Duration
 }
 
@@ -57,6 +59,10 @@ func WithHeader(key, value string) Option {
 }
 
 // WithTimeout sets the request timeout.
+//
+// Deprecated: this option is currently inert for this provider and has no
+// effect on requests. Use core.WithTimeout on the Client (or a context
+// deadline) to bound execution. Retained for API compatibility.
 func WithTimeout(d time.Duration) Option {
 	return func(c *Config) {
 		c.Timeout = d

--- a/providers/huggingface/options.go
+++ b/providers/huggingface/options.go
@@ -46,7 +46,9 @@ type Config struct {
 	// Headers contains optional extra headers to include in requests.
 	Headers http.Header
 
-	// Timeout is the optional request timeout.
+	// Timeout is retained for compatibility but is not applied by this provider.
+	//
+	// Deprecated: use core.WithTimeout on the Client instead.
 	Timeout time.Duration
 
 	// ProviderPolicy controls how requests are routed to inference providers.
@@ -84,6 +86,10 @@ func WithHeader(key, value string) Option {
 }
 
 // WithTimeout sets the request timeout.
+//
+// Deprecated: this option is currently inert for this provider and has no
+// effect on requests. Use core.WithTimeout on the Client (or a context
+// deadline) to bound execution. Retained for API compatibility.
 func WithTimeout(d time.Duration) Option {
 	return func(c *Config) {
 		c.Timeout = d

--- a/providers/ollama/options.go
+++ b/providers/ollama/options.go
@@ -33,7 +33,9 @@ type Config struct {
 	// Headers contains additional HTTP headers to include in requests.
 	Headers http.Header
 
-	// Timeout is the request timeout. Zero means no timeout.
+	// Timeout is retained for compatibility but is not applied by this provider.
+	//
+	// Deprecated: use core.WithTimeout on the Client instead.
 	Timeout time.Duration
 }
 
@@ -79,6 +81,10 @@ func WithHeaders(headers http.Header) Option {
 }
 
 // WithTimeout sets the request timeout.
+//
+// Deprecated: this option is currently inert for this provider and has no
+// effect on requests. Use core.WithTimeout on the Client (or a context
+// deadline) to bound execution. Retained for API compatibility.
 func WithTimeout(timeout time.Duration) Option {
 	return func(c *Config) {
 		c.Timeout = timeout

--- a/providers/openai/client_responses_test.go
+++ b/providers/openai/client_responses_test.go
@@ -808,3 +808,45 @@ func TestResponsesAPIMultimodalFileWithID(t *testing.T) {
 		t.Errorf("Output = %q, want expected text", resp.Output)
 	}
 }
+
+func TestGPT54MiniRoutesToResponsesAPI(t *testing.T) {
+	var gotPath, gotModel string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if m, ok := body["model"].(string); ok {
+			gotModel = m
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(responsesResponse{
+			ID:         "resp-54mini",
+			Model:      "gpt-5.4-mini",
+			Status:     "completed",
+			OutputText: "pong",
+			Output:     []responsesOutput{{Type: "message", Role: "assistant"}},
+			Usage:      &responsesUsage{InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
+		})
+	}))
+	defer server.Close()
+
+	p := New("test-key", WithBaseURL(server.URL))
+	resp, err := p.Chat(context.Background(), &core.ChatRequest{
+		Model:    ModelGPT54Mini,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "ping"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+	if gotPath != "/responses" {
+		t.Errorf("request path = %q, want /responses", gotPath)
+	}
+	if gotModel != "gpt-5.4-mini" {
+		t.Errorf("request model = %q, want gpt-5.4-mini", gotModel)
+	}
+	if resp.Output != "pong" {
+		t.Errorf("Output = %q, want pong", resp.Output)
+	}
+}

--- a/providers/openai/options.go
+++ b/providers/openai/options.go
@@ -28,7 +28,9 @@ type Config struct {
 	// Headers contains optional extra headers to include in requests.
 	Headers http.Header
 
-	// Timeout is the optional request timeout.
+	// Timeout is retained for compatibility but is not applied by this provider.
+	//
+	// Deprecated: use core.WithTimeout on the Client instead.
 	Timeout time.Duration
 }
 
@@ -77,6 +79,10 @@ func WithHeader(key, value string) Option {
 }
 
 // WithTimeout sets the request timeout.
+//
+// Deprecated: this option is currently inert for this provider and has no
+// effect on requests. Use core.WithTimeout on the Client (or a context
+// deadline) to bound execution. Retained for API compatibility.
 func WithTimeout(d time.Duration) Option {
 	return func(c *Config) {
 		c.Timeout = d

--- a/providers/perplexity/options.go
+++ b/providers/perplexity/options.go
@@ -22,7 +22,9 @@ type Config struct {
 	// Headers contains optional extra headers to include in requests.
 	Headers http.Header
 
-	// Timeout is the optional request timeout.
+	// Timeout is retained for compatibility but is not applied by this provider.
+	//
+	// Deprecated: use core.WithTimeout on the Client instead.
 	Timeout time.Duration
 }
 
@@ -57,6 +59,10 @@ func WithHeader(key, value string) Option {
 }
 
 // WithTimeout sets the request timeout.
+//
+// Deprecated: this option is currently inert for this provider and has no
+// effect on requests. Use core.WithTimeout on the Client (or a context
+// deadline) to bound execution. Retained for API compatibility.
 func WithTimeout(d time.Duration) Option {
 	return func(c *Config) {
 		c.Timeout = d

--- a/providers/voyageai/options.go
+++ b/providers/voyageai/options.go
@@ -22,7 +22,9 @@ type Config struct {
 	// Headers contains optional extra headers to include in requests.
 	Headers http.Header
 
-	// Timeout is the optional request timeout.
+	// Timeout is retained for compatibility but is not applied by this provider.
+	//
+	// Deprecated: use core.WithTimeout on the Client instead.
 	Timeout time.Duration
 }
 
@@ -57,6 +59,10 @@ func WithHeader(key, value string) Option {
 }
 
 // WithTimeout sets the request timeout.
+//
+// Deprecated: this option is currently inert for this provider and has no
+// effect on requests. Use core.WithTimeout on the Client (or a context
+// deadline) to bound execution. Retained for API compatibility.
 func WithTimeout(d time.Duration) Option {
 	return func(c *Config) {
 		c.Timeout = d

--- a/providers/xai/options.go
+++ b/providers/xai/options.go
@@ -22,7 +22,9 @@ type Config struct {
 	// Headers contains optional extra headers to include in requests.
 	Headers http.Header
 
-	// Timeout is the optional request timeout.
+	// Timeout is retained for compatibility but is not applied by this provider.
+	//
+	// Deprecated: use core.WithTimeout on the Client instead.
 	Timeout time.Duration
 }
 
@@ -57,6 +59,10 @@ func WithHeader(key, value string) Option {
 }
 
 // WithTimeout sets the request timeout.
+//
+// Deprecated: this option is currently inert for this provider and has no
+// effect on requests. Use core.WithTimeout on the Client (or a context
+// deadline) to bound execution. Retained for API compatibility.
 func WithTimeout(d time.Duration) Option {
 	return func(c *Config) {
 		c.Timeout = d

--- a/providers/zai/options.go
+++ b/providers/zai/options.go
@@ -26,7 +26,9 @@ type Config struct {
 	// Headers are additional headers to include in requests.
 	Headers http.Header
 
-	// Timeout is the request timeout. Zero means no timeout.
+	// Timeout is retained for compatibility but is not applied by this provider.
+	//
+	// Deprecated: use core.WithTimeout on the Client instead.
 	Timeout time.Duration
 }
 
@@ -55,6 +57,10 @@ func WithHeaders(headers http.Header) Option {
 }
 
 // WithTimeout sets the request timeout.
+//
+// Deprecated: this option is currently inert for this provider and has no
+// effect on requests. Use core.WithTimeout on the Client (or a context
+// deadline) to bound execution. Retained for API compatibility.
 func WithTimeout(timeout time.Duration) Option {
 	return func(c *Config) {
 		c.Timeout = timeout


### PR DESCRIPTION
## Summary

Adds a provider-agnostic **LLM execution timeout** centralized in `core`. Previously Iris applied no timeout to provider calls: a hung or slow call blocked indefinitely unless the caller passed a context deadline, so an external short timeout would cancel the work and mask the real error. Now Iris fails fast with a legible typed error.

## What changed

- **`core.WithTimeout(d)`** client option and **`DefaultTimeout = 120s`**, applied to both unary (`GetResponse`) and streaming (`Stream`) calls for every provider.
- **Precedence:** caller `ctx` deadline (untouched) > `ChatBuilder.Timeout()` > client default (120s) > none. `WithTimeout(0)` disables the default.
- **`core.ErrTimeout`** — a typed error wrapping `context.DeadlineExceeded`. Only an Iris-applied deadline is remapped to `ErrTimeout`; a caller-supplied deadline stays a raw context error. Remap happens after the retry loop, so retry classification is unaffected.
- **Streaming** applies the timeout with cancellation tied to the stream's lifetime (via `wrapStreamWithTelemetry`), so long legitimate streams aren't truncated at method return but a stalled stream still dies at the deadline.
- **Deprecated** the inert per-provider `WithTimeout`/`Config.Timeout` on 9 providers (openai, anthropic, gemini, xai, perplexity, ollama, huggingface, voyageai, zai), pointing to `core.WithTimeout`. `azurefoundry` (which actually wires its own) is unchanged.

## Behavior change

The 120s default now applies to any caller that sets neither a `ctx` deadline nor a `Timeout()`. This includes `core.Conversation.Stream`, which streams with a background context — a streamed generation longer than 120s will truncate with `ErrTimeout` unless the client raises or disables the value via `core.WithTimeout`. Opt out with `core.WithTimeout(0)`.

## Verification

- New table-driven tests in `core` for unary + streaming: default fires, per-call override, caller-deadline respected (not remapped), `WithTimeout(0)` disables, mid-stream timeout, and streaming caller-deadline non-remap. Validated with `go test -race` (incl. `-count=50` on the mid-stream path).
- `gpt-5.4-mini` verified to route to the OpenAI Responses API (`/responses`) via an `httptest` mock. A live round-trip needs Azure Key Vault credentials not available in CI.
- Full suite green under `-race`; `go build ./...` and `gofmt` clean.

## Out of scope

- The embeddings path (`EmbeddingProvider`) is not covered by the core default — noted as a follow-up.
- Idle/stall (time-to-first-byte) streaming semantics — streaming uses an overall deadline.
