### PR TITLE
fix(ci): inject version info into release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,15 @@ jobs:
       - name: Build binaries
         run: |
           mkdir -p dist
-          GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o dist/iris-linux-amd64 ./cli/cmd/iris
-          GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o dist/iris-darwin-amd64 ./cli/cmd/iris
-          GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o dist/iris-darwin-arm64 ./cli/cmd/iris
-          GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o dist/iris-windows-amd64.exe ./cli/cmd/iris
+          VERSION="${GITHUB_REF_NAME}"
+          COMMIT="$(git rev-parse --short HEAD)"
+          BUILD_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          PKG="github.com/petal-labs/iris/cli/commands"
+          LDFLAGS="-s -w -X ${PKG}.Version=${VERSION} -X ${PKG}.Commit=${COMMIT} -X ${PKG}.BuildDate=${BUILD_DATE}"
+          GOOS=linux GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o dist/iris-linux-amd64 ./cli/cmd/iris
+          GOOS=darwin GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o dist/iris-darwin-amd64 ./cli/cmd/iris
+          GOOS=darwin GOARCH=arm64 go build -ldflags="${LDFLAGS}" -o dist/iris-darwin-arm64 ./cli/cmd/iris
+          GOOS=windows GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o dist/iris-windows-amd64.exe ./cli/cmd/iris
 
       - name: Generate checksums
         run: |


### PR DESCRIPTION
Release binaries previously self-reported `Version = "dev"` because the release workflow built with `-ldflags="-s -w"` and never injected version metadata (unlike the Makefile).

This wires the same three ldflags the Makefile uses into every cross-compiled binary in `release.yml`:

- `Version` = the pushed tag (`GITHUB_REF_NAME`)
- `Commit`  = short HEAD sha
- `BuildDate` = build time (UTC)

Verified locally with the exact ldflags:

```
$ iris version --json
{"version":"v0.15.0","commit":"1e55169","buildDate":"...","goVersion":"...","platform":"..."}
```

Security note: the version is passed via the `GITHUB_REF_NAME` shell env var, not `\${{ github.ref_name }}` template interpolation, so there is no workflow-injection surface (and tag pushes are maintainer-only regardless).

Takes effect on the next tagged release. Does not retroactively change the already-published v0.15.0 assets.