### PR TITLE
feat: SDK reliability hardening (errors, structured output, timeouts)

### DIFF
--- a/core/batch.go
+++ b/core/batch.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"time"
 )
 
@@ -109,14 +110,36 @@ func (w *BatchWaiter) WithMaxWait(d time.Duration) *BatchWaiter {
 
 // Wait blocks until the batch completes or the context is cancelled.
 // Returns the final batch info, or an error if the wait times out or fails.
+//
+// Each poll is individually bounded by the remaining maxWait budget: a
+// GetBatchStatus call that hangs (e.g. a stuck network request) cannot
+// exceed the overall deadline, since the per-poll context is derived from
+// that deadline rather than from the caller's context alone.
 func (w *BatchWaiter) Wait(ctx context.Context, id BatchID) (*BatchInfo, error) {
 	deadline := time.Now().Add(w.maxWait)
 	ticker := time.NewTicker(w.pollInterval)
 	defer ticker.Stop()
 
 	for {
-		info, err := w.provider.GetBatchStatus(ctx, id)
+		// Bound this poll by the remaining maxWait budget (capped further
+		// by the caller's own ctx deadline, if any). context.WithDeadline
+		// automatically uses the earlier of the two deadlines, so a
+		// caller-supplied deadline shorter than maxWait still wins.
+		pollCtx, cancel := context.WithDeadline(ctx, deadline)
+		info, err := w.provider.GetBatchStatus(pollCtx, id)
+		cancel()
+
 		if err != nil {
+			// The caller's own context expiring/cancelling takes priority
+			// over our internally imposed deadline.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			// pollCtx timed out against our maxWait deadline (this is what
+			// bounds a stuck/hanging GetBatchStatus call).
+			if errors.Is(err, context.DeadlineExceeded) {
+				return nil, ErrBatchTimeout
+			}
 			return nil, err
 		}
 

--- a/core/batch.go
+++ b/core/batch.go
@@ -80,6 +80,10 @@ func AsBatchProvider(p Provider) (BatchProvider, bool) {
 }
 
 // BatchWaiter provides utilities for waiting on batch completion.
+//
+// BatchWaiter polls BatchProvider directly and does not go through
+// core.Client, so core.WithTimeout does not apply; bound Wait via
+// WithMaxWait and/or a context deadline passed by the caller.
 type BatchWaiter struct {
 	provider     BatchProvider
 	pollInterval time.Duration

--- a/core/batch_test.go
+++ b/core/batch_test.go
@@ -116,6 +116,33 @@ func (m *mockBatchProvider) ListBatches(_ context.Context, _ int) ([]BatchInfo, 
 	return nil, nil
 }
 
+// stuckBatchProvider implements BatchProvider with a GetBatchStatus that
+// blocks until its context is cancelled, simulating a hung network call.
+// Used to verify that BatchWaiter.Wait bounds each poll by the remaining
+// maxWait budget instead of hanging indefinitely.
+type stuckBatchProvider struct{}
+
+func (s *stuckBatchProvider) CreateBatch(_ context.Context, _ []BatchRequest) (BatchID, error) {
+	return "batch_123", nil
+}
+
+func (s *stuckBatchProvider) GetBatchStatus(ctx context.Context, _ BatchID) (*BatchInfo, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (s *stuckBatchProvider) GetBatchResults(_ context.Context, _ BatchID) ([]BatchResult, error) {
+	return nil, nil
+}
+
+func (s *stuckBatchProvider) CancelBatch(_ context.Context, _ BatchID) error {
+	return nil
+}
+
+func (s *stuckBatchProvider) ListBatches(_ context.Context, _ int) ([]BatchInfo, error) {
+	return nil, nil
+}
+
 func TestAsBatchProvider(t *testing.T) {
 	t.Run("supports batch", func(t *testing.T) {
 		mock := &fullBatchProvider{}
@@ -244,6 +271,25 @@ func TestBatchWaiter(t *testing.T) {
 			t.Errorf("Wait() error = %v, want %v", err, expectedErr)
 		}
 	})
+}
+
+func TestBatchWaiterDoesNotHangOnStuckPoll(t *testing.T) {
+	p := &stuckBatchProvider{}
+	w := NewBatchWaiter(p).
+		WithPollInterval(10 * time.Millisecond).
+		WithMaxWait(100 * time.Millisecond)
+
+	start := time.Now()
+	_, err := w.Wait(context.Background(), "batch-1")
+	if err == nil {
+		t.Fatal("want timeout error")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("Wait hung for %v; maxWait budget not enforced per-poll", elapsed)
+	}
+	if !errors.Is(err, ErrBatchTimeout) {
+		t.Errorf("Wait() error = %v, want ErrBatchTimeout", err)
+	}
 }
 
 func TestBatchWaiterWaitAndCollect(t *testing.T) {

--- a/core/client.go
+++ b/core/client.go
@@ -500,12 +500,20 @@ func (b *ChatBuilder) validate() error {
 		}
 	}
 
-	// Capability gate: reject JSON/JSON-Schema structured output requests
-	// against a provider that does not support core.FeatureStructuredOutput.
-	// This must run before the strict-schema check below so an unsupported
-	// provider fails with ErrStructuredOutputUnsupported rather than a schema
-	// validation error.
-	if b.req.ResponseFormat == ResponseFormatJSON || b.req.ResponseFormat == ResponseFormatJSONSchema {
+	// Capability gate: reject schema-based structured output requests
+	// (ResponseFormatJSONSchema) against a provider/model that does not
+	// support core.FeatureStructuredOutput. This must run before the
+	// strict-schema check below so an unsupported provider fails with
+	// ErrStructuredOutputUnsupported rather than a schema validation error.
+	//
+	// Plain JSON mode (ResponseFormatJSON / json_object) is intentionally
+	// NOT hard-gated here: it has no schema/shape contract to silently
+	// violate, and many models support json_object without being tagged
+	// with FeatureStructuredOutput (e.g. OpenAI's gpt-3.5-turbo, gpt-4, and
+	// gpt-4-turbo). Gating it would reject requests that previously worked.
+	// If a provider genuinely can't do json_object, its descriptive API
+	// error surfaces instead.
+	if b.req.ResponseFormat == ResponseFormatJSONSchema {
 		if !b.client.provider.Supports(FeatureStructuredOutput) {
 			return fmt.Errorf("%w: provider %s model %s",
 				ErrStructuredOutputUnsupported, b.client.provider.ID(), b.req.Model)

--- a/core/client.go
+++ b/core/client.go
@@ -500,10 +500,20 @@ func (b *ChatBuilder) validate() error {
 		}
 	}
 
+	// Capability gate: reject JSON/JSON-Schema structured output requests
+	// against a provider that does not support core.FeatureStructuredOutput.
+	// This must run before the strict-schema check below so an unsupported
+	// provider fails with ErrStructuredOutputUnsupported rather than a schema
+	// validation error.
+	if b.req.ResponseFormat == ResponseFormatJSON || b.req.ResponseFormat == ResponseFormatJSONSchema {
+		if !b.client.provider.Supports(FeatureStructuredOutput) {
+			return fmt.Errorf("%w: provider %s model %s",
+				ErrStructuredOutputUnsupported, b.client.provider.ID(), b.req.Model)
+		}
+	}
+
 	// Strict structured output requires a schema shape the provider can
-	// enforce exactly. (A capability gate that checks whether the target
-	// model supports strict mode at all belongs before this check; that is
-	// added separately.)
+	// enforce exactly.
 	if b.req.ResponseFormat == ResponseFormatJSONSchema && b.req.JSONSchema != nil && b.req.JSONSchema.Strict {
 		if err := validateStrictSchema(b.req.JSONSchema.Schema); err != nil {
 			return err

--- a/core/client.go
+++ b/core/client.go
@@ -349,18 +349,41 @@ func (b *ChatBuilder) ResponseJSON() *ChatBuilder {
 // This enables structured output mode where the model produces JSON conforming to the schema.
 // The schema parameter defines the structure the output must conform to.
 //
+// This always forces schema.Strict = true. Strict mode requires the schema to
+// set "additionalProperties": false and list every property in "required" at
+// every object node; validate() rejects non-compliant schemas with
+// ErrInvalidSchema before the request is sent. Use ResponseJSONSchemaNonStrict
+// to opt out of strict mode for schemas that cannot meet those constraints.
+//
 // Example:
 //
 //	schema := &core.JSONSchemaDefinition{
 //	    Name:   "person",
-//	    Strict: true,
-//	    Schema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"]}`),
+//	    Schema: json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"]}`),
 //	}
 //	resp, err := client.Chat(model).
 //	    User("Extract: John is 30 years old").
 //	    ResponseJSONSchema(schema).
 //	    GetResponse(ctx)
 func (b *ChatBuilder) ResponseJSONSchema(schema *JSONSchemaDefinition) *ChatBuilder {
+	if schema != nil {
+		schema.Strict = true
+	}
+	b.req.ResponseFormat = ResponseFormatJSONSchema
+	b.req.JSONSchema = schema
+	return b
+}
+
+// ResponseJSONSchemaNonStrict constrains the model output to match a specific
+// JSON Schema without enforcing strict mode. This forces schema.Strict = false,
+// skipping the strict-schema validation that ResponseJSONSchema applies. Use
+// this when a schema cannot satisfy strict mode's requirements (every object
+// node needs "additionalProperties": false and a "required" array covering
+// all declared properties) and the provider still accepts loose schemas.
+func (b *ChatBuilder) ResponseJSONSchemaNonStrict(schema *JSONSchemaDefinition) *ChatBuilder {
+	if schema != nil {
+		schema.Strict = false
+	}
 	b.req.ResponseFormat = ResponseFormatJSONSchema
 	b.req.JSONSchema = schema
 	return b
@@ -474,6 +497,16 @@ func (b *ChatBuilder) validate() error {
 		hasContent := msg.Content != "" || len(msg.Parts) > 0 || len(msg.ToolCalls) > 0 || len(msg.ToolResults) > 0
 		if !hasContent {
 			return ErrNoMessages
+		}
+	}
+
+	// Strict structured output requires a schema shape the provider can
+	// enforce exactly. (A capability gate that checks whether the target
+	// model supports strict mode at all belongs before this check; that is
+	// added separately.)
+	if b.req.ResponseFormat == ResponseFormatJSONSchema && b.req.JSONSchema != nil && b.req.JSONSchema.Strict {
+		if err := validateStrictSchema(b.req.JSONSchema.Schema); err != nil {
+			return err
 		}
 	}
 

--- a/core/client.go
+++ b/core/client.go
@@ -510,6 +510,23 @@ func (b *ChatBuilder) validate() error {
 			return fmt.Errorf("%w: provider %s model %s",
 				ErrStructuredOutputUnsupported, b.client.provider.ID(), b.req.Model)
 		}
+
+		// Model-level gate: the provider supports structured output overall,
+		// but the specific requested model may not (e.g. OpenAI supports it,
+		// but gpt-3.5-turbo / gpt-4 do not). If the model is present in the
+		// provider's catalog and lacks the capability, reject it. If the
+		// model is NOT present in the catalog (unknown, brand-new, or a
+		// custom deployment not yet reflected in the static catalog), fall
+		// back to allowing it since the provider-level check already passed.
+		for _, m := range b.client.provider.Models() {
+			if m.ID == b.req.Model {
+				if !m.HasCapability(FeatureStructuredOutput) {
+					return fmt.Errorf("%w: provider %s model %s",
+						ErrStructuredOutputUnsupported, b.client.provider.ID(), b.req.Model)
+				}
+				break
+			}
+		}
 	}
 
 	// Strict structured output requires a schema shape the provider can

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -1735,3 +1735,84 @@ func TestStructuredOutputUnsupportedGateRunsBeforeSchemaValidation(t *testing.T)
 		t.Error("err should not be ErrInvalidSchema; capability gate must run first")
 	}
 }
+
+// modelGatedProvider is a Provider that supports FeatureStructuredOutput at
+// the provider level, but whose per-model catalog (Models()) may declare
+// individual models that lack the capability. It is used to test the
+// model-aware structured output gate added on top of the provider-level gate.
+type modelGatedProvider struct {
+	models []ModelInfo
+}
+
+func (p modelGatedProvider) ID() string          { return "modelgated" }
+func (p modelGatedProvider) Models() []ModelInfo { return p.models }
+func (p modelGatedProvider) Supports(feature Feature) bool {
+	return feature == FeatureStructuredOutput
+}
+
+func (p modelGatedProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	return &ChatResponse{ID: "resp-1", Model: req.Model, Output: `{"name":"John"}`}, nil
+}
+
+func (p modelGatedProvider) StreamChat(ctx context.Context, req *ChatRequest) (*ChatStream, error) {
+	ch := make(chan ChatChunk, 1)
+	errCh := make(chan error, 1)
+	finalCh := make(chan *ChatResponse, 1)
+
+	go func() {
+		ch <- ChatChunk{Delta: "Hello"}
+		close(ch)
+		finalCh <- &ChatResponse{ID: "resp-1", Model: req.Model, Output: "Hello!"}
+		close(finalCh)
+		close(errCh)
+	}()
+
+	return &ChatStream{Ch: ch, Err: errCh, Final: finalCh}, nil
+}
+
+// modelGatedCatalog is shared by the model-aware structured output gate
+// tests below. "model-with-so" declares FeatureStructuredOutput;
+// "model-without-so" is in the catalog but lacks it.
+var modelGatedCatalog = []ModelInfo{
+	{ID: "model-with-so", DisplayName: "With Structured Output", Capabilities: []Feature{FeatureChat, FeatureStructuredOutput}},
+	{ID: "model-without-so", DisplayName: "Without Structured Output", Capabilities: []Feature{FeatureChat}},
+}
+
+func TestStructuredOutputUnsupportedForModelWithoutCapability(t *testing.T) {
+	// Provider supports structured output overall, but the specific
+	// requested model is in the catalog and does NOT declare the
+	// capability. This must be rejected even though the provider-level
+	// check passes.
+	c := NewClient(modelGatedProvider{models: modelGatedCatalog})
+	_, err := c.Chat("model-without-so").User("hi").ResponseJSON().GetResponse(context.Background())
+	if !errors.Is(err, ErrStructuredOutputUnsupported) {
+		t.Fatalf("err = %v, want ErrStructuredOutputUnsupported", err)
+	}
+}
+
+func TestStructuredOutputAllowedForModelWithCapability(t *testing.T) {
+	// Provider supports structured output overall, and the specific
+	// requested model is in the catalog and DOES declare the capability.
+	// This must proceed without ErrStructuredOutputUnsupported.
+	c := NewClient(modelGatedProvider{models: modelGatedCatalog})
+	_, err := c.Chat("model-with-so").User("hi").ResponseJSON().GetResponse(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+func TestStructuredOutputAllowedForModelNotInCatalog(t *testing.T) {
+	// The requested model is unknown to the provider's static catalog
+	// (e.g. a brand-new or custom-deployment model). Since the
+	// provider-level check already passed, the model-level gate must NOT
+	// reject it purely for being absent from Models() -- it falls back to
+	// allowing the request.
+	c := NewClient(modelGatedProvider{models: modelGatedCatalog})
+	_, err := c.Chat("model-unknown").User("hi").ResponseJSON().GetResponse(context.Background())
+	if errors.Is(err, ErrStructuredOutputUnsupported) {
+		t.Fatalf("err = %v, want no ErrStructuredOutputUnsupported for unknown model", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -1696,11 +1696,50 @@ func (p nonStructuredProvider) StreamChat(ctx context.Context, req *ChatRequest)
 	return nil, errors.New("nonStructuredProvider.StreamChat should not be reached")
 }
 
-func TestStructuredOutputUnsupportedIsHardError(t *testing.T) {
-	c := NewClient(nonStructuredProvider{t: t})
+// nonStructuredButChattyProvider reports false for FeatureStructuredOutput,
+// like nonStructuredProvider, but actually implements Chat/StreamChat so
+// requests that are NOT hard-gated (plain ResponseJSON) can complete and
+// prove the request reached the provider instead of erroring in validate().
+type nonStructuredButChattyProvider struct{}
+
+func (p nonStructuredButChattyProvider) ID() string          { return "nonstructured-chatty" }
+func (p nonStructuredButChattyProvider) Models() []ModelInfo { return nil }
+func (p nonStructuredButChattyProvider) Supports(feature Feature) bool {
+	return feature == FeatureChat
+}
+
+func (p nonStructuredButChattyProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	return &ChatResponse{ID: "resp-1", Model: req.Model, Output: `{"ok":true}`}, nil
+}
+
+func (p nonStructuredButChattyProvider) StreamChat(ctx context.Context, req *ChatRequest) (*ChatStream, error) {
+	ch := make(chan ChatChunk, 1)
+	errCh := make(chan error, 1)
+	finalCh := make(chan *ChatResponse, 1)
+
+	go func() {
+		ch <- ChatChunk{Delta: "ok"}
+		close(ch)
+		finalCh <- &ChatResponse{ID: "resp-1", Model: req.Model, Output: "ok"}
+		close(finalCh)
+		close(errCh)
+	}()
+
+	return &ChatStream{Ch: ch, Err: errCh, Final: finalCh}, nil
+}
+
+func TestResponseJSONNotGatedForUnsupportedProvider(t *testing.T) {
+	// Plain json_object mode has no schema/shape contract to violate, so it
+	// must NOT be hard-gated by the FeatureStructuredOutput capability check
+	// even when the provider lacks that feature. The request must reach the
+	// provider; any incompatibility surfaces as the provider's own error.
+	c := NewClient(nonStructuredButChattyProvider{})
 	_, err := c.Chat("m").User("hi").ResponseJSON().GetResponse(context.Background())
-	if !errors.Is(err, ErrStructuredOutputUnsupported) {
-		t.Fatalf("err = %v, want ErrStructuredOutputUnsupported", err)
+	if errors.Is(err, ErrStructuredOutputUnsupported) {
+		t.Fatalf("err = %v, want no ErrStructuredOutputUnsupported for ResponseJSON", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
 	}
 }
 
@@ -1781,12 +1820,31 @@ var modelGatedCatalog = []ModelInfo{
 func TestStructuredOutputUnsupportedForModelWithoutCapability(t *testing.T) {
 	// Provider supports structured output overall, but the specific
 	// requested model is in the catalog and does NOT declare the
-	// capability. This must be rejected even though the provider-level
-	// check passes.
+	// capability. Schema-based structured output (ResponseJSONSchema) must
+	// be rejected even though the provider-level check passes.
 	c := NewClient(modelGatedProvider{models: modelGatedCatalog})
-	_, err := c.Chat("model-without-so").User("hi").ResponseJSON().GetResponse(context.Background())
+	_, err := c.Chat("model-without-so").User("hi").
+		ResponseJSONSchema(&JSONSchemaDefinition{
+			Name:   "person",
+			Schema: json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"name":{"type":"string"}},"required":["name"]}`),
+		}).
+		GetResponse(context.Background())
 	if !errors.Is(err, ErrStructuredOutputUnsupported) {
 		t.Fatalf("err = %v, want ErrStructuredOutputUnsupported", err)
+	}
+}
+
+func TestResponseJSONNotGatedForModelWithoutCapability(t *testing.T) {
+	// Plain json_object mode (ResponseJSON) is not hard-gated by the
+	// model-level capability check either, even when the specific model is
+	// in the catalog and lacks FeatureStructuredOutput.
+	c := NewClient(modelGatedProvider{models: modelGatedCatalog})
+	_, err := c.Chat("model-without-so").User("hi").ResponseJSON().GetResponse(context.Background())
+	if errors.Is(err, ErrStructuredOutputUnsupported) {
+		t.Fatalf("err = %v, want no ErrStructuredOutputUnsupported for ResponseJSON", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
 	}
 }
 

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"sync"
@@ -1554,5 +1555,115 @@ func TestCloneWithResponseFormatJSON(t *testing.T) {
 
 	if clone.req.ResponseFormat != ResponseFormatJSON {
 		t.Errorf("clone.ResponseFormat = %v, want %v", clone.req.ResponseFormat, ResponseFormatJSON)
+	}
+}
+
+func TestResponseJSONSchemaDefaultsStrict(t *testing.T) {
+	b := NewClient(&mockProvider{}).Chat("m").
+		ResponseJSONSchema(&JSONSchemaDefinition{Name: "x", Schema: json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{},"required":[]}`)})
+	if !b.req.JSONSchema.Strict {
+		t.Error("ResponseJSONSchema should default Strict=true")
+	}
+}
+
+func TestResponseJSONSchemaNonStrictOptOut(t *testing.T) {
+	b := NewClient(&mockProvider{}).Chat("m").
+		ResponseJSONSchemaNonStrict(&JSONSchemaDefinition{Name: "x", Schema: json.RawMessage(`{}`)})
+	if b.req.JSONSchema.Strict {
+		t.Error("ResponseJSONSchemaNonStrict should set Strict=false")
+	}
+}
+
+func TestResponseJSONSchemaForcesStrictEvenIfCallerSetFalse(t *testing.T) {
+	schema := &JSONSchemaDefinition{
+		Name:   "x",
+		Schema: json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{},"required":[]}`),
+		Strict: false,
+	}
+	NewClient(&mockProvider{}).Chat("m").ResponseJSONSchema(schema)
+	if !schema.Strict {
+		t.Error("ResponseJSONSchema should force Strict=true even if the caller passed false")
+	}
+}
+
+func TestResponseJSONSchemaNilSchemaDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ResponseJSONSchema(nil) panicked: %v", r)
+		}
+	}()
+	b := NewClient(&mockProvider{}).Chat("m").ResponseJSONSchema(nil)
+	if b.req.JSONSchema != nil {
+		t.Error("req.JSONSchema should remain nil when passed nil")
+	}
+}
+
+func TestResponseJSONSchemaNonStrictNilSchemaDoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ResponseJSONSchemaNonStrict(nil) panicked: %v", r)
+		}
+	}()
+	b := NewClient(&mockProvider{}).Chat("m").ResponseJSONSchemaNonStrict(nil)
+	if b.req.JSONSchema != nil {
+		t.Error("req.JSONSchema should remain nil when passed nil")
+	}
+}
+
+func TestGetResponseRejectsNonStrictCompatibleSchema(t *testing.T) {
+	ctx := context.Background()
+	provider := &mockProvider{id: "test"}
+	client := NewClient(provider)
+
+	_, err := client.Chat("gpt-4").
+		User("Extract person info").
+		ResponseJSONSchema(&JSONSchemaDefinition{
+			Name:   "person",
+			Schema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`),
+		}).
+		GetResponse(ctx)
+
+	if !errors.Is(err, ErrInvalidSchema) {
+		t.Fatalf("err = %v, want ErrInvalidSchema", err)
+	}
+}
+
+func TestGetResponseAcceptsStrictCompatibleSchema(t *testing.T) {
+	ctx := context.Background()
+	provider := &mockProvider{id: "test", chatFunc: func(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+		return &ChatResponse{Output: `{"name":"John"}`}, nil
+	}}
+	client := NewClient(provider)
+
+	_, err := client.Chat("gpt-4").
+		User("Extract person info").
+		ResponseJSONSchema(&JSONSchemaDefinition{
+			Name:   "person",
+			Schema: json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"name":{"type":"string"}},"required":["name"]}`),
+		}).
+		GetResponse(ctx)
+
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+func TestGetResponseSkipsValidationForNonStrictSchema(t *testing.T) {
+	ctx := context.Background()
+	provider := &mockProvider{id: "test", chatFunc: func(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+		return &ChatResponse{Output: `{"name":"John"}`}, nil
+	}}
+	client := NewClient(provider)
+
+	_, err := client.Chat("gpt-4").
+		User("Extract person info").
+		ResponseJSONSchemaNonStrict(&JSONSchemaDefinition{
+			Name:   "person",
+			Schema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`),
+		}).
+		GetResponse(ctx)
+
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
 	}
 }

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -31,7 +31,7 @@ func (m *mockProvider) Models() []ModelInfo {
 }
 
 func (m *mockProvider) Supports(feature Feature) bool {
-	return feature == FeatureChat || feature == FeatureChatStreaming
+	return feature == FeatureChat || feature == FeatureChatStreaming || feature == FeatureStructuredOutput
 }
 
 func (m *mockProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
@@ -1665,5 +1665,73 @@ func TestGetResponseSkipsValidationForNonStrictSchema(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+// nonStructuredProvider is a Provider whose Supports reports false for
+// FeatureStructuredOutput (and every other feature). Its Chat and StreamChat
+// methods fail the test if invoked, proving the capability gate in
+// validate() short-circuits before the provider is ever called.
+type nonStructuredProvider struct {
+	t *testing.T
+}
+
+func (p nonStructuredProvider) ID() string          { return "nonstructured" }
+func (p nonStructuredProvider) Models() []ModelInfo { return nil }
+func (p nonStructuredProvider) Supports(feature Feature) bool {
+	return false
+}
+
+func (p nonStructuredProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	if p.t != nil {
+		p.t.Fatal("Chat should not be called when the structured output capability gate fires")
+	}
+	return nil, errors.New("nonStructuredProvider.Chat should not be reached")
+}
+
+func (p nonStructuredProvider) StreamChat(ctx context.Context, req *ChatRequest) (*ChatStream, error) {
+	if p.t != nil {
+		p.t.Fatal("StreamChat should not be called when the structured output capability gate fires")
+	}
+	return nil, errors.New("nonStructuredProvider.StreamChat should not be reached")
+}
+
+func TestStructuredOutputUnsupportedIsHardError(t *testing.T) {
+	c := NewClient(nonStructuredProvider{t: t})
+	_, err := c.Chat("m").User("hi").ResponseJSON().GetResponse(context.Background())
+	if !errors.Is(err, ErrStructuredOutputUnsupported) {
+		t.Fatalf("err = %v, want ErrStructuredOutputUnsupported", err)
+	}
+}
+
+func TestStructuredOutputUnsupportedIsHardErrorForJSONSchema(t *testing.T) {
+	c := NewClient(nonStructuredProvider{t: t})
+	_, err := c.Chat("m").User("hi").
+		ResponseJSONSchema(&JSONSchemaDefinition{
+			Name:   "person",
+			Schema: json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"name":{"type":"string"}},"required":["name"]}`),
+		}).
+		GetResponse(context.Background())
+	if !errors.Is(err, ErrStructuredOutputUnsupported) {
+		t.Fatalf("err = %v, want ErrStructuredOutputUnsupported", err)
+	}
+}
+
+func TestStructuredOutputUnsupportedGateRunsBeforeSchemaValidation(t *testing.T) {
+	// An invalid strict schema against an unsupported provider must surface
+	// ErrStructuredOutputUnsupported, not ErrInvalidSchema, proving the
+	// capability gate runs first.
+	c := NewClient(nonStructuredProvider{t: t})
+	_, err := c.Chat("m").User("hi").
+		ResponseJSONSchema(&JSONSchemaDefinition{
+			Name:   "person",
+			Schema: json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}`),
+		}).
+		GetResponse(context.Background())
+	if !errors.Is(err, ErrStructuredOutputUnsupported) {
+		t.Fatalf("err = %v, want ErrStructuredOutputUnsupported", err)
+	}
+	if errors.Is(err, ErrInvalidSchema) {
+		t.Error("err should not be ErrInvalidSchema; capability gate must run first")
 	}
 }

--- a/core/errors.go
+++ b/core/errors.go
@@ -67,6 +67,14 @@ var (
 // "required" array that does not cover all declared properties).
 var ErrInvalidSchema = errors.New("invalid json schema for strict structured output")
 
+// ErrStructuredOutputUnsupported indicates a request asked for JSON or
+// JSON-Schema structured output (ResponseFormatJSON or
+// ResponseFormatJSONSchema) targeting a provider that does not support
+// core.FeatureStructuredOutput. validate() returns this before the request
+// is sent so callers fail fast instead of silently receiving unconstrained
+// output.
+var ErrStructuredOutputUnsupported = errors.New("structured output not supported by this provider or model")
+
 // ErrTimeout indicates an Iris-imposed execution timeout elapsed before the
 // provider call completed. It wraps context.DeadlineExceeded, so
 // errors.Is(err, context.DeadlineExceeded) also holds.

--- a/core/errors.go
+++ b/core/errors.go
@@ -14,11 +14,16 @@ type ProviderError struct {
 	RequestID string
 	Code      string
 	Message   string
+	Body      string // raw response body (truncated); preserved when Message lacks detail
 	Err       error
 }
 
 // Error implements the error interface.
 func (e *ProviderError) Error() string {
+	// Omit the (status,code) suffix for pure network/decode errors.
+	if e.Status == 0 && e.Code == "" {
+		return fmt.Sprintf("%s: %s", e.Provider, e.Message)
+	}
 	if e.RequestID != "" {
 		return fmt.Sprintf("%s: %s (status=%d, code=%s, request_id=%s)",
 			e.Provider, e.Message, e.Status, e.Code, e.RequestID)

--- a/core/errors.go
+++ b/core/errors.go
@@ -62,6 +62,11 @@ var (
 	ErrNoMessages    = errors.New("no messages: add at least one message using .System(), .User(), or .Assistant()")
 )
 
+// ErrInvalidSchema indicates a JSON Schema is not compatible with strict
+// structured output mode (e.g., missing "additionalProperties": false or a
+// "required" array that does not cover all declared properties).
+var ErrInvalidSchema = errors.New("invalid json schema for strict structured output")
+
 // ErrTimeout indicates an Iris-imposed execution timeout elapsed before the
 // provider call completed. It wraps context.DeadlineExceeded, so
 // errors.Is(err, context.DeadlineExceeded) also holds.

--- a/core/errors_test.go
+++ b/core/errors_test.go
@@ -246,6 +246,16 @@ func TestErrorChaining(t *testing.T) {
 	}
 }
 
+func TestProviderErrorCarriesBody(t *testing.T) {
+	e := &ProviderError{Provider: "openai", Status: 400, Message: "bad", Body: `{"detail":"nope"}`}
+	if e.Body == "" {
+		t.Fatal("Body should be populated")
+	}
+	if !strings.Contains(e.Error(), "openai") {
+		t.Errorf("Error() = %q", e.Error())
+	}
+}
+
 func TestNewTimeoutError(t *testing.T) {
 	err := newTimeoutError(120 * time.Second)
 

--- a/core/retry_test.go
+++ b/core/retry_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -268,5 +269,12 @@ func TestIsRetryable(t *testing.T) {
 				t.Errorf("isRetryable(%v) = %v, want %v", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestWrappedTimeoutIsNotRetryable(t *testing.T) {
+	err := &ProviderError{Provider: "x", Err: fmt.Errorf("%w: %w", ErrNetwork, context.DeadlineExceeded)}
+	if isRetryable(err) {
+		t.Error("a timed-out request must not be retryable")
 	}
 }

--- a/core/schema.go
+++ b/core/schema.go
@@ -103,7 +103,7 @@ func validateObjectConstraints(obj map[string]any, path string) error {
 	if !hasAddl {
 		return fmt.Errorf("%w: %s: object schema missing \"additionalProperties\": false", ErrInvalidSchema, pathOrRoot(path))
 	}
-	if b, isBool := addl.(bool); !isBool || b != false {
+	if b, isBool := addl.(bool); !isBool || b {
 		return fmt.Errorf("%w: %s: \"additionalProperties\" must be false, got %#v", ErrInvalidSchema, pathOrRoot(path), addl)
 	}
 

--- a/core/schema.go
+++ b/core/schema.go
@@ -1,0 +1,154 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// validateStrictSchema checks that raw is a JSON Schema compatible with
+// provider "strict" structured-output modes (e.g. OpenAI's strict function
+// calling / response format). Strict mode requires that every object node in
+// the schema:
+//
+//   - sets "additionalProperties": false, and
+//   - lists every key present in "properties" inside the "required" array.
+//
+// Providers reject non-compliant schemas at request time with an opaque
+// error; validating locally produces a precise, actionable error instead.
+//
+// The schema is walked recursively through "properties", "items" (both the
+// single-schema and tuple-array forms), "$defs", and the legacy
+// "definitions" keyword. Nodes containing "$ref" are not recursed into: a
+// reference cannot be validated without resolving it, and if the referenced
+// definition is declared locally under $defs/definitions it is validated
+// independently as part of that walk.
+func validateStrictSchema(raw json.RawMessage) error {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	var node any
+	if err := json.Unmarshal(raw, &node); err != nil {
+		return fmt.Errorf("%w: schema is not valid JSON: %v", ErrInvalidSchema, err)
+	}
+
+	return validateStrictNode(node, "")
+}
+
+// validateStrictNode recursively validates a single decoded JSON Schema node.
+// path identifies the node's location using a JSON-path-like notation for
+// error messages, e.g. ".address.city"; the root node uses "".
+func validateStrictNode(node any, path string) error {
+	obj, ok := node.(map[string]any)
+	if !ok {
+		// Non-object-shaped nodes (booleans, string enum values, etc.) carry
+		// no strict-mode constraints of their own.
+		return nil
+	}
+
+	// A node containing "$ref" is a pointer to another schema; it cannot be
+	// validated inline. If the target is declared locally under $defs or
+	// definitions, it is validated separately when we walk those maps.
+	if _, hasRef := obj["$ref"]; hasRef {
+		return nil
+	}
+
+	if isObjectType(obj["type"]) {
+		if err := validateObjectConstraints(obj, path); err != nil {
+			return err
+		}
+	}
+
+	if props, ok := obj["properties"].(map[string]any); ok {
+		for key, val := range props {
+			if err := validateStrictNode(val, path+"."+key); err != nil {
+				return err
+			}
+		}
+	}
+
+	if items, ok := obj["items"]; ok {
+		switch v := items.(type) {
+		case map[string]any:
+			if err := validateStrictNode(v, path+".items"); err != nil {
+				return err
+			}
+		case []any:
+			for i, item := range v {
+				if err := validateStrictNode(item, fmt.Sprintf("%s.items[%d]", path, i)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	for _, defsKey := range [...]string{"$defs", "definitions"} {
+		if defs, ok := obj[defsKey].(map[string]any); ok {
+			for key, val := range defs {
+				if err := validateStrictNode(val, fmt.Sprintf("%s.%s.%s", path, defsKey, key)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateObjectConstraints enforces the two strict-mode rules that apply to
+// a single object-typed schema node: additionalProperties must be exactly
+// false, and every declared property must appear in required.
+func validateObjectConstraints(obj map[string]any, path string) error {
+	addl, hasAddl := obj["additionalProperties"]
+	if !hasAddl {
+		return fmt.Errorf("%w: %s: object schema missing \"additionalProperties\": false", ErrInvalidSchema, pathOrRoot(path))
+	}
+	if b, isBool := addl.(bool); !isBool || b != false {
+		return fmt.Errorf("%w: %s: \"additionalProperties\" must be false, got %#v", ErrInvalidSchema, pathOrRoot(path), addl)
+	}
+
+	props, _ := obj["properties"].(map[string]any)
+
+	required := make(map[string]bool, len(props))
+	if reqRaw, ok := obj["required"].([]any); ok {
+		for _, r := range reqRaw {
+			if s, ok := r.(string); ok {
+				required[s] = true
+			}
+		}
+	}
+
+	for key := range props {
+		if !required[key] {
+			return fmt.Errorf("%w: %s: property %q is not listed in \"required\"", ErrInvalidSchema, pathOrRoot(path), key)
+		}
+	}
+
+	return nil
+}
+
+// isObjectType reports whether a schema's "type" value designates an object.
+// It handles both the common string form ("type": "object") and the union
+// form ("type": ["object", "null"]).
+func isObjectType(t any) bool {
+	switch v := t.(type) {
+	case string:
+		return v == "object"
+	case []any:
+		for _, e := range v {
+			if s, ok := e.(string); ok && s == "object" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// pathOrRoot renders the root path as "root" for readability in error
+// messages, since an empty string is easy to misread as missing information.
+func pathOrRoot(path string) string {
+	if path == "" {
+		return "root"
+	}
+	return path
+}

--- a/core/schema_test.go
+++ b/core/schema_test.go
@@ -1,0 +1,202 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestValidateStrictSchemaRejectsMissingAdditionalProps(t *testing.T) {
+	s := json.RawMessage(`{"type":"object","properties":{"n":{"type":"string"}},"required":["n"]}`)
+	if err := validateStrictSchema(s); !errors.Is(err, ErrInvalidSchema) {
+		t.Fatalf("err = %v, want ErrInvalidSchema", err)
+	}
+}
+
+func TestValidateStrictSchemaAcceptsWellFormed(t *testing.T) {
+	s := json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"n":{"type":"string"}},"required":["n"]}`)
+	if err := validateStrictSchema(s); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+func TestValidateStrictSchemaRejectsMissingRequiredEntry(t *testing.T) {
+	s := json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"n":{"type":"string"},"age":{"type":"integer"}},"required":["n"]}`)
+	if err := validateStrictSchema(s); !errors.Is(err, ErrInvalidSchema) {
+		t.Fatalf("err = %v, want ErrInvalidSchema", err)
+	}
+}
+
+func TestValidateStrictSchemaRejectsNestedObjectMissingAdditionalProps(t *testing.T) {
+	// The root object is well-formed, but the nested "address" object is not:
+	// it declares "city" in properties without additionalProperties:false or
+	// listing "city" in required.
+	s := json.RawMessage(`{
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"name": {"type": "string"},
+			"address": {
+				"type": "object",
+				"properties": {
+					"city": {"type": "string"}
+				},
+				"required": ["city"]
+			}
+		},
+		"required": ["name", "address"]
+	}`)
+
+	err := validateStrictSchema(s)
+	if !errors.Is(err, ErrInvalidSchema) {
+		t.Fatalf("err = %v, want ErrInvalidSchema", err)
+	}
+	if !strings.Contains(err.Error(), ".address") {
+		t.Errorf("err = %v, want it to name the nested path .address", err)
+	}
+}
+
+func TestValidateStrictSchemaAcceptsWellFormedNestedObject(t *testing.T) {
+	s := json.RawMessage(`{
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"name": {"type": "string"},
+			"address": {
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"city": {"type": "string"},
+					"zip": {"type": "string"}
+				},
+				"required": ["city", "zip"]
+			}
+		},
+		"required": ["name", "address"]
+	}`)
+
+	if err := validateStrictSchema(s); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+func TestValidateStrictSchemaRejectsAdditionalPropertiesTrue(t *testing.T) {
+	s := json.RawMessage(`{"type":"object","additionalProperties":true,"properties":{"n":{"type":"string"}},"required":["n"]}`)
+	if err := validateStrictSchema(s); !errors.Is(err, ErrInvalidSchema) {
+		t.Fatalf("err = %v, want ErrInvalidSchema", err)
+	}
+}
+
+func TestValidateStrictSchemaAcceptsEmptyObject(t *testing.T) {
+	s := json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{},"required":[]}`)
+	if err := validateStrictSchema(s); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+func TestValidateStrictSchemaAcceptsNonObjectRoot(t *testing.T) {
+	s := json.RawMessage(`{"type":"string"}`)
+	if err := validateStrictSchema(s); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+func TestValidateStrictSchemaValidatesArrayItems(t *testing.T) {
+	s := json.RawMessage(`{
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"tags": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"label": {"type": "string"}
+					}
+				}
+			}
+		},
+		"required": ["tags"]
+	}`)
+
+	err := validateStrictSchema(s)
+	if !errors.Is(err, ErrInvalidSchema) {
+		t.Fatalf("err = %v, want ErrInvalidSchema", err)
+	}
+	if !strings.Contains(err.Error(), ".tags.items") {
+		t.Errorf("err = %v, want it to name the path .tags.items", err)
+	}
+}
+
+func TestValidateStrictSchemaValidatesDefs(t *testing.T) {
+	s := json.RawMessage(`{
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"address": {"$ref": "#/$defs/address"}
+		},
+		"required": ["address"],
+		"$defs": {
+			"address": {
+				"type": "object",
+				"properties": {
+					"city": {"type": "string"}
+				},
+				"required": ["city"]
+			}
+		}
+	}`)
+
+	err := validateStrictSchema(s)
+	if !errors.Is(err, ErrInvalidSchema) {
+		t.Fatalf("err = %v, want ErrInvalidSchema", err)
+	}
+	if !strings.Contains(err.Error(), "$defs.address") {
+		t.Errorf("err = %v, want it to name the path in $defs.address", err)
+	}
+}
+
+func TestValidateStrictSchemaSkipsRefNodes(t *testing.T) {
+	// The $ref node itself has no additionalProperties/required of its own,
+	// and must not be treated as a violation just because it points at an
+	// object schema.
+	s := json.RawMessage(`{
+		"type": "object",
+		"additionalProperties": false,
+		"properties": {
+			"address": {"$ref": "#/$defs/address"}
+		},
+		"required": ["address"],
+		"$defs": {
+			"address": {
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"city": {"type": "string"}
+				},
+				"required": ["city"]
+			}
+		}
+	}`)
+
+	if err := validateStrictSchema(s); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+func TestValidateStrictSchemaEmptyRawMessage(t *testing.T) {
+	if err := validateStrictSchema(nil); err != nil {
+		t.Fatalf("unexpected err for nil schema: %v", err)
+	}
+	if err := validateStrictSchema(json.RawMessage{}); err != nil {
+		t.Fatalf("unexpected err for empty schema: %v", err)
+	}
+}
+
+func TestValidateStrictSchemaInvalidJSON(t *testing.T) {
+	err := validateStrictSchema(json.RawMessage(`{not valid json`))
+	if !errors.Is(err, ErrInvalidSchema) {
+		t.Fatalf("err = %v, want ErrInvalidSchema", err)
+	}
+}

--- a/core/secret.go
+++ b/core/secret.go
@@ -1,5 +1,7 @@
 package core
 
+import "strings"
+
 // Secret wraps a sensitive string value with protection against accidental logging.
 // The underlying value is never exposed through String(), GoString(), or JSON marshaling.
 //
@@ -16,8 +18,11 @@ type Secret struct {
 }
 
 // NewSecret creates a new Secret from a string value.
+// Surrounding whitespace (including trailing newlines commonly introduced by
+// secret managers such as Azure Key Vault) is trimmed so downstream
+// comparisons and HTTP headers never carry accidental corruption.
 func NewSecret(value string) Secret {
-	return Secret{value: value}
+	return Secret{value: strings.TrimSpace(value)}
 }
 
 // String returns a redacted placeholder.
@@ -54,7 +59,7 @@ func (s Secret) Expose() string {
 	return s.value
 }
 
-// IsEmpty returns true if the secret value is empty.
+// IsEmpty returns true if the secret value is empty or whitespace-only.
 func (s Secret) IsEmpty() bool {
-	return s.value == ""
+	return strings.TrimSpace(s.value) == ""
 }

--- a/core/secret_test.go
+++ b/core/secret_test.go
@@ -72,7 +72,7 @@ func TestSecretIsEmpty(t *testing.T) {
 	}{
 		{"empty string", "", true},
 		{"non-empty string", "sk-abc123", false},
-		{"whitespace only", "  ", false}, // whitespace is not considered empty
+		{"whitespace only", "  ", true}, // whitespace-only is treated as empty
 	}
 
 	for _, tt := range tests {
@@ -83,6 +83,19 @@ func TestSecretIsEmpty(t *testing.T) {
 				t.Errorf("Secret.IsEmpty() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestNewSecretTrims(t *testing.T) {
+	s := NewSecret("  sk-abc\n")
+	if s.Expose() != "sk-abc" {
+		t.Errorf("Expose() = %q, want %q", s.Expose(), "sk-abc")
+	}
+}
+
+func TestIsEmptyTreatsWhitespaceAsEmpty(t *testing.T) {
+	if !NewSecret("   ").IsEmpty() {
+		t.Error("whitespace-only secret should be empty")
 	}
 }
 

--- a/core/streaming.go
+++ b/core/streaming.go
@@ -32,10 +32,16 @@ type ChatStream struct {
 //
 // Behavior:
 //  1. Read all chunks from Ch, accumulating Delta into output string
-//  2. Check Err channel for any errors
-//  3. Wait for Final to get complete response with usage/tool calls
-//  4. If Final includes Output, use it; otherwise use accumulated deltas
-//  5. Handle context cancellation gracefully
+//  2. Keep reading after Ch closes until BOTH Err and Final have resolved
+//     (closed or delivered a value) — mirrors wrapStreamWithTelemetry's
+//     non-lossy discipline so a real stream error delivered after Ch
+//     closes is never missed.
+//  3. If Final closes without a value, that's not itself an error; Err is
+//     still checked independently.
+//  4. If Final includes Output, use it; otherwise use accumulated deltas.
+//  5. On context cancellation, do one final non-blocking drain of Err
+//     (and Final) so a concrete provider error wins over a generic
+//     context error, then return ctx.Err().
 func DrainStream(ctx context.Context, s *ChatStream) (*ChatResponse, error) {
 	if s == nil {
 		return nil, ErrBadRequest
@@ -44,56 +50,72 @@ func DrainStream(ctx context.Context, s *ChatStream) (*ChatResponse, error) {
 	var accumulated strings.Builder
 	var streamErr error
 	var finalResp *ChatResponse
+	chClosed := false
+	errResolved := false
+	finalResolved := false
 
-	// Read all chunks, checking for cancellation
-	for {
+	for !chClosed || !errResolved || !finalResolved {
+		var chRecv <-chan ChatChunk
+		if !chClosed {
+			chRecv = s.Ch
+		}
+		var errRecv <-chan error
+		if !errResolved {
+			errRecv = s.Err
+		}
+		var finalRecv <-chan *ChatResponse
+		if !finalResolved {
+			finalRecv = s.Final
+		}
+
 		select {
 		case <-ctx.Done():
+			// A concrete provider error should win over the generic
+			// context error, so do a final non-blocking drain of both
+			// Err and Final before giving up.
+			select {
+			case err, ok := <-s.Err:
+				if ok && err != nil {
+					streamErr = err
+				}
+			default:
+			}
+			select {
+			case <-s.Final:
+			default:
+			}
+			if streamErr != nil {
+				return nil, streamErr
+			}
 			return nil, ctx.Err()
 
-		case chunk, ok := <-s.Ch:
+		case chunk, ok := <-chRecv:
 			if !ok {
-				// Channel closed, move on
-				goto checkErr
+				chClosed = true
+				continue
 			}
 			accumulated.WriteString(chunk.Delta)
 
-		case err, ok := <-s.Err:
+		case err, ok := <-errRecv:
+			errResolved = true
 			if ok && err != nil {
 				streamErr = err
 			}
-			// Continue draining Ch even after error
+			// If Err closed without a value, keep waiting on Ch/Final.
 
-		case resp, ok := <-s.Final:
+		case resp, ok := <-finalRecv:
+			finalResolved = true
 			if ok {
 				finalResp = resp
 			}
+			// If Final closed without a value, that alone isn't an
+			// error — Err is tracked independently above.
 		}
-	}
-
-checkErr:
-	// Drain any remaining error
-	select {
-	case err, ok := <-s.Err:
-		if ok && err != nil {
-			streamErr = err
-		}
-	default:
 	}
 
 	// If we have an error, return it
 	if streamErr != nil {
 		return nil, streamErr
-	}
-
-	// Wait for final response
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case resp, ok := <-s.Final:
-		if ok {
-			finalResp = resp
-		}
 	}
 
 	// Build response

--- a/core/streaming_test.go
+++ b/core/streaming_test.go
@@ -224,6 +224,55 @@ func TestDrainStreamWithTimeout(t *testing.T) {
 	}
 }
 
+func TestDrainStreamDoesNotSwallowLateError(t *testing.T) {
+	ch := make(chan ChatChunk, 1)
+	errc := make(chan error, 1)
+	final := make(chan *ChatResponse, 1)
+	ch <- ChatChunk{Delta: "partial"}
+	close(ch) // Ch closes FIRST
+	go func() {
+		// error delivered slightly later, after Ch is already closed
+		time.Sleep(5 * time.Millisecond)
+		errc <- &ProviderError{Provider: "x", Message: "mid-stream boom", Err: ErrServer}
+		close(errc)
+		close(final)
+	}()
+
+	s := &ChatStream{Ch: ch, Err: errc, Final: final}
+	_, err := DrainStream(context.Background(), s)
+	if err == nil {
+		t.Fatal("DrainStream returned nil error; the late stream error was swallowed")
+	}
+}
+
+func TestDrainStreamNormalStreamAfterChCloses(t *testing.T) {
+	ch := make(chan ChatChunk, 3)
+	errc := make(chan error, 1)
+	final := make(chan *ChatResponse, 1)
+	ch <- ChatChunk{Delta: "Hello"}
+	ch <- ChatChunk{Delta: " "}
+	ch <- ChatChunk{Delta: "World"}
+	close(ch) // Ch closes first, same timing shape as the race above
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		close(errc)
+		final <- &ChatResponse{ID: "resp-late", Usage: TokenUsage{TotalTokens: 7}}
+		close(final)
+	}()
+
+	s := &ChatStream{Ch: ch, Err: errc, Final: final}
+	resp, err := DrainStream(context.Background(), s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Output != "Hello World" {
+		t.Errorf("Output = %q, want %q", resp.Output, "Hello World")
+	}
+	if resp.Usage.TotalTokens != 7 {
+		t.Errorf("Usage.TotalTokens = %d, want 7", resp.Usage.TotalTokens)
+	}
+}
+
 func TestChatStreamTypeHasCorrectChannelDirections(t *testing.T) {
 	// This is a compile-time check - if it compiles, the channel directions are correct
 	ch := make(chan ChatChunk)

--- a/core/timeout_test.go
+++ b/core/timeout_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -238,5 +239,33 @@ func TestStreamCallerDeadlineNotRemapped(t *testing.T) {
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("err = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+// wrappingTimeoutProvider simulates a real provider that wraps a timed-out
+// transport error the way normalize.NetworkError does.
+type wrappingTimeoutProvider struct{}
+
+func (wrappingTimeoutProvider) ID() string            { return "wrapping" }
+func (wrappingTimeoutProvider) Models() []ModelInfo   { return nil }
+func (wrappingTimeoutProvider) Supports(Feature) bool { return false }
+func (wrappingTimeoutProvider) Chat(ctx context.Context, _ *ChatRequest) (*ChatResponse, error) {
+	<-ctx.Done()
+	// Emulate NetworkError chain: sentinel + underlying ctx error.
+	return nil, &ProviderError{Provider: "wrapping", Message: ctx.Err().Error(),
+		Err: fmt.Errorf("%w: %w", ErrNetwork, ctx.Err())}
+}
+func (wrappingTimeoutProvider) StreamChat(ctx context.Context, _ *ChatRequest) (*ChatStream, error) {
+	<-ctx.Done()
+	return nil, &ProviderError{Provider: "wrapping", Message: ctx.Err().Error(),
+		Err: fmt.Errorf("%w: %w", ErrNetwork, ctx.Err())}
+}
+
+func TestGetResponseTimeoutSurfacesThroughWrappedNetworkError(t *testing.T) {
+	c := NewClient(wrappingTimeoutProvider{}, WithTimeout(50*time.Millisecond),
+		WithRetryPolicy(noRetryPolicy{}))
+	_, err := c.Chat("m").User("hi").GetResponse(context.Background())
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("err = %v, want ErrTimeout even when provider wraps via NetworkError", err)
 	}
 }

--- a/core/types.go
+++ b/core/types.go
@@ -43,7 +43,8 @@ type JSONSchemaDefinition struct {
 	Schema json.RawMessage `json:"schema"`
 	// Strict enables strict schema validation (recommended).
 	// When true, the model will always output valid JSON matching the schema.
-	Strict bool `json:"strict,omitempty"`
+	// The tag omits omitempty so an explicit false is still marshaled.
+	Strict bool `json:"strict"`
 }
 
 // APIEndpoint represents which API endpoint a model uses.

--- a/docs/changes/2026-08-01_v0.16.0_sdk-reliability-hardening.md
+++ b/docs/changes/2026-08-01_v0.16.0_sdk-reliability-hardening.md
@@ -1,0 +1,248 @@
+---
+date: 2026-08-01
+version: v0.16.0
+feature: SDK Reliability Hardening (Errors, Structured Output, Timeouts)
+product: iris
+change_type: feature
+affected_components: [core/batch.go, core/client.go, core/errors.go, core/schema.go, core/secret.go, core/streaming.go, core/types.go, providers/internal/normalize/errors.go, providers/anthropic/errors.go, providers/gemini/errors.go, providers/voyageai/errors.go, providers/zai/errors.go, providers/ollama/chat.go, providers/ollama/embeddings.go, providers/ollama/stream.go, providers/openai/client.go, providers/openai/client_batch.go, providers/openai/client_embeddings.go, providers/openai/client_responses.go, providers/openai/errors.go, providers/openai/mapping_responses.go, providers/openai/models.go, providers/openai/provider.go, providers/openai/streaming.go, providers/openai/streaming_responses.go, providers/openai/types_responses.go]
+related_frds: [docs/superpowers/specs/2026-08-01-sdk-reliability-hardening-design.md]
+---
+
+## Summary
+
+This change hardens three failure classes surfaced by a production audit of a downstream app built on Iris: error messages that dropped the provider's real detail and broke `errors.Is` chains, structured output that was inconsistently enforced (and silently ignored on the Responses API and unsupported providers), and API keys that could be corrupted by trailing whitespace from secret managers. It also fixes two concrete concurrency/timeout bugs: `core.DrainStream` could swallow a late stream error, and `core.BatchWaiter.Wait` could hang past its configured `maxWait` on a stuck poll. There are two intentional behavior changes, both hard errors that replace previous silent/lossy behavior: structured output now defaults to strict schema validation, and requesting structured output from a provider or model that doesn't support it is now a hard error instead of silently returning unconstrained output.
+
+## Motivation
+
+A downstream app hit three concrete failures in production, confirmed by a four-part source audit (see the design spec, `docs/superpowers/specs/2026-08-01-sdk-reliability-hardening-design.md`): (1) provider error bodies were replaced with generic `http.StatusText`, decode errors omitted the body, and transport errors dropped the wrapped `context.DeadlineExceeded` so timeouts stopped surfacing as `core.ErrTimeout`; (2) structured output was wired only on the OpenAI Chat Completions path — the Responses API (all GPT-5.x models, including `gpt-5.4-mini`, which declares `core.FeatureStructuredOutput`) silently dropped the schema, `Strict` defaulted to `false`, and there was no capability gating to catch a request going to a provider/model that couldn't honor it; (3) API keys were never trimmed, so a trailing newline from a secret manager (e.g. Azure Key Vault) corrupted the `Authorization` header, and `Secret.IsEmpty()` missed whitespace-only values. Root cause for most of (1): `core.ProviderError` had no field for the raw body, and the normalization layer discarded both the provider's real error text and the original wrapped error object.
+
+## What Changed
+
+### New Additions
+
+- `core.ErrInvalidSchema` (`core/errors.go`) — sentinel returned when a JSON Schema submitted for strict structured output fails local validation (e.g. missing `additionalProperties: false` or an incomplete `required` array).
+- `core.ErrStructuredOutputUnsupported` (`core/errors.go`) — sentinel returned when a request asks for `ResponseFormatJSON`/`ResponseFormatJSONSchema` against a provider or model that does not declare `core.FeatureStructuredOutput`.
+- `ProviderError.Body string` field (`core/errors.go`) — the raw (truncated to ~4KB) response body, preserved whenever the structured error message was empty or body-derived.
+- `normalize.DecodeErrorWithBody(provider string, err error, body []byte) error` (`providers/internal/normalize/errors.go`) — decode-error constructor that also stores the raw body on `ProviderError.Body`.
+- `normalize.truncateBody(body []byte) string` (`providers/internal/normalize/errors.go`, and duplicated in `providers/anthropic/errors.go`) — trims and caps a raw body at 4096 bytes for inclusion on `ProviderError.Body`.
+- `(*ChatBuilder) ResponseJSONSchemaNonStrict(schema *JSONSchemaDefinition) *ChatBuilder` (`core/client.go`) — sets `schema.Strict = false` and skips strict-schema validation; the explicit opt-out for schemas that can't satisfy strict mode.
+- `core/schema.go` (new file) — `validateStrictSchema(raw json.RawMessage) error` and helpers (`validateStrictNode`, `validateObjectConstraints`, `isObjectType`, `pathOrRoot`) that recursively walk a JSON Schema (through `properties`, `items`, `$defs`, `definitions`) and enforce strict-mode compatibility.
+- `responsesText` / `responsesTextFormat` types (`providers/openai/types_responses.go`) — carry `text.format.{type,name,schema,strict}` on Responses API requests.
+- `mapResponsesTextFormat(req *core.ChatRequest) *responsesTextFormat` (`providers/openai/mapping_responses.go`) — maps `core.ChatRequest.ResponseFormat`/`JSONSchema` to the Responses API's flatter `text.format` shape (mirrors `mapResponseFormat` for Chat Completions).
+- `(*OpenAI) requireAPIKey() error` (`providers/openai/provider.go`) — returns a descriptive `*core.ProviderError` wrapping `core.ErrUnauthorized` when `p.config.APIKey.IsEmpty()`; called at the top of `Chat`, `StreamChat`, and `CreateEmbeddings` before any HTTP call.
+
+### Modifications
+
+- `normalize.NetworkError` / `normalize.DecodeError` (`providers/internal/normalize/errors.go`): now wrap with `fmt.Errorf("%w: %w", sentinel, err)` instead of discarding `err`, so `errors.Is(_, context.DeadlineExceeded)` (and any other wrapped sentinel) holds through the sentinel chain. Same fix applied by hand in `providers/ollama/chat.go`, `providers/ollama/embeddings.go`, and `providers/ollama/stream.go`.
+- `normalize.OpenAIStyleProviderError`: when the parsed `error.message` is empty, uses the truncated raw body instead of `http.StatusText` and stores it on `ProviderError.Body`. Same treatment applied to the hand-rolled equivalents in `providers/anthropic/errors.go`, `providers/gemini/errors.go`, `providers/voyageai/errors.go`, and `providers/zai/errors.go`.
+- `ProviderError.Error()` (`core/errors.go`): omits the `(status=%d, code=%s[, request_id=%s])` suffix when both `Status` and `Code` are zero-valued, so pure network/decode errors read as `"<provider>: <message>"` instead of a noisy `"(status=0, code=)"` suffix.
+- `core.NewSecret` (`core/secret.go`): now `strings.TrimSpace`s the input value before storing it — fixes the Key-Vault trailing-newline corruption at the source, for every provider that constructs a `Secret`.
+- `Secret.IsEmpty()` (`core/secret.go`): now `strings.TrimSpace`s before the emptiness check, so a whitespace-only value is treated as empty.
+- `(*ChatBuilder) ResponseJSONSchema(schema *JSONSchemaDefinition) *ChatBuilder` (`core/client.go`): **behavior change** — now forces `schema.Strict = true` unconditionally (previously passed `Strict` through as given, defaulting to `false`).
+- `(*ChatBuilder) validate()` (`core/client.go`): **behavior change** — gained a capability-gate check (provider-level via `Provider.Supports(FeatureStructuredOutput)`, then model-level via `ModelInfo.HasCapability(FeatureStructuredOutput)` when the requested model is present in the provider's static catalog) that returns `ErrStructuredOutputUnsupported` before the request is sent; and a strict-schema check that calls `validateStrictSchema` and returns `ErrInvalidSchema` on violation, run after the capability gate so an unsupported provider/model fails with the more specific error.
+- `JSONSchemaDefinition.Strict` tag (`core/types.go`): changed from `json:"strict,omitempty"` to `json:"strict"` so an explicit `false` is transmittable (needed because the Responses API's `strict` field is `*bool` and must be able to encode `false` distinctly from absent).
+- `providers/openai/models.go`: added `core.FeatureStructuredOutput` to the `Capabilities` list of every OpenAI model that supports structured output, including the GPT-5.x Responses-API models (e.g. `gpt-5.4-mini`).
+- `core.DrainStream` (`core/streaming.go`): rewritten to use the same non-lossy discipline as `wrapStreamWithTelemetry` — the read loop no longer exits the instant `Ch` closes; it continues until both `Err` and `Final` have resolved (closed or delivered a value), and on `ctx.Done()` it does one final non-blocking drain of `Err`/`Final` so a concrete provider error wins over a generic context error. Previously, an error delivered on `Err` after `Ch` closed could be missed, causing `DrainStream` to return a false-success response.
+- `(*BatchWaiter) Wait` (`core/batch.go`): **behavior change** (bug fix) — each poll is now bounded by the remaining `maxWait` budget via `context.WithDeadline(ctx, deadline)` passed to `GetBatchStatus`, instead of checking `maxWait` only after each poll call returns. A `GetBatchStatus` call that hangs (e.g., a stuck network request) can no longer block `Wait` past the configured `maxWait`; it now returns `core.ErrBatchTimeout`. The caller's own `ctx` cancellation/expiry still takes priority over the internally imposed deadline.
+
+### Removals
+
+N/A — no public API was removed.
+
+## Technical Specification
+
+### Data Schemas / Types
+
+```go
+// core/errors.go
+type ProviderError struct {
+    Provider  string
+    Status    int
+    RequestID string
+    Code      string
+    Message   string
+    Body      string // raw response body (truncated); preserved when Message lacks detail
+    Err       error
+}
+
+var ErrInvalidSchema = errors.New("invalid json schema for strict structured output")
+var ErrStructuredOutputUnsupported = errors.New("structured output not supported by this provider or model")
+```
+
+```go
+// providers/openai/types_responses.go
+type responsesText struct {
+    Format *responsesTextFormat `json:"format,omitempty"`
+}
+
+// Type is "text", "json_object", or "json_schema"; Name, Schema, and Strict
+// apply only to json_schema.
+type responsesTextFormat struct {
+    Type   string          `json:"type"`
+    Name   string          `json:"name,omitempty"`
+    Schema json.RawMessage `json:"schema,omitempty"`
+    Strict *bool           `json:"strict,omitempty"`
+}
+```
+
+`responsesRequest` (same file) gained a `Text *responsesText \`json:"text,omitempty"\`` field.
+
+### API Endpoints
+
+N/A — Iris is an SDK; there is no daemon HTTP API surface in this repo. The change affects the outbound request shape Iris sends to the OpenAI Responses API (`text.format.{type,name,schema,strict}`), not an Iris-hosted endpoint.
+
+### CLI Interface
+
+N/A — no CLI commands were added or changed by this work.
+
+### Go Package API
+
+```go
+// core/client.go
+
+// ResponseJSONSchema constrains the model output to match a specific JSON Schema.
+// Always forces schema.Strict = true; validate() rejects non-strict-compatible
+// schemas with ErrInvalidSchema before the request is sent.
+func (b *ChatBuilder) ResponseJSONSchema(schema *JSONSchemaDefinition) *ChatBuilder
+
+// ResponseJSONSchemaNonStrict is the explicit opt-out: forces schema.Strict = false
+// and skips the strict-schema validator.
+func (b *ChatBuilder) ResponseJSONSchemaNonStrict(schema *JSONSchemaDefinition) *ChatBuilder
+```
+
+```go
+// core/schema.go
+
+// validateStrictSchema walks a JSON Schema and returns ErrInvalidSchema
+// (wrapped, naming the offending path) if any object node is missing
+// "additionalProperties": false, or has a "required" array that does not
+// cover every key in "properties". Recurses through properties, items
+// (single-schema and tuple-array forms), $defs, and definitions. Nodes
+// containing "$ref" are not recursed into.
+func validateStrictSchema(raw json.RawMessage) error
+```
+
+```go
+// providers/openai/provider.go
+
+// requireAPIKey returns a descriptive *core.ProviderError wrapping
+// core.ErrUnauthorized when the configured API key is empty or
+// whitespace-only. Called at the top of Chat, StreamChat, and
+// CreateEmbeddings before any HTTP request is built.
+func (p *OpenAI) requireAPIKey() error
+```
+
+Usage contract: `ResponseJSONSchema` callers whose schema cannot satisfy strict mode (e.g., a schema with optional properties, or without `additionalProperties: false`) must either restructure the schema or switch to `ResponseJSONSchemaNonStrict`. `validate()` runs both the capability gate and the strict-schema check before any network call, so failures are synchronous and side-effect-free.
+
+### Configuration
+
+No new configuration fields, environment variables, or config-file keys were added. `core.WithTimeout` (existing `ClientOption`) is unchanged in behavior for `Chat`/`StreamChat`; see Deferred below for where it still does not apply.
+
+## Usage Examples
+
+### Example: Strict structured output (happy path)
+
+```go
+schema := &core.JSONSchemaDefinition{
+    Name: "person",
+    Schema: json.RawMessage(`{
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "name": {"type": "string"},
+            "age":  {"type": "integer"}
+        },
+        "required": ["name", "age"]
+    }`),
+}
+
+resp, err := client.Chat(openai.ModelGPT54Mini).
+    User("Extract: John is 30 years old").
+    ResponseJSONSchema(schema).
+    GetResponse(ctx)
+// Sent to the Responses API as text.format:
+// {"type":"json_schema","name":"person","schema":{...},"strict":true}
+```
+
+### Example: Non-strict schema opt-out (error case avoided)
+
+```go
+looseSchema := &core.JSONSchemaDefinition{
+    Name:   "loose",
+    Schema: json.RawMessage(`{"type":"object","properties":{"note":{"type":"string"}}}`),
+}
+
+// ResponseJSONSchema(looseSchema) would return:
+//   core.ErrInvalidSchema: root: object schema missing "additionalProperties": false
+// because the schema has no additionalProperties:false and "note" isn't required.
+// Opt out of strict validation instead:
+resp, err := client.Chat(model).
+    User("...").
+    ResponseJSONSchemaNonStrict(looseSchema).
+    GetResponse(ctx)
+```
+
+### Example: Unsupported provider/model hard error
+
+```go
+resp, err := client.Chat(zaiModel). // zai.Supports(core.FeatureStructuredOutput) == false
+    User("...").
+    ResponseJSON().
+    GetResponse(ctx)
+
+if errors.Is(err, core.ErrStructuredOutputUnsupported) {
+    // err: "structured output not supported by this provider or model: provider zai model ..."
+    // No HTTP request was made.
+}
+```
+
+### Example: Empty OpenAI key fails fast
+
+```go
+provider := openai.New("")
+client := core.NewClient(provider)
+
+_, err := client.Chat(openai.ModelGPT56).User("hi").GetResponse(ctx)
+// err wraps core.ErrUnauthorized with message:
+// "API key is empty; pass it to openai.New(key) or configure your secret source"
+// No HTTP request is made — httptest-backed tests assert the server is never hit.
+```
+
+### Example: Error body preserved end-to-end
+
+```go
+_, err := client.Chat(model).User("...").GetResponse(ctx)
+var pe *core.ProviderError
+if errors.As(err, &pe) {
+    fmt.Println(pe.Body) // the provider's raw (truncated) response body,
+                          // no longer replaced by a generic status string
+}
+```
+
+## Integration Notes
+
+- The capability gate in `validate()` checks the provider-level `Supports(core.FeatureStructuredOutput)` first, then (only if the requested model is present in the provider's static model catalog) the model-level `ModelInfo.HasCapability(core.FeatureStructuredOutput)`. A model absent from the catalog (unknown, brand-new, or a custom deployment) falls back to allowing the request once the provider-level check passes — this avoids false negatives for models the static catalog hasn't caught up with yet, at the cost of not catching a genuinely unsupported unlisted model until the provider rejects it.
+- `gemini` already declares `core.FeatureStructuredOutput` and has pre-existing native wiring (`responseMimeType`/`responseSchema` in `providers/gemini/mapping.go`) that predates this branch; it was not modified here. `anthropic`, `ollama`, `perplexity`, `zai`, `huggingface`, and `xai` do **not** declare `core.FeatureStructuredOutput`, so a structured-output request against them now hard-errors via the capability gate (option (b) from the design spec) rather than silently ignoring the schema.
+- The `%w: %w` double-wrap in `normalize.NetworkError`/`DecodeError` requires Go 1.20+ (multiple `%w` verbs in `fmt.Errorf`); this repo's `go.mod` already requires a newer toolchain, so no version bump was needed.
+- `isRetryable` (`core/retry.go`) checks `errors.Is(err, context.DeadlineExceeded)` before its `ErrNetwork` check; the A1 fix (restoring the wrapped chain) is what makes that ordering actually matter — before this fix, a timed-out request could never satisfy the `DeadlineExceeded` check because the wrapping had been lost.
+
+## Breaking Changes & Migration
+
+1. **`ResponseJSONSchema` now defaults to strict.** A schema that previously passed (loosely validated or not validated at all) may now return `core.ErrInvalidSchema` if it lacks `additionalProperties: false` at any object node or doesn't list every property in `required`. **Migration:** either make the schema strict-compatible, or switch the call to `ResponseJSONSchemaNonStrict(schema)` to opt out explicitly.
+2. **Structured output against an unsupported provider/model is now a hard error.** Previously, requesting `ResponseFormatJSON`/`ResponseFormatJSONSchema` against a provider or model without native support silently returned unconstrained text output. It now returns `core.ErrStructuredOutputUnsupported` before any network call. **Migration:** check `provider.Supports(core.FeatureStructuredOutput)` (and the model's `HasCapability`) ahead of time, or catch the error with `errors.Is` and fall back to prompting for JSON in the message content instead.
+
+Non-breaking but worth noting: `ProviderError.Error()` no longer prints `(status=0, code=)` for pure network/decode errors — any code that string-matched on that exact suffix (rather than using `errors.Is`/`errors.As`) will see a different message shape.
+
+## Deferred / Out of Scope
+
+- **Empty-key preflight for providers other than OpenAI.** `core.NewSecret`'s whitespace trim covers the common Key-Vault-style corruption for every provider, but only OpenAI (`Chat`, `StreamChat`, `CreateEmbeddings`) gets an explicit pre-flight `ErrUnauthorized` before an HTTP call. Anthropic, Gemini, Ollama, and the rest still discover an empty key via the provider's normal 401 response path.
+- **Native structured output wiring for Anthropic and Ollama.** Both providers now correctly hard-error (they don't declare `core.FeatureStructuredOutput`) rather than silently ignoring a requested schema, but neither has been wired to actually enforce structured output natively. Gemini already has pre-existing native wiring (`responseMimeType`/`responseSchema`) that this pass didn't touch or harden further (e.g., it does not run `validateStrictSchema` against Gemini's schema dialect).
+- **Broad non-chat timeout coverage.** `core.WithTimeout` applies only to `Chat`/`StreamChat` via `core.Client`. Embeddings, batch (`CreateBatch`, `GetBatchStatus`, `GetBatchResults`, `CancelBatch`, `ListBatches`, and `core.BatchWaiter.Wait`), files, vector-store, and image calls bypass `core.Client` entirely and are not covered by its timeout machinery. This pass fixed the one concrete hang (the batch-poll bug in `BatchWaiter.Wait`) and added doc-comment notes on the affected OpenAI methods (see below) directing callers to supply their own context deadline; broader wrapper coverage is a follow-up.
+- **Client-side response validation.** Iris validates the outbound schema shape (strict-mode compatibility) but does not re-validate the model's returned JSON against the schema after the fact. A model could still return JSON that technically violates its own declared schema; catching that is a separate feature.
+- **`validateStrictSchema` implicit-type edge case.** The validator only inspects object constraints (`additionalProperties`, `required`) on nodes where `"type"` is explicitly `"object"` (or includes it in a union). A schema node that omits `"type"` entirely but still declares `"properties"` — which JSON Schema treats as implicitly object-shaped — is not currently checked, so such a node could pass local validation and still be rejected by the provider as non-strict-compliant. Tightening this requires deciding whether `properties` alone should imply `"object"` for validation purposes.
+
+## Testing Notes
+
+- Full suite run with the race detector: `go test -race ./...` — all packages pass, no data races reported (see verification summary in the task report).
+- `go build ./...` succeeds; `gofmt -l .` reports no files needing formatting (the pre-existing untracked `CLAUDE.md` and `docs/changes/2026-03-18_*azure*` files are unrelated to this branch and were not touched).
+- New/expanded test coverage added across Tasks 1–8: `core/batch_test.go`, `core/client_test.go`, `core/errors_test.go`, `core/retry_test.go`, `core/schema_test.go`, `core/secret_test.go`, `core/streaming_test.go`, `core/timeout_test.go`, `providers/anthropic/errors_test.go`, `providers/huggingface/errors_test.go`, `providers/internal/normalize/errors_test.go`, `providers/openai/auth_test.go` (new), `providers/openai/client_responses_test.go` (new), `providers/openai/errors_test.go`, `providers/perplexity/errors_test.go`. Notably: a table test asserting a `context.DeadlineExceeded` wrapped by `NetworkError` satisfies `errors.Is` for both `ErrNetwork` and `context.DeadlineExceeded`; an httptest asserting the Responses API request carries `text.format` with `type:"json_schema"` and `strict:true`; a stub `BatchProvider` whose `GetBatchStatus` blocks, asserting `Wait` returns within `~maxWait` with `ErrBatchTimeout` rather than hanging; a `DrainStream` test that delivers an error via the `Err` channel after `Ch` closes, asserting the error is not swallowed, run under `-race`.

--- a/docs/changes/2026-08-01_v0.16.0_sdk-reliability-hardening.md
+++ b/docs/changes/2026-08-01_v0.16.0_sdk-reliability-hardening.md
@@ -10,7 +10,7 @@ related_frds: [docs/superpowers/specs/2026-08-01-sdk-reliability-hardening-desig
 
 ## Summary
 
-This change hardens three failure classes surfaced by a production audit of a downstream app built on Iris: error messages that dropped the provider's real detail and broke `errors.Is` chains, structured output that was inconsistently enforced (and silently ignored on the Responses API and unsupported providers), and API keys that could be corrupted by trailing whitespace from secret managers. It also fixes two concrete concurrency/timeout bugs: `core.DrainStream` could swallow a late stream error, and `core.BatchWaiter.Wait` could hang past its configured `maxWait` on a stuck poll. There are two intentional behavior changes, both hard errors that replace previous silent/lossy behavior: structured output now defaults to strict schema validation, and requesting structured output from a provider or model that doesn't support it is now a hard error instead of silently returning unconstrained output.
+This change hardens three failure classes surfaced by a production audit of a downstream app built on Iris: error messages that dropped the provider's real detail and broke `errors.Is` chains, structured output that was inconsistently enforced (and silently ignored on the Responses API and unsupported providers), and API keys that could be corrupted by trailing whitespace from secret managers. It also fixes two concrete concurrency/timeout bugs: `core.DrainStream` could swallow a late stream error, and `core.BatchWaiter.Wait` could hang past its configured `maxWait` on a stuck poll. There are two intentional behavior changes, both hard errors that replace previous silent/lossy behavior: schema-based structured output (`ResponseJSONSchema`) now defaults to strict schema validation, and requesting schema-based structured output (`ResponseJSONSchema`) from a provider or model that doesn't support it is now a hard error instead of silently returning unconstrained output. Plain JSON mode (`ResponseJSON` / `json_object`) is intentionally **not** hard-gated by the capability check, since it has no schema/shape contract to violate.
 
 ## Motivation
 
@@ -21,7 +21,7 @@ A downstream app hit three concrete failures in production, confirmed by a four-
 ### New Additions
 
 - `core.ErrInvalidSchema` (`core/errors.go`) — sentinel returned when a JSON Schema submitted for strict structured output fails local validation (e.g. missing `additionalProperties: false` or an incomplete `required` array).
-- `core.ErrStructuredOutputUnsupported` (`core/errors.go`) — sentinel returned when a request asks for `ResponseFormatJSON`/`ResponseFormatJSONSchema` against a provider or model that does not declare `core.FeatureStructuredOutput`.
+- `core.ErrStructuredOutputUnsupported` (`core/errors.go`) — sentinel returned when a request asks for schema-based structured output (`ResponseFormatJSONSchema`) against a provider or model that does not declare `core.FeatureStructuredOutput`. Plain JSON mode (`ResponseFormatJSON` / `json_object`) never returns this sentinel — see the capability-gate note under Modifications.
 - `ProviderError.Body string` field (`core/errors.go`) — the raw (truncated to ~4KB) response body, preserved whenever the structured error message was empty or body-derived.
 - `normalize.DecodeErrorWithBody(provider string, err error, body []byte) error` (`providers/internal/normalize/errors.go`) — decode-error constructor that also stores the raw body on `ProviderError.Body`.
 - `normalize.truncateBody(body []byte) string` (`providers/internal/normalize/errors.go`, and duplicated in `providers/anthropic/errors.go`) — trims and caps a raw body at 4096 bytes for inclusion on `ProviderError.Body`.
@@ -39,7 +39,7 @@ A downstream app hit three concrete failures in production, confirmed by a four-
 - `core.NewSecret` (`core/secret.go`): now `strings.TrimSpace`s the input value before storing it — fixes the Key-Vault trailing-newline corruption at the source, for every provider that constructs a `Secret`.
 - `Secret.IsEmpty()` (`core/secret.go`): now `strings.TrimSpace`s before the emptiness check, so a whitespace-only value is treated as empty.
 - `(*ChatBuilder) ResponseJSONSchema(schema *JSONSchemaDefinition) *ChatBuilder` (`core/client.go`): **behavior change** — now forces `schema.Strict = true` unconditionally (previously passed `Strict` through as given, defaulting to `false`).
-- `(*ChatBuilder) validate()` (`core/client.go`): **behavior change** — gained a capability-gate check (provider-level via `Provider.Supports(FeatureStructuredOutput)`, then model-level via `ModelInfo.HasCapability(FeatureStructuredOutput)` when the requested model is present in the provider's static catalog) that returns `ErrStructuredOutputUnsupported` before the request is sent; and a strict-schema check that calls `validateStrictSchema` and returns `ErrInvalidSchema` on violation, run after the capability gate so an unsupported provider/model fails with the more specific error.
+- `(*ChatBuilder) validate()` (`core/client.go`): **behavior change** — gained a capability-gate check that applies only to schema-based structured output (`ResponseFormatJSONSchema`): provider-level via `Provider.Supports(FeatureStructuredOutput)`, then model-level via `ModelInfo.HasCapability(FeatureStructuredOutput)` when the requested model is present in the provider's static catalog, returning `ErrStructuredOutputUnsupported` before the request is sent. Plain JSON mode (`ResponseFormatJSON` / `json_object`) is deliberately excluded from this gate — it has no schema/shape contract to silently violate, and several models (e.g. OpenAI's `gpt-3.5-turbo`, `gpt-4`, `gpt-4-turbo`) support `json_object` without declaring `core.FeatureStructuredOutput`, so gating it would reject previously-working requests before any HTTP call. A provider that genuinely can't honor `json_object` surfaces its own descriptive API error instead. The strict-schema check (calls `validateStrictSchema`, returns `ErrInvalidSchema` on violation) still applies only within the `ResponseFormatJSONSchema` branch and runs after the capability gate, so an unsupported provider/model fails with the more specific error.
 - `JSONSchemaDefinition.Strict` tag (`core/types.go`): changed from `json:"strict,omitempty"` to `json:"strict"` so an explicit `false` is transmittable (needed because the Responses API's `strict` field is `*bool` and must be able to encode `false` distinctly from absent).
 - `providers/openai/models.go`: added `core.FeatureStructuredOutput` to the `Capabilities` list of every OpenAI model that supports structured output, including the GPT-5.x Responses-API models (e.g. `gpt-5.4-mini`).
 - `core.DrainStream` (`core/streaming.go`): rewritten to use the same non-lossy discipline as `wrapStreamWithTelemetry` — the read loop no longer exits the instant `Ch` closes; it continues until both `Err` and `Final` have resolved (closed or delivered a value), and on `ctx.Done()` it does one final non-blocking drain of `Err`/`Final` so a concrete provider error wins over a generic context error. Previously, an error delivered on `Err` after `Ch` closed could be missed, causing `DrainStream` to return a false-success response.
@@ -182,18 +182,33 @@ resp, err := client.Chat(model).
     GetResponse(ctx)
 ```
 
-### Example: Unsupported provider/model hard error
+### Example: Unsupported provider/model hard error (schema-based structured output)
 
 ```go
 resp, err := client.Chat(zaiModel). // zai.Supports(core.FeatureStructuredOutput) == false
     User("...").
-    ResponseJSON().
+    ResponseJSONSchema(schema).
     GetResponse(ctx)
 
 if errors.Is(err, core.ErrStructuredOutputUnsupported) {
     // err: "structured output not supported by this provider or model: provider zai model ..."
     // No HTTP request was made.
 }
+```
+
+### Example: Plain JSON mode is NOT hard-gated
+
+```go
+// gpt-3.5-turbo supports json_object mode but is not tagged with
+// core.FeatureStructuredOutput in the static catalog. ResponseJSON() (unlike
+// ResponseJSONSchema) is not subject to the capability gate, so this reaches
+// the provider instead of hard-erroring locally.
+resp, err := client.Chat("gpt-3.5-turbo").
+    User("Return a JSON object describing a person named John, age 30.").
+    ResponseJSON().
+    GetResponse(ctx)
+// err is nil on success; ErrStructuredOutputUnsupported is never returned
+// for ResponseJSON regardless of the provider/model's declared capabilities.
 ```
 
 ### Example: Empty OpenAI key fails fast
@@ -221,15 +236,15 @@ if errors.As(err, &pe) {
 
 ## Integration Notes
 
-- The capability gate in `validate()` checks the provider-level `Supports(core.FeatureStructuredOutput)` first, then (only if the requested model is present in the provider's static model catalog) the model-level `ModelInfo.HasCapability(core.FeatureStructuredOutput)`. A model absent from the catalog (unknown, brand-new, or a custom deployment) falls back to allowing the request once the provider-level check passes — this avoids false negatives for models the static catalog hasn't caught up with yet, at the cost of not catching a genuinely unsupported unlisted model until the provider rejects it.
-- `gemini` already declares `core.FeatureStructuredOutput` and has pre-existing native wiring (`responseMimeType`/`responseSchema` in `providers/gemini/mapping.go`) that predates this branch; it was not modified here. `anthropic`, `ollama`, `perplexity`, `zai`, `huggingface`, and `xai` do **not** declare `core.FeatureStructuredOutput`, so a structured-output request against them now hard-errors via the capability gate (option (b) from the design spec) rather than silently ignoring the schema.
+- The capability gate in `validate()` fires only for `ResponseFormatJSONSchema` requests. It checks the provider-level `Supports(core.FeatureStructuredOutput)` first, then (only if the requested model is present in the provider's static model catalog) the model-level `ModelInfo.HasCapability(core.FeatureStructuredOutput)`. A model absent from the catalog (unknown, brand-new, or a custom deployment) falls back to allowing the request once the provider-level check passes — this avoids false negatives for models the static catalog hasn't caught up with yet, at the cost of not catching a genuinely unsupported unlisted model until the provider rejects it. `ResponseFormatJSON` (`json_object`) requests never enter this gate, regardless of provider/model capability.
+- `gemini` already declares `core.FeatureStructuredOutput` and has pre-existing native wiring (`responseMimeType`/`responseSchema` in `providers/gemini/mapping.go`) that predates this branch; it was not modified here. `anthropic`, `ollama`, `perplexity`, `zai`, `huggingface`, and `xai` do **not** declare `core.FeatureStructuredOutput`, so a schema-based structured-output request (`ResponseJSONSchema`) against them now hard-errors via the capability gate (option (b) from the design spec) rather than silently ignoring the schema. A plain `ResponseJSON` request against those same providers is unaffected by this gate and proceeds to the provider as before this branch.
 - The `%w: %w` double-wrap in `normalize.NetworkError`/`DecodeError` requires Go 1.20+ (multiple `%w` verbs in `fmt.Errorf`); this repo's `go.mod` already requires a newer toolchain, so no version bump was needed.
 - `isRetryable` (`core/retry.go`) checks `errors.Is(err, context.DeadlineExceeded)` before its `ErrNetwork` check; the A1 fix (restoring the wrapped chain) is what makes that ordering actually matter — before this fix, a timed-out request could never satisfy the `DeadlineExceeded` check because the wrapping had been lost.
 
 ## Breaking Changes & Migration
 
 1. **`ResponseJSONSchema` now defaults to strict.** A schema that previously passed (loosely validated or not validated at all) may now return `core.ErrInvalidSchema` if it lacks `additionalProperties: false` at any object node or doesn't list every property in `required`. **Migration:** either make the schema strict-compatible, or switch the call to `ResponseJSONSchemaNonStrict(schema)` to opt out explicitly.
-2. **Structured output against an unsupported provider/model is now a hard error.** Previously, requesting `ResponseFormatJSON`/`ResponseFormatJSONSchema` against a provider or model without native support silently returned unconstrained text output. It now returns `core.ErrStructuredOutputUnsupported` before any network call. **Migration:** check `provider.Supports(core.FeatureStructuredOutput)` (and the model's `HasCapability`) ahead of time, or catch the error with `errors.Is` and fall back to prompting for JSON in the message content instead.
+2. **Schema-based structured output against an unsupported provider/model is now a hard error.** Previously, requesting `ResponseFormatJSONSchema` against a provider or model without native support silently returned unconstrained text output. It now returns `core.ErrStructuredOutputUnsupported` before any network call. **This does not apply to plain `ResponseFormatJSON` (`json_object`) requests** — those are never hard-gated by capability, since json_object mode has no schema/shape contract to silently violate; a provider that can't honor it surfaces its own descriptive error. **Migration (ResponseJSONSchema callers only):** check `provider.Supports(core.FeatureStructuredOutput)` (and the model's `HasCapability`) ahead of time, or catch the error with `errors.Is` and fall back to prompting for JSON in the message content instead. `ResponseJSON` callers require no migration for this change.
 
 Non-breaking but worth noting: `ProviderError.Error()` no longer prints `(status=0, code=)` for pure network/decode errors — any code that string-matched on that exact suffix (rather than using `errors.Is`/`errors.As`) will see a different message shape.
 
@@ -246,3 +261,4 @@ Non-breaking but worth noting: `ProviderError.Error()` no longer prints `(status
 - Full suite run with the race detector: `go test -race ./...` — all packages pass, no data races reported (see verification summary in the task report).
 - `go build ./...` succeeds; `gofmt -l .` reports no files needing formatting (the pre-existing untracked `CLAUDE.md` and `docs/changes/2026-03-18_*azure*` files are unrelated to this branch and were not touched).
 - New/expanded test coverage added across Tasks 1–8: `core/batch_test.go`, `core/client_test.go`, `core/errors_test.go`, `core/retry_test.go`, `core/schema_test.go`, `core/secret_test.go`, `core/streaming_test.go`, `core/timeout_test.go`, `providers/anthropic/errors_test.go`, `providers/huggingface/errors_test.go`, `providers/internal/normalize/errors_test.go`, `providers/openai/auth_test.go` (new), `providers/openai/client_responses_test.go` (new), `providers/openai/errors_test.go`, `providers/perplexity/errors_test.go`. Notably: a table test asserting a `context.DeadlineExceeded` wrapped by `NetworkError` satisfies `errors.Is` for both `ErrNetwork` and `context.DeadlineExceeded`; an httptest asserting the Responses API request carries `text.format` with `type:"json_schema"` and `strict:true`; a stub `BatchProvider` whose `GetBatchStatus` blocks, asserting `Wait` returns within `~maxWait` with `ErrBatchTimeout` rather than hanging; a `DrainStream` test that delivers an error via the `Err` channel after `Ch` closes, asserting the error is not swallowed, run under `-race`.
+- Final-review fix (capability-gate scope) added to `core/client_test.go`: `nonStructuredButChattyProvider` (a `Provider` that reports `false` for `FeatureStructuredOutput` but implements a working `Chat`/`StreamChat`, unlike the pre-existing `nonStructuredProvider` which fails the test if invoked) backs `TestResponseJSONNotGatedForUnsupportedProvider`, asserting `ResponseJSON()` reaches the provider and returns no `ErrStructuredOutputUnsupported` even when the provider lacks the feature. `TestResponseJSONNotGatedForModelWithoutCapability` asserts the same for the model-level gate using the existing `modelGatedProvider`/`modelGatedCatalog`. `TestStructuredOutputUnsupportedForModelWithoutCapability` was switched from `ResponseJSON()` to `ResponseJSONSchema(...)` so it continues to assert `ErrStructuredOutputUnsupported`, since that gate now applies only to schema-based structured output. `go test ./core/ -run 'Structured|Unsupported|JSON|Model|Schema' -v` and `go test ./...` both pass; `gofmt -l core/` reports no files.

--- a/docs/superpowers/plans/2026-08-01-sdk-reliability-hardening.md
+++ b/docs/superpowers/plans/2026-08-01-sdk-reliability-hardening.md
@@ -1,0 +1,802 @@
+# SDK Reliability Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix descriptive/propagated errors, enforce strict structured output (incl. the Responses API), and close two streaming/timeout robustness bugs — the concrete failures a downstream app hit.
+
+**Architecture:** Preserve error chains and raw bodies in the shared normalization layer; wire and gate structured output in core + the OpenAI Responses path; harden `DrainStream` and `BatchWaiter`. No new public API beyond the symbols listed in Global Constraints.
+
+**Tech Stack:** Go 1.24, standard library. Tests use `testing`, `net/http/httptest`, `-race`.
+
+## Global Constraints
+
+- Module `github.com/petal-labs/iris` (go 1.24). Base branch: `feat/sdk-reliability-hardening`.
+- New exported symbols (only these): `core.ProviderError.Body`, `core.ErrInvalidSchema`, `core.ErrStructuredOutputUnsupported`, `(*core.ChatBuilder).ResponseJSONSchemaNonStrict`.
+- Behavior changes (must be documented in the change doc): `ResponseJSONSchema` defaults to strict; structured output on an unsupported provider/model is a hard error.
+- `Provider.Supports(feature core.Feature) bool` is on the `core.Provider` interface (`core/client.go:15`). Use it for capability gating.
+- Conventional commits, subject ≤ 72 chars, no trailing period, no backticks/emoji.
+- Windows-safe paths (`filepath.Join`) in any test that touches the filesystem (none expected).
+- Every task ends green: `go test ./...` (and `-race` where noted), `go build ./...`, `gofmt -l` clean.
+
+---
+
+### Task 1: Preserve error chains in normalization (Workstream A1)
+
+**Files:**
+- Modify: `providers/internal/normalize/errors.go` (NetworkError ~40-46, DecodeError ~49-55)
+- Modify: `providers/ollama/chat.go`, `providers/ollama/embeddings.go` (hand-rolled network errors)
+- Test: `providers/internal/normalize/errors_test.go`; `core/timeout_test.go` (append)
+
+**Interfaces:**
+- Produces: `NetworkError`/`DecodeError` return a `*core.ProviderError` whose `Err` wraps the original error, so `errors.Is` reaches both the sentinel and the underlying (e.g. `context.DeadlineExceeded`).
+
+- [ ] **Step 1: Failing test (chain preservation)**
+
+In `providers/internal/normalize/errors_test.go`:
+
+```go
+func TestNetworkErrorPreservesChain(t *testing.T) {
+	underlying := fmt.Errorf("dial tcp: %w", context.DeadlineExceeded)
+	err := NetworkError("openai", underlying)
+	if !errors.Is(err, core.ErrNetwork) {
+		t.Error("want errors.Is(err, core.ErrNetwork)")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Error("want errors.Is(err, context.DeadlineExceeded)")
+	}
+}
+
+func TestDecodeErrorPreservesChain(t *testing.T) {
+	underlying := errors.New("invalid character '<'")
+	err := DecodeError("openai", underlying)
+	if !errors.Is(err, core.ErrDecode) {
+		t.Error("want errors.Is(err, core.ErrDecode)")
+	}
+	if !errors.Is(err, underlying) {
+		t.Error("want errors.Is(err, underlying)")
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`go test ./providers/internal/normalize/ -run PreservesChain -v`) — currently `Err` is the bare sentinel.
+
+- [ ] **Step 3: Implement**
+
+```go
+func NetworkError(provider string, err error) error {
+	return &core.ProviderError{
+		Provider: provider,
+		Message:  err.Error(),
+		Err:      fmt.Errorf("%w: %w", core.ErrNetwork, err),
+	}
+}
+
+func DecodeError(provider string, err error) error {
+	return &core.ProviderError{
+		Provider: provider,
+		Message:  err.Error(),
+		Err:      fmt.Errorf("%w: %w", core.ErrDecode, err),
+	}
+}
+```
+
+Add `"fmt"` to imports. Then update the ollama hand-rolled equivalents (grep `rg -n "Err:.*ErrNetwork" providers/ollama/`) to the same `fmt.Errorf("%w: %w", core.ErrNetwork, err)` shape. Confirm `providers/azurefoundry` routes through `normalize.NetworkError`; if it hand-rolls, fix it the same way.
+
+- [ ] **Step 4: Run — expect PASS.**
+
+- [ ] **Step 5: Failing test (streaming timeout now surfaces as ErrTimeout + retry classification)**
+
+Append to `core/timeout_test.go` a provider whose `StreamChat` blocks then returns a `NetworkError`-wrapped context error, mirroring real providers:
+
+```go
+// wrappingTimeoutProvider simulates a real provider that wraps a timed-out
+// transport error the way normalize.NetworkError does.
+type wrappingTimeoutProvider struct{}
+
+func (wrappingTimeoutProvider) ID() string                 { return "wrapping" }
+func (wrappingTimeoutProvider) Supports(Feature) bool      { return false }
+func (wrappingTimeoutProvider) Chat(ctx context.Context, _ *ChatRequest) (*ChatResponse, error) {
+	<-ctx.Done()
+	// Emulate NetworkError chain: sentinel + underlying ctx error.
+	return nil, &ProviderError{Provider: "wrapping", Message: ctx.Err().Error(),
+		Err: fmt.Errorf("%w: %w", ErrNetwork, ctx.Err())}
+}
+func (wrappingTimeoutProvider) StreamChat(ctx context.Context, _ *ChatRequest) (*ChatStream, error) {
+	<-ctx.Done()
+	return nil, &ProviderError{Provider: "wrapping", Message: ctx.Err().Error(),
+		Err: fmt.Errorf("%w: %w", ErrNetwork, ctx.Err())}
+}
+
+func TestGetResponseTimeoutSurfacesThroughWrappedNetworkError(t *testing.T) {
+	c := NewClient(wrappingTimeoutProvider{}, WithTimeout(50*time.Millisecond),
+		WithRetryPolicy(noRetryPolicy{}))
+	_, err := c.Chat("m").User("hi").GetResponse(context.Background())
+	if !errors.Is(err, ErrTimeout) {
+		t.Fatalf("err = %v, want ErrTimeout even when provider wraps via NetworkError", err)
+	}
+}
+```
+
+(`noRetryPolicy` already exists in `core/timeout_test.go` from prior work; reuse it. `ErrNetwork` is in package `core`, same package as the test.)
+
+Also add a retry-classification assertion in `core/retry_test.go`:
+
+```go
+func TestWrappedTimeoutIsNotRetryable(t *testing.T) {
+	err := &ProviderError{Provider: "x", Err: fmt.Errorf("%w: %w", ErrNetwork, context.DeadlineExceeded)}
+	if isRetryable(err) {
+		t.Error("a timed-out request must not be retryable")
+	}
+}
+```
+
+Confirm the real `isRetryable` symbol/name via `rg -n "func isRetryable|isRetryable\(" core/retry.go` and adapt the call if the API differs (e.g. it may be a method on the policy).
+
+- [ ] **Step 6: Run both — expect PASS** (`go test ./core/ -run 'Timeout|Retryable' -v`). This proves the A1 fix restores the timeout feature for real providers.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add providers/internal/normalize/ providers/ollama/ core/timeout_test.go core/retry_test.go
+git commit -m "fix(providers): preserve wrapped error chain in normalization"
+```
+
+---
+
+### Task 2: Carry the raw body on ProviderError (Workstream A2)
+
+**Files:**
+- Modify: `core/errors.go` (ProviderError struct + Error())
+- Modify: `providers/internal/normalize/errors.go` (OpenAIStyleProviderError, add DecodeErrorWithBody)
+- Modify hand-rolled normalizers: `providers/anthropic/errors.go`, `providers/gemini/errors.go`, `providers/zai/errors.go`, `providers/voyageai/errors.go`
+- Modify OpenAI decode call sites: `providers/openai/client.go`, `providers/openai/client_responses.go`, `providers/openai/streaming.go`, `providers/openai/errors.go` (newDecodeError)
+- Test: `core/errors_test.go`, `providers/internal/normalize/errors_test.go`
+
+**Interfaces:**
+- Consumes: Task 1's chain-preserving normalizers.
+- Produces: `core.ProviderError.Body string`; `normalize.DecodeErrorWithBody(provider string, err error, body []byte) error`; the truncation helper `normalize.truncateBody([]byte) string`.
+
+- [ ] **Step 1: Failing test**
+
+In `core/errors_test.go`:
+
+```go
+func TestProviderErrorCarriesBody(t *testing.T) {
+	e := &ProviderError{Provider: "openai", Status: 400, Message: "bad", Body: `{"detail":"nope"}`}
+	if e.Body == "" {
+		t.Fatal("Body should be populated")
+	}
+	if !strings.Contains(e.Error(), "openai") {
+		t.Errorf("Error() = %q", e.Error())
+	}
+}
+```
+
+In `providers/internal/normalize/errors_test.go`:
+
+```go
+func TestOpenAIStyleErrorFallsBackToBody(t *testing.T) {
+	// Body is valid text but NOT the {"error":{"message"}} envelope.
+	body := []byte(`{"detail":"model gpt-x does not exist"}`)
+	err := OpenAIStyleProviderError("openai", 404, body, "req-1")
+	var pe *core.ProviderError
+	if !errors.As(err, &pe) {
+		t.Fatal("want *core.ProviderError")
+	}
+	if !strings.Contains(pe.Message+pe.Body, "does not exist") {
+		t.Errorf("real body text lost: msg=%q body=%q", pe.Message, pe.Body)
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (Body field/behavior absent).
+
+- [ ] **Step 3: Implement**
+
+`core/errors.go` — add field and adjust Error():
+
+```go
+type ProviderError struct {
+	Provider  string
+	Status    int
+	RequestID string
+	Code      string
+	Message   string
+	Body      string // raw response body (truncated); preserved when Message lacks detail
+	Err       error
+}
+
+func (e *ProviderError) Error() string {
+	// Omit the (status,code) suffix for pure network/decode errors.
+	if e.Status == 0 && e.Code == "" {
+		return fmt.Sprintf("%s: %s", e.Provider, e.Message)
+	}
+	if e.RequestID != "" {
+		return fmt.Sprintf("%s: %s (status=%d, code=%s, request_id=%s)",
+			e.Provider, e.Message, e.Status, e.Code, e.RequestID)
+	}
+	return fmt.Sprintf("%s: %s (status=%d, code=%s)", e.Provider, e.Message, e.Status, e.Code)
+}
+```
+
+`providers/internal/normalize/errors.go`:
+
+```go
+const maxBodyLen = 4096
+
+func truncateBody(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if len(s) > maxBodyLen {
+		return s[:maxBodyLen] + "…(truncated)"
+	}
+	return s
+}
+
+func OpenAIStyleProviderError(provider string, status int, body []byte, requestID string) error {
+	var errResp openAIStyleErrorResponse
+	_ = json.Unmarshal(body, &errResp)
+
+	message := errResp.Error.Message
+	bodyStr := truncateBody(body)
+	if message == "" {
+		if bodyStr != "" {
+			message = bodyStr // surface the real body instead of http.StatusText
+		} else {
+			message = http.StatusText(status)
+		}
+	}
+	code := errResp.Error.Code
+	if code == "" {
+		code = errResp.Error.Type
+	}
+	pe := ProviderError(provider, status, requestID, code, message, SentinelForStatus(status))
+	pe.(*core.ProviderError).Body = bodyStr
+	return pe
+}
+
+func DecodeErrorWithBody(provider string, err error, body []byte) error {
+	return &core.ProviderError{
+		Provider: provider,
+		Message:  err.Error(),
+		Body:     truncateBody(body),
+		Err:      fmt.Errorf("%w: %w", core.ErrDecode, err),
+	}
+}
+```
+
+Add `"strings"` to imports. Apply the same body-preservation pattern to the four hand-rolled normalizers (anthropic/gemini/zai/voyageai `errors.go`): where they currently fall back to `http.StatusText`, prefer the truncated body, and set `.Body`.
+
+`providers/openai/errors.go`: change `newDecodeError` to accept the body and delegate to `DecodeErrorWithBody`:
+
+```go
+func newDecodeError(err error, body []byte) error {
+	return normalize.DecodeErrorWithBody("openai", err, body)
+}
+```
+
+Update OpenAI decode call sites to pass the body they already have (`respBody`): `providers/openai/client.go:63-66`, `client_responses.go` (decode), `streaming.go` decode site. Grep: `rg -n "newDecodeError" providers/openai/`.
+
+- [ ] **Step 4: Run — expect PASS** (`go test ./core/ ./providers/internal/normalize/ ./providers/openai/ -run 'Body|Decode|Error' -v`).
+
+- [ ] **Step 5: Full build (other providers' newDecodeError unchanged, still compile)**
+
+Run: `go build ./...` — expect success. (Only OpenAI's `newDecodeError` signature changed; other providers keep theirs — deferred per spec.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/errors.go providers/internal/normalize/ providers/anthropic/errors.go providers/gemini/errors.go providers/zai/errors.go providers/voyageai/errors.go providers/openai/
+git commit -m "fix(errors): preserve raw response body on ProviderError"
+```
+
+---
+
+### Task 3: Key sanitization & empty-key validation (Workstream A3)
+
+**Files:**
+- Modify: `core/secret.go` (NewSecret, IsEmpty)
+- Modify: `providers/openai/provider.go` and/or `client.go`/`client_responses.go`/`streaming.go`/`client_embeddings.go` (empty-key preflight)
+- Test: `core/secret_test.go`, `providers/openai/provider_test.go` (or a new `providers/openai/auth_test.go`)
+
+**Interfaces:**
+- Produces: trimmed secrets globally; OpenAI Chat/StreamChat/CreateEmbeddings return a descriptive `ErrUnauthorized` error when the key is empty, before any HTTP call.
+
+- [ ] **Step 1: Failing test**
+
+`core/secret_test.go`:
+
+```go
+func TestNewSecretTrims(t *testing.T) {
+	s := NewSecret("  sk-abc\n")
+	if s.Expose() != "sk-abc" {
+		t.Errorf("Expose() = %q, want %q", s.Expose(), "sk-abc")
+	}
+}
+
+func TestIsEmptyTreatsWhitespaceAsEmpty(t *testing.T) {
+	if !NewSecret("   ").IsEmpty() {
+		t.Error("whitespace-only secret should be empty")
+	}
+}
+```
+
+`providers/openai/auth_test.go` (new):
+
+```go
+package openai
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.Chat(context.Background(), &core.ChatRequest{
+		Model:    ModelGPT52,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Implement**
+
+`core/secret.go`: add `"strings"`; `NewSecret` → `return Secret{value: strings.TrimSpace(value)}`; `IsEmpty` → `return strings.TrimSpace(s.value) == ""`.
+
+`providers/openai/`: add a preflight guard used by `Chat`, `StreamChat`, and `CreateEmbeddings`. Add to `provider.go`:
+
+```go
+func (p *OpenAI) requireAPIKey() error {
+	if p.config.APIKey.IsEmpty() {
+		return &core.ProviderError{
+			Provider: "openai",
+			Message:  "API key is empty; pass it to openai.New(key) or configure your secret source",
+			Err:      core.ErrUnauthorized,
+		}
+	}
+	return nil
+}
+```
+
+Call it at the top of `Chat` (`provider.go:114`), `StreamChat`, and `CreateEmbeddings` (`client_embeddings.go`), returning the error before building/sending the request.
+
+- [ ] **Step 4: Run — expect PASS** (`go test ./core/ -run Secret -v` and `go test ./providers/openai/ -run EmptyKey -v`).
+
+- [ ] **Step 5: Full suite (trim doesn't break existing secret/provider tests)**
+
+Run: `go test ./...` — expect PASS. If any test asserted an untrimmed secret value, it was asserting a bug; fix the assertion to the trimmed value.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/secret.go core/secret_test.go providers/openai/
+git commit -m "fix(auth): trim secrets and fail fast on empty OpenAI key"
+```
+
+---
+
+### Task 4: Wire structured output into the Responses API (Workstream B1)
+
+**Files:**
+- Modify: `providers/openai/types_responses.go`, `providers/openai/mapping_responses.go`
+- Test: `providers/openai/mapping_responses_test.go` or `client_responses_test.go`
+
+**Interfaces:**
+- Produces: `responsesRequest.Text *responsesText` carrying `format.{type,name,schema,strict}`, populated from `req.ResponseFormat`/`req.JSONSchema`.
+
+- [ ] **Step 1: VERIFY the wire shape first**
+
+Use the context7 MCP (`resolve-library-id` → OpenAI, then `query-docs` "Responses API structured outputs text format json_schema strict") to confirm the exact JSON. Expected: `"text": {"format": {"type":"json_schema","name":"...","schema":{...},"strict":true}}`. Record the confirmed shape in the task-4 report. If it differs, adjust the struct in Step 3 accordingly.
+
+- [ ] **Step 2: Failing test**
+
+Append to `providers/openai/client_responses_test.go`:
+
+```go
+func TestResponsesAPISendsStrictSchema(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode(responsesResponse{ID: "r", Status: "completed", OutputText: "{}"})
+	}))
+	defer srv.Close()
+
+	p := New("k", WithBaseURL(srv.URL))
+	_, err := p.Chat(context.Background(), &core.ChatRequest{
+		Model:          ModelGPT52,
+		Messages:       []core.Message{{Role: core.RoleUser, Content: "hi"}},
+		ResponseFormat: core.ResponseFormatJSONSchema,
+		JSONSchema: &core.JSONSchemaDefinition{
+			Name:   "person",
+			Strict: true,
+			Schema: json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"n":{"type":"string"}},"required":["n"]}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	text, _ := body["text"].(map[string]any)
+	format, _ := text["format"].(map[string]any)
+	if format["type"] != "json_schema" {
+		t.Fatalf("text.format.type = %v, want json_schema; body=%v", format["type"], body)
+	}
+	if format["strict"] != true {
+		t.Errorf("text.format.strict = %v, want true", format["strict"])
+	}
+	if format["name"] != "person" {
+		t.Errorf("text.format.name = %v, want person", format["name"])
+	}
+}
+```
+
+- [ ] **Step 3: Run — expect FAIL**, then implement.
+
+`providers/openai/types_responses.go` — add to `responsesRequest`:
+
+```go
+	Text *responsesText `json:"text,omitempty"`
+```
+
+and new types (adjust to the Step 1 verified shape):
+
+```go
+type responsesText struct {
+	Format *responsesTextFormat `json:"format,omitempty"`
+}
+
+type responsesTextFormat struct {
+	Type   string          `json:"type"`
+	Name   string          `json:"name,omitempty"`
+	Schema json.RawMessage `json:"schema,omitempty"`
+	Strict *bool           `json:"strict,omitempty"`
+}
+```
+
+`providers/openai/mapping_responses.go` — in `buildResponsesRequest`, before `return respReq`:
+
+```go
+	if tf := mapResponsesTextFormat(req); tf != nil {
+		respReq.Text = &responsesText{Format: tf}
+	}
+```
+
+and add:
+
+```go
+func mapResponsesTextFormat(req *core.ChatRequest) *responsesTextFormat {
+	switch req.ResponseFormat {
+	case core.ResponseFormatJSON:
+		return &responsesTextFormat{Type: "json_object"}
+	case core.ResponseFormatJSONSchema:
+		if req.JSONSchema == nil {
+			return nil
+		}
+		strict := req.JSONSchema.Strict
+		return &responsesTextFormat{
+			Type:   "json_schema",
+			Name:   req.JSONSchema.Name,
+			Schema: req.JSONSchema.Schema,
+			Strict: &strict,
+		}
+	default:
+		return nil
+	}
+}
+```
+
+- [ ] **Step 4: Run — expect PASS** (`go test ./providers/openai/ -run ResponsesAPISendsStrictSchema -v`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add providers/openai/types_responses.go providers/openai/mapping_responses.go providers/openai/client_responses_test.go
+git commit -m "feat(openai): send structured output on the Responses API"
+```
+
+---
+
+### Task 5: Strict-by-default + schema validation (Workstream B2)
+
+**Files:**
+- Modify: `core/client.go` (ResponseJSONSchema, add ResponseJSONSchemaNonStrict), `core/types.go` (Strict tag), `core/errors.go` (ErrInvalidSchema)
+- Create: `core/schema.go` (validator)
+- Test: `core/schema_test.go`, `core/client_test.go` (append)
+
+**Interfaces:**
+- Consumes: `JSONSchemaDefinition`.
+- Produces: `ResponseJSONSchema` forces `Strict=true`; `ResponseJSONSchemaNonStrict(*JSONSchemaDefinition) *ChatBuilder`; `core.ErrInvalidSchema`; `func validateStrictSchema(json.RawMessage) error`.
+
+- [ ] **Step 1: Failing tests**
+
+`core/schema_test.go`:
+
+```go
+func TestValidateStrictSchemaRejectsMissingAdditionalProps(t *testing.T) {
+	s := json.RawMessage(`{"type":"object","properties":{"n":{"type":"string"}},"required":["n"]}`)
+	if err := validateStrictSchema(s); !errors.Is(err, ErrInvalidSchema) {
+		t.Fatalf("err = %v, want ErrInvalidSchema", err)
+	}
+}
+
+func TestValidateStrictSchemaAcceptsWellFormed(t *testing.T) {
+	s := json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"n":{"type":"string"}},"required":["n"]}`)
+	if err := validateStrictSchema(s); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+```
+
+`core/client_test.go`:
+
+```go
+func TestResponseJSONSchemaDefaultsStrict(t *testing.T) {
+	b := NewClient(&mockProvider{}).Chat("m").
+		ResponseJSONSchema(&JSONSchemaDefinition{Name: "x", Schema: json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{},"required":[]}`)})
+	if !b.req.JSONSchema.Strict {
+		t.Error("ResponseJSONSchema should default Strict=true")
+	}
+}
+
+func TestResponseJSONSchemaNonStrictOptOut(t *testing.T) {
+	b := NewClient(&mockProvider{}).Chat("m").
+		ResponseJSONSchemaNonStrict(&JSONSchemaDefinition{Name: "x", Schema: json.RawMessage(`{}`)})
+	if b.req.JSONSchema.Strict {
+		t.Error("ResponseJSONSchemaNonStrict should set Strict=false")
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Implement**
+
+`core/errors.go`: add `ErrInvalidSchema = errors.New("invalid json schema for strict structured output")`.
+
+`core/types.go`: change the tag to `Strict bool \`json:"strict"\`` (drop `omitempty`) so an explicit false is representable.
+
+`core/schema.go` (new): implement `validateStrictSchema(raw json.RawMessage) error` — unmarshal into `map[string]any`; recursively for every node with `"type":"object"`, require `additionalProperties == false` and that the set of `required` entries covers all `properties` keys; on violation return `fmt.Errorf("%w: %s", ErrInvalidSchema, detail)` naming the JSON path (track a path string like `.address.city`). Walk `properties`, `items`, `$defs`.
+
+`core/client.go`:
+
+```go
+func (b *ChatBuilder) ResponseJSONSchema(schema *JSONSchemaDefinition) *ChatBuilder {
+	if schema != nil {
+		schema.Strict = true
+	}
+	b.req.ResponseFormat = ResponseFormatJSONSchema
+	b.req.JSONSchema = schema
+	return b
+}
+
+func (b *ChatBuilder) ResponseJSONSchemaNonStrict(schema *JSONSchemaDefinition) *ChatBuilder {
+	if schema != nil {
+		schema.Strict = false
+	}
+	b.req.ResponseFormat = ResponseFormatJSONSchema
+	b.req.JSONSchema = schema
+	return b
+}
+```
+
+In `validate()` (`core/client.go:433`), after the existing checks, add:
+
+```go
+	if b.req.ResponseFormat == ResponseFormatJSONSchema && b.req.JSONSchema != nil && b.req.JSONSchema.Strict {
+		if err := validateStrictSchema(b.req.JSONSchema.Schema); err != nil {
+			return err
+		}
+	}
+```
+
+- [ ] **Step 4: Run — expect PASS** (`go test ./core/ -run 'Strict|Schema|NonStrict' -v`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/errors.go core/types.go core/schema.go core/client.go core/schema_test.go core/client_test.go
+git commit -m "feat(core): default structured output to strict with schema validation"
+```
+
+---
+
+### Task 6: Capability gating — hard error when unsupported (Workstream B3)
+
+**Files:**
+- Modify: `core/client.go` (validate/preflight), `core/errors.go` (ErrStructuredOutputUnsupported)
+- Modify: `providers/openai/models.go` (ensure structured-output-capable models declare `FeatureStructuredOutput`)
+- Audit-only: other providers' `Supports`/model declarations
+- Test: `core/client_test.go` (append)
+
+**Interfaces:**
+- Consumes: `Provider.Supports`, `core.FeatureStructuredOutput`.
+- Produces: `core.ErrStructuredOutputUnsupported`; validate() returns it when a JSON/JSONSchema request targets an unsupporting provider.
+
+- [ ] **Step 1: Failing test**
+
+`core/client_test.go` (mockProvider's `Supports` returns based on the feature — check its current impl at `core/client_test.go:32` and make it return false for `FeatureStructuredOutput`, or add a dedicated provider):
+
+```go
+func TestStructuredOutputUnsupportedIsHardError(t *testing.T) {
+	// nonStructuredProvider.Supports(FeatureStructuredOutput) == false
+	c := NewClient(nonStructuredProvider{})
+	_, err := c.Chat("m").User("hi").ResponseJSON().GetResponse(context.Background())
+	if !errors.Is(err, ErrStructuredOutputUnsupported) {
+		t.Fatalf("err = %v, want ErrStructuredOutputUnsupported", err)
+	}
+}
+```
+
+Add a minimal `nonStructuredProvider` in the test file whose `Supports` returns false and whose `Chat` would fail the test if reached (`t.Fatal`-style sentinel, or return a marker error) so the test proves the gate fires before the provider call.
+
+- [ ] **Step 2: Run — expect FAIL.**
+
+- [ ] **Step 3: Implement**
+
+`core/errors.go`: add `ErrStructuredOutputUnsupported = errors.New("structured output not supported by this provider or model")`.
+
+`core/client.go` `validate()` — before the strict-schema check from Task 5:
+
+```go
+	if b.req.ResponseFormat == ResponseFormatJSON || b.req.ResponseFormat == ResponseFormatJSONSchema {
+		if !b.client.provider.Supports(FeatureStructuredOutput) {
+			return fmt.Errorf("%w: provider %s model %s",
+				ErrStructuredOutputUnsupported, b.client.provider.ID(), b.req.Model)
+		}
+	}
+```
+
+Confirm `"fmt"` is imported in `core/client.go` (it is).
+
+`providers/openai/models.go`: verify the models that support structured output (GPT-4o family, GPT-5.x, o-series) include `core.FeatureStructuredOutput` in their `Capabilities`, and that `OpenAI.Supports(core.FeatureStructuredOutput)` returns true (`provider.go:73`). Add the feature where missing.
+
+Audit (report only, no change unless a provider declares-but-ignores): for anthropic, gemini, ollama, perplexity, zai — confirm each provider's `Supports(FeatureStructuredOutput)` returns **false** OR it actually wires the schema. If any returns true while ignoring the schema (per the earlier audit: anthropic/ollama/perplexity/zai ignore it), change that provider's `Supports` to return false for `FeatureStructuredOutput` so the gate protects callers. Record findings in the task-6 report.
+
+- [ ] **Step 4: Run — expect PASS**, then full suite `go test ./...` (the gate must not break existing structured-output tests on OpenAI, which supports it).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/errors.go core/client.go providers/openai/models.go providers/*/provider.go core/client_test.go
+git commit -m "feat(core): hard-error structured output on unsupported providers"
+```
+
+---
+
+### Task 7: Fix DrainStream error-swallowing race (Workstream C1)
+
+**Files:**
+- Modify: `core/streaming.go` (DrainStream)
+- Test: `core/streaming_test.go` (append)
+
+**Interfaces:**
+- Produces: `DrainStream` never returns `(partial, nil)` when an error is delivered on `Err`, even if `Ch` closes first.
+
+- [ ] **Step 1: Failing test**
+
+Append to `core/streaming_test.go` a stream whose `Ch` closes before the error is delivered on `Err`:
+
+```go
+func TestDrainStreamDoesNotSwallowLateError(t *testing.T) {
+	ch := make(chan ChatChunk, 1)
+	errc := make(chan error, 1)
+	final := make(chan *ChatResponse, 1)
+	ch <- ChatChunk{Delta: "partial"}
+	close(ch) // Ch closes FIRST
+	go func() {
+		// error delivered slightly later, after Ch is already closed
+		errc <- &ProviderError{Provider: "x", Message: "mid-stream boom", Err: ErrServer}
+		close(errc)
+		close(final)
+	}()
+	s := &ChatStream{Ch: ch, Err: errc, Final: final}
+	_, err := DrainStream(context.Background(), s)
+	if err == nil {
+		t.Fatal("DrainStream returned nil error; the late stream error was swallowed")
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (currently returns nil error with partial text), run under `-race` too.
+
+- [ ] **Step 3: Implement** — rewrite `DrainStream` to mirror the non-lossy discipline in `wrapStreamWithTelemetry` (`core/client.go:800-868`): keep reading after `Ch` closes until both `Err` and `Final` resolve; on `Final` closing without a value, check `Err`; on `ctx.Done()`, do a final non-blocking drain of `Err`/`Final` before returning `ctx.Err()`. Preserve the existing accumulation of `Ch` deltas.
+
+- [ ] **Step 4: Run — expect PASS**, incl. `go test -race ./core/ -run DrainStream -count=20`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/streaming.go core/streaming_test.go
+git commit -m "fix(core): stop DrainStream swallowing late stream errors"
+```
+
+---
+
+### Task 8: Fix batch-poll infinite hang (Workstream C2)
+
+**Files:**
+- Modify: `core/batch.go` (BatchWaiter.Wait)
+- Test: `core/batch_test.go` (append)
+
+**Interfaces:**
+- Produces: `Wait` bounds each poll by the remaining `maxWait` budget so a hung poll cannot exceed it.
+
+- [ ] **Step 1: Failing test**
+
+```go
+func TestBatchWaiterDoesNotHangOnStuckPoll(t *testing.T) {
+	p := &stuckBatchProvider{} // GetBatchStatus blocks on <-ctx.Done()
+	w := NewBatchWaiter(p, /* interval */ 10*time.Millisecond, /* maxWait */ 100*time.Millisecond)
+	start := time.Now()
+	_, err := w.Wait(context.Background(), "batch-1")
+	if err == nil {
+		t.Fatal("want timeout error")
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Fatalf("Wait hung for %v; maxWait budget not enforced per-poll", time.Since(start))
+	}
+}
+```
+
+Check the real `NewBatchWaiter`/`BatchWaiter.Wait` signatures (`rg -n "func NewBatchWaiter|func .*BatchWaiter. Wait" core/batch.go`) and the existing batch test mocks (`core/batch_test.go`) — reuse/extend a mock rather than inventing one; add a `stuckBatchProvider` whose `GetBatchStatus` blocks on `<-ctx.Done()`.
+
+- [ ] **Step 2: Run — expect FAIL/hang** (bounded by `go test -timeout 30s`).
+
+- [ ] **Step 3: Implement** — in `Wait`, compute an overall deadline from `maxWait` and derive a per-poll context: `pollCtx, cancel := context.WithDeadline(ctx, deadline)` (or `WithTimeout` for the remaining budget) for each `GetBatchStatus` call, and return a deadline error once `now > deadline`. Ensure `cancel()` runs each iteration (no leak).
+
+- [ ] **Step 4: Run — expect PASS** (`go test ./core/ -run BatchWaiter -v -timeout 30s`), and `-race`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/batch.go core/batch_test.go
+git commit -m "fix(core): bound batch poll by maxWait to prevent hang"
+```
+
+---
+
+### Task 9: Change doc + timeout-gap docs + full verification
+
+**Files:**
+- Create: `docs/changes/2026-08-01_v0.16.0_sdk-reliability-hardening.md`
+- Modify: doc comments on the uncovered non-chat methods (embeddings/batch/files/images) noting they require a caller-supplied context deadline
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Full suite with race** — `go test -race ./...` — expect PASS.
+- [ ] **Step 2: Build + fmt** — `go build ./...`; `gofmt -l .` (expect empty besides pre-existing untracked files).
+- [ ] **Step 3: Change doc** per repo `CLAUDE.md` structure: `product: iris`, `change_type: feature`. `affected_components` must list every file touched across Tasks 1-8. Document exactly: `ErrTimeout` restoration for real providers, `ProviderError.Body`, key trimming + empty-key error, Responses-API structured output, strict-by-default (+ `ErrInvalidSchema`, `ResponseJSONSchemaNonStrict`), capability gating (`ErrStructuredOutputUnsupported`), `DrainStream` and batch-poll fixes, and the two behavior changes. Include a "Deferred" section: other providers' empty-key preflight, native structured output on anthropic/ollama/gemini, broad non-chat timeout coverage, client-side response validation.
+- [ ] **Step 4: Timeout-gap doc comments** — add a one-line note to the Go doc comment of each non-chat entry point (`CreateEmbeddings`, batch methods, files, images) that `core.WithTimeout` does not apply and a context deadline must be supplied by the caller.
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/changes/ providers/ core/
+git commit -m "docs: change doc and timeout-gap notes for reliability hardening"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** A1→T1, A2→T2, A3→T3, B1→T4, B2→T5, B3→T6, C1→T7, C2→T8, C3(docs)→T9. Both behavior changes (strict default, unsupported hard-error) are implemented (T5/T6) and documented (T9). Deferrals are recorded in T9's change doc. All spec sections covered.
+
+**Placeholder scan:** No TBD/TODO. Every external-contract unknown (Responses API shape in T4, `isRetryable` name in T1, `NewBatchWaiter` signature in T8, mockProvider `Supports` in T6) is called out with an explicit `rg`/context7 verification step and a fallback, not left vague.
+
+**Type consistency:** `ProviderError.Body string`, `DecodeErrorWithBody(provider, err, body)`, `validateStrictSchema(json.RawMessage) error`, `ResponseJSONSchemaNonStrict(*JSONSchemaDefinition) *ChatBuilder`, `ErrInvalidSchema`, `ErrStructuredOutputUnsupported`, `responsesTextFormat` used consistently across tasks. Task 2 changes only OpenAI's `newDecodeError` signature; other providers' wrappers are explicitly left intact so the build stays green.

--- a/docs/superpowers/specs/2026-08-01-sdk-reliability-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-01-sdk-reliability-hardening-design.md
@@ -1,0 +1,187 @@
+# Design: SDK Reliability Hardening (Errors, Structured Output, Timeouts)
+
+- **Date:** 2026-08-01
+- **Status:** Approved (pending spec review)
+- **Branch:** `feat/sdk-reliability-hardening`
+
+## Problem
+
+A downstream app built on Iris hit three classes of failure, confirmed by a four-part source audit:
+
+1. **Errors not descriptive / not propagated.** Provider error bodies are replaced with generic `http.StatusText`; decode errors omit the body; transport errors drop the wrapped `context.DeadlineExceeded`; and the standard streaming drain (`DrainStream`) can swallow a real error and return false success.
+2. **Non-strict document shapes from models.** Structured output is wired only on the OpenAI Chat Completions path. The Responses API (all GPT-5.x models, incl. `gpt-5.4-mini`) silently drops it; `Strict` defaults to false; several providers ignore the schema entirely; and there is no capability gating.
+3. **Provider keys "didn't work."** The API key is never trimmed (a trailing newline from Azure Key Vault corrupts the `Authorization` header); empty keys are not validated at construction; `Secret.IsEmpty()` misses whitespace.
+
+A cross-cutting root cause underlies much of #1: `core.ProviderError` has no field for the raw body, and the normalization layer discards both the provider's real error text and the original error object.
+
+## Goals
+
+- Errors carry the provider's actual detail and preserve `errors.Is` chains end-to-end (including `context.DeadlineExceeded` → `ErrTimeout`).
+- Structured output is enforced on every path that claims to support it, strict by default, and fails loud when unsupported.
+- API keys are sanitized and validated so a mis-provisioned key fails with a clear, early error.
+- No streaming error is ever silently swallowed.
+
+## Non-Goals / Deferred
+
+- Full timeout coverage for embeddings/batch/files/vector-stores/images via new `core.Client` wrappers. This pass fixes the one concrete hang (batch poll) and **documents** the remaining gap; broad coverage is a follow-up.
+- Client-side re-validation of the model's returned JSON against the schema (a separate feature). We enforce the request-side contract only.
+- Adding `WithAPIKey` options across all providers (API-symmetry nicety, not a correctness bug).
+- PetalFlow changes — separate repo; only the Iris contract it consumes is in scope.
+
+## Decisions (confirmed with maintainer)
+
+- **`Strict` defaults to true** for schema requests. The builder forces strict on; a validator checks the schema can satisfy OpenAI strict mode and returns a clear error if not (rather than letting the API reject it). An explicit non-strict opt-out is provided.
+- **Unsupported structured output is a hard error** before the request is sent (behavior change from silent-ignore).
+
+---
+
+## Workstream A — Error handling & key hygiene
+
+### A1. Preserve error chains in normalization
+
+`providers/internal/normalize/errors.go`:
+
+```go
+func NetworkError(provider string, err error) error {
+    return &core.ProviderError{
+        Provider: provider,
+        Message:  err.Error(),
+        Err:      fmt.Errorf("%w: %w", core.ErrNetwork, err), // was: core.ErrNetwork
+    }
+}
+```
+
+Same treatment for `DecodeError` (`Err: fmt.Errorf("%w: %w", core.ErrDecode, err)`). `ProviderError.Unwrap()` returns `e.Err`, so both `errors.Is(_, core.ErrNetwork)` and `errors.Is(_, context.DeadlineExceeded)` then hold.
+
+Effects (all verified in the audit):
+- Streaming timeouts surface as `core.ErrTimeout` again (the remap at `core/client.go:629,659` fires).
+- `GetResponse` returns `ErrTimeout` even when retries are exhausted/disabled.
+- `isRetryable` (`core/retry.go`) stops misclassifying a timed-out request as retryable — its `context.DeadlineExceeded` check (which runs before the `ErrNetwork` check) now matches. **A test must assert this ordering holds.**
+
+Also apply the same `%w` fix to the hand-rolled equivalents in `providers/ollama/chat.go` and `providers/ollama/embeddings.go`, and confirm `providers/azurefoundry` uses `normalize.NetworkError` (or fix its hand-rolled version).
+
+### A2. Carry the raw body on `ProviderError`
+
+`core/errors.go`: add a field.
+
+```go
+type ProviderError struct {
+    Provider  string
+    Status    int
+    RequestID string
+    Code      string
+    Message   string
+    Body      string // raw response body (truncated), preserved when the structured message is empty
+    Err       error
+}
+```
+
+- `normalize.OpenAIStyleProviderError` and the hand-rolled per-provider variants: when the parsed `error.message` is empty, set `Message` from a truncated body snippet (first ~512 bytes) instead of `http.StatusText`, and store the truncated body (≤ ~4 KB) in `Body`. Never silently discard the body.
+- `normalize.DecodeError` gains a `body []byte` parameter; store the truncated body and include a snippet in `Message`. Update all `newDecodeError` call sites (mechanical; enumerate with `rg "newDecodeError|DecodeError\("`).
+- `ProviderError.Error()`: include the request ID as today; append `Body` snippet only when `Message` is body-derived (avoid double-printing). Omit the `(status=0, code=)` suffix when both are zero-valued (fixes noisy network/decode output).
+
+### A3. Key sanitization & validation
+
+- `core/secret.go`: `NewSecret` trims surrounding whitespace: `Secret{value: strings.TrimSpace(value)}`. This is the primary fix for the Key-Vault trailing-newline symptom and applies to every provider at once.
+- `Secret.IsEmpty()`: `return strings.TrimSpace(s.value) == ""` (defensive; azurefoundry's only auth guard).
+- Empty-key preflight error: add a descriptive, typed error when the key is empty at request time. Scope this pass to the **OpenAI** provider (the app's primary): at the top of `Chat`/`StreamChat` (and `CreateEmbeddings`), if `p.config.APIKey.IsEmpty()`, return a `*core.ProviderError{Provider:"openai", Message:"API key is empty; pass it to openai.New(key) or configure your secret source", Err: core.ErrUnauthorized}` before any HTTP call. Other providers: tracked as a follow-up (documented in Deferred), since the global `NewSecret` trim already covers the common corruption case for all of them.
+
+### A4. `DrainStream` must not swallow errors (Workstream C item, grouped here for the streaming-error theme — implemented in C1)
+
+---
+
+## Workstream B — Structured output
+
+### B1. Wire structured output into the Responses API
+
+`providers/openai/types_responses.go`: add a text/format field to `responsesRequest`.
+
+```go
+type responsesRequest struct {
+    // ...existing...
+    Text *responsesText `json:"text,omitempty"`
+}
+
+type responsesText struct {
+    Format *responsesTextFormat `json:"format,omitempty"`
+}
+
+type responsesTextFormat struct {
+    Type   string          `json:"type"`             // "json_schema" | "json_object"
+    Name   string          `json:"name,omitempty"`   // required for json_schema
+    Schema json.RawMessage `json:"schema,omitempty"`
+    Strict *bool           `json:"strict,omitempty"`
+}
+```
+
+`providers/openai/mapping_responses.go` `buildResponsesRequest`: map `req.ResponseFormat`/`req.JSONSchema` into `Text.Format`, mirroring `mapResponseFormat` for Chat Completions.
+
+> **Implementer must verify the exact Responses API wire shape** against current OpenAI docs (use the context7 MCP: resolve OpenAI docs, query "Responses API structured outputs text.format json_schema strict"). The shape above is the expected form (`text.format.{type,name,schema,strict}`); confirm field names/nesting before finalizing, and add an httptest that asserts the emitted JSON matches.
+
+### B2. Strict-by-default + schema validation
+
+`core/client.go`:
+- `ResponseJSONSchema(schema)` forces strict on: if `schema.Strict` is false, set it true. Add `ResponseJSONSchemaNonStrict(schema *JSONSchemaDefinition)` as the explicit opt-out (sets `Strict=false`). Document that `ResponseJSONSchema` upgrades to strict (behavior change).
+- Add a strict-schema validator invoked in `validate()` (or `GetResponse`/`Stream`) when `ResponseFormat == ResponseFormatJSONSchema && JSONSchema.Strict`:
+  - Walk the JSON Schema; for every `type:"object"`, require `additionalProperties:false` and that `required` lists all `properties` keys.
+  - On violation, return a new sentinel `core.ErrInvalidSchema` with a message naming the offending path (e.g. `strict schema requires additionalProperties:false at .address`). This surfaces the problem before the provider rejects it.
+- `core/types.go`: `JSONSchemaDefinition.Strict` tag becomes `json:"strict"` (drop `omitempty`) so an explicit `false` is transmittable where a provider distinguishes it; the Responses `strict` field is `*bool` to encode true/false explicitly.
+
+### B3. Capability gating (hard error when unsupported)
+
+`core/client.go` `validate()` (or a shared preflight used by both `GetResponse` and `Stream`):
+- When `req.ResponseFormat` is `ResponseFormatJSON` or `ResponseFormatJSONSchema`, verify support:
+  - Provider-level: if the `Provider` interface exposes `Supports(Feature) bool`, require `Supports(core.FeatureStructuredOutput)`.
+  - Model-level: if the provider exposes model info (e.g. openai `GetModelInfo`), require `HasCapability(core.FeatureStructuredOutput)`.
+- On unsupported, return new sentinel `core.ErrStructuredOutputUnsupported` with a message naming provider + model.
+
+> **Implementer must verify** whether `Supports` is on the `core.Provider` interface or only concrete providers. If not on the interface, gate on what is reliably available (model registry via a small capability hook) and document the mechanism. Ensure the OpenAI models that use structured output actually declare `FeatureStructuredOutput` in `providers/openai/models.go` (add where missing for models that support it, e.g. the GPT-5.x entries).
+
+### B4. Wire or explicitly reject on other providers
+
+For anthropic, ollama, perplexity, zai, gemini: rather than silently ignoring the schema, the B3 capability gate makes an unsupported request a hard error. **Minimum bar for this pass:** ensure each provider either (a) correctly declares `FeatureStructuredOutput` AND wires the schema, or (b) does *not* declare it, so B3 rejects the request. No provider may declare support while ignoring the schema. Actually wiring native structured output for anthropic/ollama/gemini is a follow-up (documented in Deferred); this pass guarantees no silent non-conformance.
+
+---
+
+## Workstream C — Streaming & timeout robustness
+
+### C1. Fix the `DrainStream` error-swallowing race
+
+`core/streaming.go`: rewrite `DrainStream` to use the same non-lossy discipline as `wrapStreamWithTelemetry` (`core/client.go:800-868`):
+- Do not exit the read loop the instant `Ch` closes; continue until both `Err` and `Final` are resolved.
+- Treat `Final` closing without a value as "check `Err`".
+- On `ctx.Done()`, do a final non-blocking drain of `Err`/`Final` before returning `ctx.Err()`, so a concrete provider error wins over a generic context error.
+- Test: a provider that emits chunks, then delivers an error via the supervisor path *after* `Ch` closes → assert `DrainStream` returns that error (not false success). Run under `-race`.
+
+### C2. Fix the batch-poll infinite hang
+
+`core/batch.go` `BatchWaiter.Wait`: the `maxWait` budget is checked only after each poll returns, so one hung `GetBatchStatus` blocks forever. Fix by bounding each poll with the remaining budget:
+- Derive an overall deadline from `maxWait`; for each poll, call with a context carrying the remaining time (`context.WithTimeout(ctx, remaining)`), and stop when the deadline passes.
+- Test: a stub `BatchProvider` whose `GetBatchStatus` blocks; assert `Wait` returns within ~`maxWait` with a deadline-related error rather than hanging.
+
+### C3. Document the remaining timeout gap
+
+Add to the change doc (and a short note in the relevant Go doc comments): embeddings, batch, files, vector-store, and image calls do **not** go through `core.Client` and thus are not covered by `core.WithTimeout`; callers must pass a context with a deadline. List the affected methods.
+
+---
+
+## Testing
+
+- **A1:** table test — a `context.DeadlineExceeded` wrapped by `NetworkError` satisfies `errors.Is` for both `ErrNetwork` and `context.DeadlineExceeded`; a streaming timeout against a mock provider that wraps via `NetworkError` now surfaces as `ErrTimeout`; `isRetryable` returns false for that error.
+- **A2:** given a non-JSON / wrong-shape error body, `ProviderError.Message`/`Body` contain the real body text; decode failure includes the body snippet.
+- **A3:** `NewSecret(" sk-x\n")` exposes `"sk-x"`; `IsEmpty` true for `" "`; OpenAI `Chat` with empty key returns the descriptive `ErrUnauthorized` before any HTTP call (httptest server asserts it is never hit).
+- **B1:** httptest asserts the Responses API request carries `text.format` with `type:"json_schema"`, the schema, and `strict:true`.
+- **B2:** `ResponseJSONSchema` sets strict true; a schema lacking `additionalProperties:false` yields `ErrInvalidSchema` naming the path; `ResponseJSONSchemaNonStrict` sets false.
+- **B3:** requesting structured output against a provider/model without `FeatureStructuredOutput` returns `ErrStructuredOutputUnsupported` before any call.
+- **C1/C2:** as described above, both under `-race`.
+
+## Breaking Changes & Migration
+
+- `ResponseJSONSchema` now defaults to strict; a previously-passing loose schema may now return `ErrInvalidSchema`. Migration: make the schema strict-compatible (`additionalProperties:false`, all fields required) or use `ResponseJSONSchemaNonStrict`.
+- Requesting structured output from an unsupported provider/model now returns `ErrStructuredOutputUnsupported` instead of silently returning unconstrained output.
+- `normalize.DecodeError` gains a `body` parameter (internal package; not part of the public SDK surface).
+- New exported symbols: `ProviderError.Body`, `core.ErrInvalidSchema`, `core.ErrStructuredOutputUnsupported`, `ChatBuilder.ResponseJSONSchemaNonStrict`.
+
+## Rollout
+
+Semantically a minor release (0.x) with two documented behavior changes; ship as `v0.16.0`. Each workstream is independently testable; land A first (highest impact, lowest risk), then B, then C.

--- a/providers/anthropic/errors.go
+++ b/providers/anthropic/errors.go
@@ -4,10 +4,25 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/petal-labs/iris/core"
 	"github.com/petal-labs/iris/providers/internal/normalize"
 )
+
+// maxBodyLen caps how much of a raw response body is retained on
+// ProviderError.Body so oversized error pages don't bloat logs.
+const maxBodyLen = 4096
+
+// truncateBody trims and caps a raw response body for inclusion on
+// ProviderError.Body.
+func truncateBody(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if len(s) > maxBodyLen {
+		return s[:maxBodyLen] + "…(truncated)"
+	}
+	return s
+}
 
 // ErrToolArgsInvalidJSON is returned when tool call arguments contain invalid JSON.
 var ErrToolArgsInvalidJSON = errors.New("tool args invalid json")
@@ -22,8 +37,13 @@ func normalizeError(status int, body []byte, requestID string) error {
 	_ = json.Unmarshal(body, &errResp)
 
 	message := errResp.Error.Message
+	bodyStr := truncateBody(body)
 	if message == "" {
-		message = http.StatusText(status)
+		if bodyStr != "" {
+			message = bodyStr // surface the real body instead of http.StatusText
+		} else {
+			message = http.StatusText(status)
+		}
 	}
 
 	code := errResp.Error.Type
@@ -35,7 +55,9 @@ func normalizeError(status int, body []byte, requestID string) error {
 		http.StatusNotFound: core.ErrNotFound,
 	})
 
-	return normalize.ProviderError("anthropic", status, requestID, code, message, sentinel)
+	pe := normalize.ProviderError("anthropic", status, requestID, code, message, sentinel)
+	pe.(*core.ProviderError).Body = bodyStr
+	return pe
 }
 
 // newNetworkError creates a ProviderError for network-related failures.

--- a/providers/anthropic/errors_test.go
+++ b/providers/anthropic/errors_test.go
@@ -77,7 +77,7 @@ func TestNormalizeError(t *testing.T) {
 			body:      []byte(`not json`),
 			requestID: "",
 			wantErr:   core.ErrServer,
-			wantMsg:   "Internal Server Error",
+			wantMsg:   "not json",
 			wantCode:  "unknown_error",
 		},
 	}

--- a/providers/gemini/errors.go
+++ b/providers/gemini/errors.go
@@ -4,10 +4,25 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/petal-labs/iris/core"
 	"github.com/petal-labs/iris/providers/internal/normalize"
 )
+
+// maxBodyLen caps how much of a raw response body is retained on
+// ProviderError.Body so oversized error pages don't bloat logs.
+const maxBodyLen = 4096
+
+// truncateBody trims and caps a raw response body for inclusion on
+// ProviderError.Body.
+func truncateBody(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if len(s) > maxBodyLen {
+		return s[:maxBodyLen] + "…(truncated)"
+	}
+	return s
+}
 
 // File-specific error sentinels.
 var (
@@ -25,8 +40,13 @@ func normalizeError(status int, body []byte) error {
 	_ = json.Unmarshal(body, &errResp)
 
 	message := errResp.Error.Message
+	bodyStr := truncateBody(body)
 	if message == "" {
-		message = http.StatusText(status)
+		if bodyStr != "" {
+			message = bodyStr // surface the real body instead of http.StatusText
+		} else {
+			message = http.StatusText(status)
+		}
 	}
 
 	code := errResp.Error.Status
@@ -38,7 +58,9 @@ func normalizeError(status int, body []byte) error {
 		http.StatusNotFound: core.ErrBadRequest,
 	})
 
-	return normalize.ProviderError("gemini", status, "", code, message, sentinel)
+	pe := normalize.ProviderError("gemini", status, "", code, message, sentinel)
+	pe.(*core.ProviderError).Body = bodyStr
+	return pe
 }
 
 // newNetworkError creates a ProviderError for network-related failures.

--- a/providers/huggingface/errors_test.go
+++ b/providers/huggingface/errors_test.go
@@ -69,7 +69,7 @@ func TestNormalizeError(t *testing.T) {
 			body:         []byte(`{}`),
 			requestID:    "",
 			wantCode:     "",
-			wantMsg:      "Bad Gateway",
+			wantMsg:      "{}",
 			wantSentinel: core.ErrServer,
 		},
 		{
@@ -78,7 +78,7 @@ func TestNormalizeError(t *testing.T) {
 			body:         []byte(`not json`),
 			requestID:    "req-def",
 			wantCode:     "",
-			wantMsg:      "Bad Request",
+			wantMsg:      "not json",
 			wantSentinel: core.ErrBadRequest,
 		},
 		{
@@ -96,7 +96,7 @@ func TestNormalizeError(t *testing.T) {
 			body:         []byte(`{}`),
 			requestID:    "",
 			wantCode:     "",
-			wantMsg:      "I'm a teapot",
+			wantMsg:      "{}",
 			wantSentinel: core.ErrServer,
 		},
 	}

--- a/providers/internal/normalize/errors.go
+++ b/providers/internal/normalize/errors.go
@@ -3,6 +3,7 @@ package normalize
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/petal-labs/iris/core"
@@ -41,7 +42,7 @@ func NetworkError(provider string, err error) error {
 	return &core.ProviderError{
 		Provider: provider,
 		Message:  err.Error(),
-		Err:      core.ErrNetwork,
+		Err:      fmt.Errorf("%w: %w", core.ErrNetwork, err),
 	}
 }
 
@@ -50,7 +51,7 @@ func DecodeError(provider string, err error) error {
 	return &core.ProviderError{
 		Provider: provider,
 		Message:  err.Error(),
-		Err:      core.ErrDecode,
+		Err:      fmt.Errorf("%w: %w", core.ErrDecode, err),
 	}
 }
 

--- a/providers/internal/normalize/errors.go
+++ b/providers/internal/normalize/errors.go
@@ -5,9 +5,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/petal-labs/iris/core"
 )
+
+// maxBodyLen caps how much of a raw response body is retained on
+// ProviderError.Body so oversized error pages don't bloat logs.
+const maxBodyLen = 4096
+
+// truncateBody trims and caps a raw response body for inclusion on
+// ProviderError.Body.
+func truncateBody(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if len(s) > maxBodyLen {
+		return s[:maxBodyLen] + "…(truncated)"
+	}
+	return s
+}
 
 // openAIStyleErrorResponse represents providers that return:
 // {"error":{"message":"...","type":"...","code":"..."}}
@@ -25,8 +40,13 @@ func OpenAIStyleProviderError(provider string, status int, body []byte, requestI
 	_ = json.Unmarshal(body, &errResp)
 
 	message := errResp.Error.Message
+	bodyStr := truncateBody(body)
 	if message == "" {
-		message = http.StatusText(status)
+		if bodyStr != "" {
+			message = bodyStr // surface the real body instead of http.StatusText
+		} else {
+			message = http.StatusText(status)
+		}
 	}
 
 	code := errResp.Error.Code
@@ -34,7 +54,9 @@ func OpenAIStyleProviderError(provider string, status int, body []byte, requestI
 		code = errResp.Error.Type
 	}
 
-	return ProviderError(provider, status, requestID, code, message, SentinelForStatus(status))
+	pe := ProviderError(provider, status, requestID, code, message, SentinelForStatus(status))
+	pe.(*core.ProviderError).Body = bodyStr
+	return pe
 }
 
 // NetworkError wraps transport failures as provider-specific network errors.
@@ -51,6 +73,19 @@ func DecodeError(provider string, err error) error {
 	return &core.ProviderError{
 		Provider: provider,
 		Message:  err.Error(),
+		Err:      fmt.Errorf("%w: %w", core.ErrDecode, err),
+	}
+}
+
+// DecodeErrorWithBody wraps decode/parsing failures as provider-specific
+// decode errors, additionally preserving the raw response body (truncated)
+// that failed to decode so callers can inspect what the provider actually
+// sent back.
+func DecodeErrorWithBody(provider string, err error, body []byte) error {
+	return &core.ProviderError{
+		Provider: provider,
+		Message:  err.Error(),
+		Body:     truncateBody(body),
 		Err:      fmt.Errorf("%w: %w", core.ErrDecode, err),
 	}
 }

--- a/providers/internal/normalize/errors_test.go
+++ b/providers/internal/normalize/errors_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/petal-labs/iris/core"
@@ -41,7 +42,7 @@ func TestOpenAIStyleProviderError(t *testing.T) {
 		{
 			name:         "fallback to status text",
 			status:       http.StatusBadGateway,
-			body:         []byte(`{}`),
+			body:         []byte{},
 			requestID:    "",
 			wantCode:     "",
 			wantMsg:      "Bad Gateway",
@@ -77,6 +78,19 @@ func TestOpenAIStyleProviderError(t *testing.T) {
 				t.Errorf("error should wrap %v", tt.wantSentinel)
 			}
 		})
+	}
+}
+
+func TestOpenAIStyleErrorFallsBackToBody(t *testing.T) {
+	// Body is valid text but NOT the {"error":{"message"}} envelope.
+	body := []byte(`{"detail":"model gpt-x does not exist"}`)
+	err := OpenAIStyleProviderError("openai", 404, body, "req-1")
+	var pe *core.ProviderError
+	if !errors.As(err, &pe) {
+		t.Fatal("want *core.ProviderError")
+	}
+	if !strings.Contains(pe.Message+pe.Body, "does not exist") {
+		t.Errorf("real body text lost: msg=%q body=%q", pe.Message, pe.Body)
 	}
 }
 

--- a/providers/internal/normalize/errors_test.go
+++ b/providers/internal/normalize/errors_test.go
@@ -1,7 +1,9 @@
 package normalize
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -126,6 +128,28 @@ func TestProviderErrorDefaults(t *testing.T) {
 	}
 	if !errors.Is(err, core.ErrServer) {
 		t.Error("error should wrap core.ErrServer")
+	}
+}
+
+func TestNetworkErrorPreservesChain(t *testing.T) {
+	underlying := fmt.Errorf("dial tcp: %w", context.DeadlineExceeded)
+	err := NetworkError("openai", underlying)
+	if !errors.Is(err, core.ErrNetwork) {
+		t.Error("want errors.Is(err, core.ErrNetwork)")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Error("want errors.Is(err, context.DeadlineExceeded)")
+	}
+}
+
+func TestDecodeErrorPreservesChain(t *testing.T) {
+	underlying := errors.New("invalid character '<'")
+	err := DecodeError("openai", underlying)
+	if !errors.Is(err, core.ErrDecode) {
+		t.Error("want errors.Is(err, core.ErrDecode)")
+	}
+	if !errors.Is(err, underlying) {
+		t.Error("want errors.Is(err, underlying)")
 	}
 }
 

--- a/providers/ollama/chat.go
+++ b/providers/ollama/chat.go
@@ -41,7 +41,7 @@ func (p *Ollama) doChat(ctx context.Context, req *core.ChatRequest) (*core.ChatR
 			Provider: "ollama",
 			Code:     "network_error",
 			Message:  err.Error(),
-			Err:      core.ErrNetwork,
+			Err:      fmt.Errorf("%w: %w", core.ErrNetwork, err),
 		}
 	}
 	defer resp.Body.Close()

--- a/providers/ollama/embeddings.go
+++ b/providers/ollama/embeddings.go
@@ -58,7 +58,7 @@ func (p *Ollama) CreateEmbeddings(ctx context.Context, req *core.EmbeddingReques
 			Provider: "ollama",
 			Code:     "network_error",
 			Message:  err.Error(),
-			Err:      core.ErrNetwork,
+			Err:      fmt.Errorf("%w: %w", core.ErrNetwork, err),
 		}
 	}
 	defer resp.Body.Close()

--- a/providers/ollama/stream.go
+++ b/providers/ollama/stream.go
@@ -42,7 +42,7 @@ func (p *Ollama) doStreamChat(ctx context.Context, req *core.ChatRequest) (*core
 			Provider: "ollama",
 			Code:     "network_error",
 			Message:  err.Error(),
-			Err:      core.ErrNetwork,
+			Err:      fmt.Errorf("%w: %w", core.ErrNetwork, err),
 		}
 	}
 

--- a/providers/openai/auth_test.go
+++ b/providers/openai/auth_test.go
@@ -1,0 +1,83 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.Chat(context.Background(), &core.ChatRequest{
+		Model:    ModelGPT52,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}
+
+func TestStreamChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    ModelGPT52,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}
+
+func TestCreateEmbeddingsEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "text-embedding-3-small",
+		Input: []core.EmbeddingInput{{Text: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}
+
+func TestChatWhitespaceOnlyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("   \n", WithBaseURL(srv.URL))
+	_, err := p.Chat(context.Background(), &core.ChatRequest{
+		Model:    ModelGPT52,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with a whitespace-only key")
+	}
+}

--- a/providers/openai/client.go
+++ b/providers/openai/client.go
@@ -21,7 +21,7 @@ func (p *OpenAI) doChat(ctx context.Context, req *core.ChatRequest) (*core.ChatR
 	// Marshal request body
 	body, err := json.Marshal(oaiReq)
 	if err != nil {
-		return nil, newDecodeError(err)
+		return nil, newDecodeError(err, nil)
 	}
 
 	// Create HTTP request
@@ -62,7 +62,7 @@ func (p *OpenAI) doChat(ctx context.Context, req *core.ChatRequest) (*core.ChatR
 	// Parse response
 	var oaiResp openAIResponse
 	if err := json.Unmarshal(respBody, &oaiResp); err != nil {
-		return nil, newDecodeError(err)
+		return nil, newDecodeError(err, respBody)
 	}
 
 	// Map to Iris response

--- a/providers/openai/client_batch.go
+++ b/providers/openai/client_batch.go
@@ -18,6 +18,9 @@ const batchesPath = "/batches"
 
 // CreateBatch submits requests for asynchronous batch processing.
 // The requests are serialized to JSONL, uploaded as a file, and submitted as a batch.
+//
+// This call does not go through core.Client, so core.WithTimeout does not
+// apply; pass a context with a deadline if a bound is needed.
 func (p *OpenAI) CreateBatch(ctx context.Context, requests []core.BatchRequest) (core.BatchID, error) {
 	if len(requests) == 0 {
 		return "", &core.ProviderError{
@@ -107,6 +110,12 @@ func (p *OpenAI) CreateBatch(ctx context.Context, requests []core.BatchRequest) 
 }
 
 // GetBatchStatus returns the current status of a batch.
+//
+// This call does not go through core.Client, so core.WithTimeout does not
+// apply; pass a context with a deadline if a bound is needed. This matters
+// in particular when polling via core.BatchWaiter.Wait, which bounds each
+// poll using the caller-supplied context combined with its own maxWait
+// budget rather than any core.Client timeout.
 func (p *OpenAI) GetBatchStatus(ctx context.Context, id core.BatchID) (*core.BatchInfo, error) {
 	url := p.config.BaseURL + batchesPath + "/" + string(id)
 
@@ -158,6 +167,9 @@ func (p *OpenAI) GetBatchStatus(ctx context.Context, id core.BatchID) (*core.Bat
 }
 
 // GetBatchResults retrieves completed batch results.
+//
+// This call does not go through core.Client, so core.WithTimeout does not
+// apply; pass a context with a deadline if a bound is needed.
 func (p *OpenAI) GetBatchResults(ctx context.Context, id core.BatchID) ([]core.BatchResult, error) {
 	// First get the batch to find the output file ID
 	info, err := p.GetBatchStatus(ctx, id)
@@ -194,6 +206,9 @@ func (p *OpenAI) GetBatchResults(ctx context.Context, id core.BatchID) ([]core.B
 }
 
 // CancelBatch cancels a pending or in-progress batch.
+//
+// This call does not go through core.Client, so core.WithTimeout does not
+// apply; pass a context with a deadline if a bound is needed.
 func (p *OpenAI) CancelBatch(ctx context.Context, id core.BatchID) error {
 	url := p.config.BaseURL + batchesPath + "/" + string(id) + "/cancel"
 
@@ -235,6 +250,9 @@ func (p *OpenAI) CancelBatch(ctx context.Context, id core.BatchID) error {
 }
 
 // ListBatches returns all batches for the account.
+//
+// This call does not go through core.Client, so core.WithTimeout does not
+// apply; pass a context with a deadline if a bound is needed.
 func (p *OpenAI) ListBatches(ctx context.Context, limit int) ([]core.BatchInfo, error) {
 	url := p.config.BaseURL + batchesPath
 	if limit > 0 {

--- a/providers/openai/client_embeddings.go
+++ b/providers/openai/client_embeddings.go
@@ -14,6 +14,9 @@ import (
 const embeddingsPath = "/embeddings"
 
 // CreateEmbeddings generates embeddings for the given input texts.
+//
+// This call does not go through core.Client, so core.WithTimeout does not
+// apply; pass a context with a deadline if a bound is needed.
 func (p *OpenAI) CreateEmbeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
 	if err := p.requireAPIKey(); err != nil {
 		return nil, err

--- a/providers/openai/client_embeddings.go
+++ b/providers/openai/client_embeddings.go
@@ -53,7 +53,7 @@ func (p *OpenAI) CreateEmbeddings(ctx context.Context, req *core.EmbeddingReques
 
 	var oaiResp openAIEmbeddingResponse
 	if err := json.Unmarshal(respBody, &oaiResp); err != nil {
-		return nil, newDecodeError(err)
+		return nil, newDecodeError(err, respBody)
 	}
 
 	return mapEmbeddingResponse(&oaiResp, req), nil

--- a/providers/openai/client_embeddings.go
+++ b/providers/openai/client_embeddings.go
@@ -15,6 +15,10 @@ const embeddingsPath = "/embeddings"
 
 // CreateEmbeddings generates embeddings for the given input texts.
 func (p *OpenAI) CreateEmbeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	if err := p.requireAPIKey(); err != nil {
+		return nil, err
+	}
+
 	oaiReq := buildEmbeddingRequest(req)
 
 	body, err := json.Marshal(oaiReq)

--- a/providers/openai/client_responses.go
+++ b/providers/openai/client_responses.go
@@ -21,7 +21,7 @@ func (p *OpenAI) doResponsesChat(ctx context.Context, req *core.ChatRequest) (*c
 	// Marshal request body
 	body, err := json.Marshal(respReq)
 	if err != nil {
-		return nil, newDecodeError(err)
+		return nil, newDecodeError(err, nil)
 	}
 
 	// Create HTTP request
@@ -62,7 +62,7 @@ func (p *OpenAI) doResponsesChat(ctx context.Context, req *core.ChatRequest) (*c
 	// Parse response
 	var respResp responsesResponse
 	if err := json.Unmarshal(respBody, &respResp); err != nil {
-		return nil, newDecodeError(err)
+		return nil, newDecodeError(err, respBody)
 	}
 
 	// Map to Iris response

--- a/providers/openai/client_responses_test.go
+++ b/providers/openai/client_responses_test.go
@@ -850,3 +850,39 @@ func TestGPT54MiniRoutesToResponsesAPI(t *testing.T) {
 		t.Errorf("Output = %q, want pong", resp.Output)
 	}
 }
+
+func TestResponsesAPISendsStrictSchema(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode(responsesResponse{ID: "r", Status: "completed", OutputText: "{}"})
+	}))
+	defer srv.Close()
+
+	p := New("k", WithBaseURL(srv.URL))
+	_, err := p.Chat(context.Background(), &core.ChatRequest{
+		Model:          ModelGPT52,
+		Messages:       []core.Message{{Role: core.RoleUser, Content: "hi"}},
+		ResponseFormat: core.ResponseFormatJSONSchema,
+		JSONSchema: &core.JSONSchemaDefinition{
+			Name:   "person",
+			Strict: true,
+			Schema: json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{"n":{"type":"string"}},"required":["n"]}`),
+		},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	text, _ := body["text"].(map[string]any)
+	format, _ := text["format"].(map[string]any)
+	if format["type"] != "json_schema" {
+		t.Fatalf("text.format.type = %v, want json_schema; body=%v", format["type"], body)
+	}
+	if format["strict"] != true {
+		t.Errorf("text.format.strict = %v, want true", format["strict"])
+	}
+	if format["name"] != "person" {
+		t.Errorf("text.format.name = %v, want person", format["name"])
+	}
+}

--- a/providers/openai/errors.go
+++ b/providers/openai/errors.go
@@ -29,7 +29,8 @@ func newNetworkError(err error) error {
 	return normalize.NetworkError("openai", err)
 }
 
-// newDecodeError creates a ProviderError for JSON decode failures.
-func newDecodeError(err error) error {
-	return normalize.DecodeError("openai", err)
+// newDecodeError creates a ProviderError for JSON decode failures, preserving
+// the raw body that failed to decode.
+func newDecodeError(err error, body []byte) error {
+	return normalize.DecodeErrorWithBody("openai", err, body)
 }

--- a/providers/openai/errors_test.go
+++ b/providers/openai/errors_test.go
@@ -118,9 +118,10 @@ func TestNormalizeErrorInvalidJSON(t *testing.T) {
 		t.Fatal("expected ProviderError")
 	}
 
-	// Should use HTTP status text as fallback
-	if pErr.Message != "Bad Request" {
-		t.Errorf("Message = %q, want %q", pErr.Message, "Bad Request")
+	// Should surface the real (non-empty) body instead of the generic
+	// HTTP status text.
+	if pErr.Message != "not json" {
+		t.Errorf("Message = %q, want %q", pErr.Message, "not json")
 	}
 }
 
@@ -176,7 +177,7 @@ func TestNewNetworkError(t *testing.T) {
 
 func TestNewDecodeError(t *testing.T) {
 	originalErr := errors.New("unexpected EOF")
-	err := newDecodeError(originalErr)
+	err := newDecodeError(originalErr, []byte(`{"malformed`))
 
 	var pErr *core.ProviderError
 	if !errors.As(err, &pErr) {
@@ -185,5 +186,9 @@ func TestNewDecodeError(t *testing.T) {
 
 	if !errors.Is(err, core.ErrDecode) {
 		t.Error("expected error to wrap ErrDecode")
+	}
+
+	if pErr.Body != `{"malformed` {
+		t.Errorf("Body = %q, want %q", pErr.Body, `{"malformed`)
 	}
 }

--- a/providers/openai/mapping_responses.go
+++ b/providers/openai/mapping_responses.go
@@ -66,7 +66,36 @@ func buildResponsesRequest(req *core.ChatRequest, stream bool) *responsesRequest
 		}
 	}
 
+	// Map response format for structured output
+	if tf := mapResponsesTextFormat(req); tf != nil {
+		respReq.Text = &responsesText{Format: tf}
+	}
+
 	return respReq
+}
+
+// mapResponsesTextFormat converts Iris response format to the Responses API's
+// text.format shape. Mirrors mapResponseFormat in mapping.go for the Chat
+// Completions API, adjusted for the Responses API's flatter format object.
+func mapResponsesTextFormat(req *core.ChatRequest) *responsesTextFormat {
+	switch req.ResponseFormat {
+	case core.ResponseFormatJSON:
+		return &responsesTextFormat{Type: "json_object"}
+	case core.ResponseFormatJSONSchema:
+		if req.JSONSchema == nil {
+			return nil
+		}
+		strict := req.JSONSchema.Strict
+		return &responsesTextFormat{
+			Type:   "json_schema",
+			Name:   req.JSONSchema.Name,
+			Schema: req.JSONSchema.Schema,
+			Strict: &strict,
+		}
+	default:
+		// ResponseFormatText or empty: no format constraint
+		return nil
+	}
 }
 
 // buildResponsesInput creates the input for a Responses API request.

--- a/providers/openai/models.go
+++ b/providers/openai/models.go
@@ -89,6 +89,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.6",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -102,6 +103,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.6 Luna",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -115,6 +117,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.6 Sol",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -128,6 +131,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.6 Terra",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -142,6 +146,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.5",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -155,6 +160,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.5 Pro",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -169,6 +175,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.3 Codex",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -182,6 +189,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.3 Codex Spark",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -196,6 +204,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.4",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -209,6 +218,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.4 Pro",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -222,6 +232,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.4 Mini",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -235,6 +246,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.4 Nano",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -249,6 +261,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.2",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -262,6 +275,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.2 Pro",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -275,6 +289,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.2 Codex",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -289,6 +304,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.1",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -302,6 +318,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.1 Codex",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -315,6 +332,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.1 Codex Mini",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -328,6 +346,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5.1 Codex Max",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -342,6 +361,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -355,6 +375,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5 Mini",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -368,6 +389,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5 Nano",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -380,6 +402,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5 Pro",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -393,6 +416,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5 Codex",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -406,6 +430,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-5 Thinking",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -420,6 +445,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-4.1",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -432,6 +458,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-4.1 Mini",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -444,6 +471,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-4.1 Nano",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -457,6 +485,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-4o",
 		APIEndpoint: core.APIEndpointCompletions,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -467,6 +496,7 @@ var models = []core.ModelInfo{
 		DisplayName: "GPT-4o Mini",
 		APIEndpoint: core.APIEndpointCompletions,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -529,6 +559,7 @@ var models = []core.ModelInfo{
 		DisplayName: "o4-mini",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -542,6 +573,7 @@ var models = []core.ModelInfo{
 		DisplayName: "o4-mini Deep Research",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -555,6 +587,7 @@ var models = []core.ModelInfo{
 		DisplayName: "o3",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -568,6 +601,7 @@ var models = []core.ModelInfo{
 		DisplayName: "o3-pro",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -581,6 +615,7 @@ var models = []core.ModelInfo{
 		DisplayName: "o3-mini",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -594,6 +629,7 @@ var models = []core.ModelInfo{
 		DisplayName: "o1",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,
@@ -606,6 +642,7 @@ var models = []core.ModelInfo{
 		DisplayName: "o1 Pro",
 		APIEndpoint: core.APIEndpointResponses,
 		Capabilities: []core.Feature{
+			core.FeatureStructuredOutput,
 			core.FeatureChat,
 			core.FeatureChatStreaming,
 			core.FeatureToolCalling,

--- a/providers/openai/provider.go
+++ b/providers/openai/provider.go
@@ -81,6 +81,22 @@ func (p *OpenAI) Supports(feature core.Feature) bool {
 	}
 }
 
+// requireAPIKey returns a descriptive *core.ProviderError wrapping
+// core.ErrUnauthorized when the configured API key is empty (or
+// whitespace-only). Callers must invoke this before building or sending any
+// HTTP request so misconfigured clients fail fast instead of round-tripping
+// to the API for a guaranteed 401.
+func (p *OpenAI) requireAPIKey() error {
+	if p.config.APIKey.IsEmpty() {
+		return &core.ProviderError{
+			Provider: "openai",
+			Message:  "API key is empty; pass it to openai.New(key) or configure your secret source",
+			Err:      core.ErrUnauthorized,
+		}
+	}
+	return nil
+}
+
 // buildHeaders constructs the HTTP headers for an API request.
 func (p *OpenAI) buildHeaders() http.Header {
 	headers := make(http.Header)
@@ -112,6 +128,9 @@ func (p *OpenAI) buildHeaders() http.Header {
 // Chat sends a non-streaming chat request.
 // Routes to either the Chat Completions API or Responses API based on the model.
 func (p *OpenAI) Chat(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	if err := p.requireAPIKey(); err != nil {
+		return nil, err
+	}
 	if p.shouldUseResponsesAPI(req.Model) {
 		return p.doResponsesChat(ctx, req)
 	}
@@ -121,6 +140,9 @@ func (p *OpenAI) Chat(ctx context.Context, req *core.ChatRequest) (*core.ChatRes
 // StreamChat sends a streaming chat request.
 // Routes to either the Chat Completions API or Responses API based on the model.
 func (p *OpenAI) StreamChat(ctx context.Context, req *core.ChatRequest) (*core.ChatStream, error) {
+	if err := p.requireAPIKey(); err != nil {
+		return nil, err
+	}
 	if p.shouldUseResponsesAPI(req.Model) {
 		return p.doResponsesStreamChat(ctx, req)
 	}

--- a/providers/openai/streaming.go
+++ b/providers/openai/streaming.go
@@ -88,7 +88,7 @@ func (p *OpenAI) doStreamChat(ctx context.Context, req *core.ChatRequest) (*core
 	// Marshal request body
 	body, err := json.Marshal(oaiReq)
 	if err != nil {
-		return nil, newDecodeError(err)
+		return nil, newDecodeError(err, nil)
 	}
 
 	// Create HTTP request
@@ -198,7 +198,7 @@ func (p *OpenAI) processSSEStream(
 		// Parse chunk
 		var chunk openAIStreamChunk
 		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
-			errCh <- newDecodeError(err)
+			errCh <- newDecodeError(err, []byte(payload))
 			return
 		}
 

--- a/providers/openai/streaming_responses.go
+++ b/providers/openai/streaming_responses.go
@@ -22,7 +22,7 @@ func (p *OpenAI) doResponsesStreamChat(ctx context.Context, req *core.ChatReques
 	// Marshal request body
 	body, err := json.Marshal(respReq)
 	if err != nil {
-		return nil, newDecodeError(err)
+		return nil, newDecodeError(err, nil)
 	}
 
 	// Create HTTP request
@@ -152,7 +152,7 @@ func (p *OpenAI) processResponsesStream(
 		// Parse event
 		var event responsesStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
-			errCh <- newDecodeError(err)
+			errCh <- newDecodeError(err, []byte(payload))
 			return
 		}
 

--- a/providers/openai/types_responses.go
+++ b/providers/openai/types_responses.go
@@ -18,6 +18,22 @@ type responsesRequest struct {
 	Truncation         string                   `json:"truncation,omitempty"`
 	Stream             bool                     `json:"stream,omitempty"`
 	StreamOptions      *streamOptions           `json:"stream_options,omitempty"`
+	Text               *responsesText           `json:"text,omitempty"`
+}
+
+// responsesText configures structured output formatting for the Responses API.
+type responsesText struct {
+	Format *responsesTextFormat `json:"format,omitempty"`
+}
+
+// responsesTextFormat specifies the output format constraint sent as
+// text.format in a Responses API request. Type is "text", "json_object",
+// or "json_schema"; Name, Schema, and Strict apply only to json_schema.
+type responsesTextFormat struct {
+	Type   string          `json:"type"`
+	Name   string          `json:"name,omitempty"`
+	Schema json.RawMessage `json:"schema,omitempty"`
+	Strict *bool           `json:"strict,omitempty"`
 }
 
 // responsesToolResources contains configuration for built-in tools.

--- a/providers/perplexity/errors_test.go
+++ b/providers/perplexity/errors_test.go
@@ -69,7 +69,7 @@ func TestNormalizeError(t *testing.T) {
 			body:         []byte(`{}`),
 			requestID:    "",
 			wantCode:     "",
-			wantMsg:      "Bad Gateway",
+			wantMsg:      "{}",
 			wantSentinel: core.ErrServer,
 		},
 		{
@@ -78,7 +78,7 @@ func TestNormalizeError(t *testing.T) {
 			body:         []byte(`not json`),
 			requestID:    "req-def",
 			wantCode:     "",
-			wantMsg:      "Bad Request",
+			wantMsg:      "not json",
 			wantSentinel: core.ErrBadRequest,
 		},
 		{
@@ -96,7 +96,7 @@ func TestNormalizeError(t *testing.T) {
 			body:         []byte(`{}`),
 			requestID:    "",
 			wantCode:     "",
-			wantMsg:      "I'm a teapot",
+			wantMsg:      "{}",
 			wantSentinel: core.ErrServer,
 		},
 	}

--- a/providers/voyageai/errors.go
+++ b/providers/voyageai/errors.go
@@ -3,9 +3,25 @@ package voyageai
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
+	"github.com/petal-labs/iris/core"
 	"github.com/petal-labs/iris/providers/internal/normalize"
 )
+
+// maxBodyLen caps how much of a raw response body is retained on
+// ProviderError.Body so oversized error pages don't bloat logs.
+const maxBodyLen = 4096
+
+// truncateBody trims and caps a raw response body for inclusion on
+// ProviderError.Body.
+func truncateBody(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if len(s) > maxBodyLen {
+		return s[:maxBodyLen] + "…(truncated)"
+	}
+	return s
+}
 
 // voyageErrorResponse represents an error response from the Voyage AI API.
 type voyageErrorResponse struct {
@@ -19,11 +35,18 @@ func normalizeError(status int, body []byte, requestID string) error {
 	_ = json.Unmarshal(body, &errResp)
 
 	message := errResp.Detail
+	bodyStr := truncateBody(body)
 	if message == "" {
-		message = http.StatusText(status)
+		if bodyStr != "" {
+			message = bodyStr // surface the real body instead of http.StatusText
+		} else {
+			message = http.StatusText(status)
+		}
 	}
 
-	return normalize.ProviderError("voyageai", status, requestID, "", message, normalize.SentinelForStatus(status))
+	pe := normalize.ProviderError("voyageai", status, requestID, "", message, normalize.SentinelForStatus(status))
+	pe.(*core.ProviderError).Body = bodyStr
+	return pe
 }
 
 // newNetworkError creates a ProviderError for network-related failures.

--- a/providers/zai/errors.go
+++ b/providers/zai/errors.go
@@ -4,10 +4,25 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/petal-labs/iris/core"
 	"github.com/petal-labs/iris/providers/internal/normalize"
 )
+
+// maxBodyLen caps how much of a raw response body is retained on
+// ProviderError.Body so oversized error pages don't bloat logs.
+const maxBodyLen = 4096
+
+// truncateBody trims and caps a raw response body for inclusion on
+// ProviderError.Body.
+func truncateBody(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if len(s) > maxBodyLen {
+		return s[:maxBodyLen] + "…(truncated)"
+	}
+	return s
+}
 
 // ErrToolArgsInvalidJSON is returned when tool call arguments contain invalid JSON.
 var ErrToolArgsInvalidJSON = errors.New("tool args invalid json")
@@ -27,8 +42,13 @@ func normalizeError(status int, body []byte, requestID string) error {
 	_ = json.Unmarshal(body, &errResp)
 
 	message := errResp.Error.Message
+	bodyStr := truncateBody(body)
 	if message == "" {
-		message = http.StatusText(status)
+		if bodyStr != "" {
+			message = bodyStr // surface the real body instead of http.StatusText
+		} else {
+			message = http.StatusText(status)
+		}
 	}
 
 	code := errResp.Error.Code
@@ -37,7 +57,9 @@ func normalizeError(status int, body []byte, requestID string) error {
 		http.StatusNotFound: core.ErrBadRequest,
 	})
 
-	return normalize.ProviderError("zai", status, requestID, code, message, sentinel)
+	pe := normalize.ProviderError("zai", status, requestID, code, message, sentinel)
+	pe.(*core.ProviderError).Body = bodyStr
+	return pe
 }
 
 // newNetworkError creates a ProviderError for network-related failures.


### PR DESCRIPTION
## Summary

Hardens three areas a downstream app hit: **error propagation**, **structured-output contracts**, and **streaming/timeout robustness**. Driven by a four-part source audit; the concrete symptoms were non-descriptive errors, models returning non-strict document shapes, and API keys "not working."

## Errors

- **Preserve error chains** (`normalize.NetworkError`/`DecodeError` now wrap the underlying error via `%w`). This restores `errors.Is(err, core.ErrTimeout)` end-to-end for real providers on both unary and streaming paths (previously the wrap dropped `context.DeadlineExceeded`, silently defeating the execution timeout), and fixes a retry misclassification where timed-out requests were treated as retryable.
- **`core.ProviderError.Body`** — the raw response body is preserved (truncated) instead of being replaced with generic `http.StatusText`, so a provider's real 4xx reason is no longer lost. Applied to the shared normalizer + the four hand-rolled ones; OpenAI decode paths include the body.
- **`DrainStream`** no longer swallows a late stream error and returns false success (channel-substitution race with `wrapStreamWithTelemetry`).

## Structured output

- **Responses API now sends structured output** (`text.format.{type,name,schema,strict}`) — previously silently dropped for all GPT-5.x models incl. `gpt-5.4-mini`. Wire shape verified against OpenAI docs.
- **Strict by default**: `ResponseJSONSchema` forces `strict:true`; `ResponseJSONSchemaNonStrict` is the opt-out. A new `validateStrictSchema` (`core.ErrInvalidSchema`) rejects non-strict-compatible schemas up front instead of letting the API reject them.
- **Hard error on unsupported** (`core.ErrStructuredOutputUnsupported`): a `ResponseJSONSchema` request against a provider or catalog model lacking `FeatureStructuredOutput` fails loud before the call (provider- and model-level). Scoped to json_schema; plain `ResponseJSON()` json_object mode is not hard-gated.

## Provider keys

- **`core.NewSecret` trims whitespace** (fixes Azure Key Vault trailing-newline corruption of the `Authorization` header for all providers); `Secret.IsEmpty()` is whitespace-aware; OpenAI `Chat`/`StreamChat`/`CreateEmbeddings` return a descriptive `ErrUnauthorized` on an empty key before any HTTP call.

## Timeouts

- **Batch poll** (`BatchWaiter.Wait`) bounds each poll by the remaining `maxWait` so a stuck poll can't hang forever.
- Doc comments added to non-chat entry points (embeddings, batch) noting `core.WithTimeout` does not apply there and a caller context deadline is required.

## Behavior changes (see change doc for migration)

1. `ResponseJSONSchema` is strict by default — a previously-loose schema may now return `ErrInvalidSchema`; make it strict-compatible or use `ResponseJSONSchemaNonStrict`.
2. `ResponseJSONSchema` against an unsupported provider/model now returns `ErrStructuredOutputUnsupported` instead of silently returning unconstrained output.

New exported symbols: `ProviderError.Body`, `ErrInvalidSchema`, `ErrStructuredOutputUnsupported`, `ResponseJSONSchemaNonStrict`.

## Deferred (documented in the change doc)

Other providers' empty-key preflight; native structured output on Anthropic/Ollama; broad non-chat timeout coverage; client-side re-validation of returned JSON; a `validateStrictSchema` implicit-object (untyped node) edge case.

## Verification

Full `go test -race ./...` passes; `go build ./...` and `gofmt` clean. Each change is TDD'd with tests asserting the real behavior (error chains, wire JSON, gate ordering, the DrainStream race under `-race`, the batch hang bound). Structured-output verification against `gpt-5.4-mini` routing was done via httptest (a live round-trip needs Key Vault credentials).
