### PR TITLE
docs: sync README and docs with v0.15/v0.16 behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Iris solves these problems by providing:
 - Automatic retry with exponential backoff
 - Telemetry hooks for observability
 - Configurable non-fatal warning routing with `core.WithWarningHandler(...)`
-- Normalized error types across providers
+- Normalized error types across providers, including `core.ErrTimeout`, `core.ErrInvalidSchema`, and `core.ErrStructuredOutputUnsupported`, plus a `Body` field on `core.ProviderError` carrying the raw (truncated) response body
 
 ### CLI Features
 - `iris chat` - Send chat completions from the terminal
@@ -382,6 +382,31 @@ if resp.Reasoning != nil && len(resp.Reasoning.Summary) > 0 {
 }
 ```
 
+### Timeouts
+
+`Chat`/`GetResponse` and `Stream` calls have a default 120-second execution timeout (`core.DefaultTimeout`). Adjust it client-wide with `core.WithTimeout(d)`, or per-call with `.Timeout(d)`:
+
+```go
+// Client-wide: raise the default to 5 minutes
+client := core.NewClient(provider, core.WithTimeout(5*time.Minute))
+
+// Disable the default entirely (unbounded, unless ctx has its own deadline)
+client := core.NewClient(provider, core.WithTimeout(0))
+
+// Per-call override
+resp, err := client.Chat("gpt-4o").
+    User("Hello").
+    Timeout(30 * time.Second).
+    GetResponse(context.Background())
+
+if errors.Is(err, core.ErrTimeout) {
+    // errors.Is(err, context.DeadlineExceeded) also holds
+    fmt.Println("request timed out")
+}
+```
+
+Precedence: a deadline already on the caller's `ctx` always wins; otherwise the per-call `.Timeout(d)` applies; otherwise the client's default. This timeout only covers `Chat`/`Stream` — embeddings, batch, file, and image calls are not subject to it, so pass a `context.WithTimeout` deadline yourself for those. Per-provider `WithTimeout`/`Config.Timeout` options are deprecated in favor of `core.WithTimeout`.
+
 ### Streaming Responses
 
 ```go
@@ -484,6 +509,7 @@ schema := &core.JSONSchemaDefinition{
     Strict: true,
     Schema: json.RawMessage(`{
         "type": "object",
+        "additionalProperties": false,
         "properties": {
             "name": {"type": "string"},
             "age": {"type": "integer"}
@@ -499,6 +525,8 @@ resp, err := client.Chat("gpt-4o").
 
 // Output is guaranteed to match the schema
 ```
+
+`ResponseJSONSchema` is strict-by-default: it forces `schema.Strict = true` and validates the schema up front, so every object node in the schema must set `"additionalProperties": false` and list all of its properties in `"required"`. A schema that doesn't meet those constraints returns `core.ErrInvalidSchema` before any request is sent. Use `ResponseJSONSchemaNonStrict(schema)` to opt out and skip that validation. Requesting a schema against a provider or model that doesn't support structured output returns `core.ErrStructuredOutputUnsupported`, also before the call is made. Structured output is currently supported on OpenAI (both the Chat Completions and Responses API, GPT-5.x) and Google Gemini; other providers reject `ResponseJSONSchema` requests with that error. Plain `ResponseJSON()` (JSON mode) is not gated and works across providers that support `json_object`-style output.
 
 ### Conversation Management
 
@@ -803,6 +831,8 @@ secret := core.NewSecret(os.Getenv("OPENAI_API_KEY"))
 fmt.Println(secret)        // Prints: [REDACTED]
 apiKey := secret.Expose()  // Access actual value when needed
 ```
+
+`core.NewSecret` trims leading/trailing whitespace (including the trailing newlines some secret managers, like Azure Key Vault, append), so `Expose()` never returns a padded credential and `IsEmpty()` correctly treats whitespace-only values as empty. Passing an empty OpenAI key surfaces a descriptive `core.ErrUnauthorized` before any HTTP call is made.
 
 See [docs/SECURITY.md](docs/SECURITY.md) for comprehensive security documentation.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -215,7 +215,8 @@ type ProviderError struct {
     RequestID string
     Code      string
     Message   string
-    Err       error // Wraps sentinel error
+    Body      string // raw response body (truncated); preserved when Message lacks detail
+    Err       error  // Wraps sentinel error
 }
 ```
 
@@ -238,18 +239,77 @@ if errors.As(err, &pe) {
 }
 ```
 
+**Additional Sentinels**: Beyond the provider-classification errors above, three more sentinels cover request-shape and execution-budget failures rather than transport errors:
+
+```go
+var ErrTimeout                     = errors.New("execution timeout")
+var ErrInvalidSchema               = errors.New("invalid json schema for strict structured output")
+var ErrStructuredOutputUnsupported = errors.New("structured output not supported by this provider or model")
+```
+
+- `ErrTimeout` is returned when Iris's own execution timeout (see [Default Execution Timeout](#default-execution-timeout) below) elapses. It wraps `context.DeadlineExceeded`, so `errors.Is(err, context.DeadlineExceeded)` holds in addition to `errors.Is(err, core.ErrTimeout)`.
+- `ErrInvalidSchema` is returned by `ChatBuilder.validate()` when a strict-mode JSON schema (`ResponseJSONSchema`) doesn't set `"additionalProperties": false` and list every property in `"required"` at every object node.
+- `ErrStructuredOutputUnsupported` is returned when `ResponseJSONSchema` targets a provider or model that doesn't declare `core.FeatureStructuredOutput`. Both are returned before any request is sent.
+
 ### Retry Integration
 
 The retry policy uses sentinel errors to determine retryability:
 
 ```go
 func isRetryable(err error) bool {
+    if errors.Is(err, context.Canceled) { return false }         // Caller gave up
+    if errors.Is(err, context.DeadlineExceeded) { return false } // Ctx or Iris timeout elapsed
     if errors.Is(err, ErrUnauthorized) { return false }  // Don't retry auth errors
     if errors.Is(err, ErrRateLimited) { return true }    // Retry rate limits
     if errors.Is(err, ErrServer) { return true }         // Retry server errors
     // ...
 }
 ```
+
+---
+
+## Default Execution Timeout
+
+### Decision
+`Chat`/`GetResponse` and `Stream` calls carry a default 120-second execution timeout (`core.DefaultTimeout`), applied automatically unless the caller already supplies a context deadline.
+
+### Rationale
+
+**Fail Fast by Default**: A hung provider connection or a stalled stream would otherwise block a caller indefinitely. A sane default timeout means "silently hangs forever" is not a failure mode users have to guard against manually.
+
+**Opt-In Escape Hatch**: Some workloads (long reasoning chains, large batch-style single calls) legitimately need more than 120 seconds, or none at all. `core.WithTimeout(d)` on the client and `.Timeout(d)` per call both allow raising the bound; `core.WithTimeout(0)` disables it entirely.
+
+**Scoped to Interactive Calls**: The timeout applies only to `Chat`/`Stream`. Embeddings, batch, file, and image calls are not bounded by it — those workloads have their own duration expectations (batch jobs can run for hours) and callers are expected to supply their own `context.WithTimeout` deadline when they want one.
+
+### Precedence
+
+```go
+func (b *ChatBuilder) effectiveTimeout(ctx context.Context) time.Duration {
+    if _, hasDeadline := ctx.Deadline(); hasDeadline {
+        return 0 // caller's ctx deadline always wins
+    }
+    if b.timeout > 0 {
+        return b.timeout // per-call ChatBuilder.Timeout() next
+    }
+    return b.client.timeout // client default (core.DefaultTimeout unless overridden)
+}
+```
+
+1. A deadline already present on the caller's `ctx` always wins — Iris never shortens or overrides it.
+2. Otherwise, a per-call `ChatBuilder.Timeout(d)` applies.
+3. Otherwise, the client's default (`core.DefaultTimeout`, or whatever `core.WithTimeout(d)` set at `NewClient` time) applies.
+
+When the Iris-applied timeout (not a caller-supplied ctx deadline) elapses, the call returns `core.ErrTimeout`, which wraps `context.DeadlineExceeded` so both `errors.Is(err, core.ErrTimeout)` and `errors.Is(err, context.DeadlineExceeded)` hold.
+
+### Migration Note
+
+Per-provider timeout options (e.g. `openai.WithTimeout`, `Config.Timeout` on each provider) are deprecated in favor of `core.WithTimeout` on the `Client`, which is provider-agnostic and composes with the precedence rules above.
+
+### Alternatives Considered
+
+**No Default Timeout**: Leave calls unbounded unless the caller sets a ctx deadline. Rejected because it silently reproduces the "hangs forever" failure mode that most callers don't think to guard against until it bites them in production.
+
+**Timeout Only at the Provider Level**: Keep timeout configuration per-provider only. Rejected because it's inconsistent across providers, doesn't compose with `core.ErrTimeout` classification, and forces callers to configure the same thing N times for N providers.
 
 ---
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -4,19 +4,21 @@ This document provides a comprehensive comparison of the AI providers supported 
 
 ## Feature Support Matrix
 
-| Provider | Chat | Streaming | Tool Calling | Reasoning | Built-in Tools | Response Chain | Embeddings | Reranking |
-|----------|------|-----------|--------------|-----------|----------------|----------------|------------|-----------|
-| OpenAI | Yes | Yes | Yes | Yes* | Yes* | Yes* | No | No |
-| Anthropic | Yes | Yes | Yes | No | No | No | No | No |
-| Gemini | Yes | Yes | Yes | Yes | No | No | No | No |
-| xAI (Grok) | Yes | Yes | Yes | Yes* | No | No | No | No |
-| Perplexity | Yes | Yes | Yes* | Yes* | No | No | No | No |
-| Z.ai (GLM) | Yes | Yes | Yes | Yes* | No | No | No | No |
-| Ollama | Yes | Yes | Yes* | Yes* | No | No | No | No |
-| HuggingFace | Yes | Yes | Yes | No | No | No | No | No |
-| VoyageAI | No | No | No | No | No | No | Yes | Yes |
+| Provider | Chat | Streaming | Tool Calling | Reasoning | Built-in Tools | Response Chain | Structured Output | Embeddings | Reranking |
+|----------|------|-----------|--------------|-----------|----------------|----------------|--------------------|------------|-----------|
+| OpenAI | Yes | Yes | Yes | Yes* | Yes* | Yes* | Yes | No | No |
+| Anthropic | Yes | Yes | Yes | No | No | No | No† | No | No |
+| Gemini | Yes | Yes | Yes | Yes | No | No | Yes | No | No |
+| xAI (Grok) | Yes | Yes | Yes | Yes* | No | No | No† | No | No |
+| Perplexity | Yes | Yes | Yes* | Yes* | No | No | No† | No | No |
+| Z.ai (GLM) | Yes | Yes | Yes | Yes* | No | No | No† | No | No |
+| Ollama | Yes | Yes | Yes* | Yes* | No | No | No† | No | No |
+| HuggingFace | Yes | Yes | Yes | No | No | No | No† | No | No |
+| VoyageAI | No | No | No | No | No | No | N/A | Yes | Yes |
 
 *Feature availability varies by model. See model-specific tables below.
+
+†"No" means a `ResponseJSONSchema` request against this provider fails fast with `core.ErrStructuredOutputUnsupported` before being sent, rather than silently ignoring the schema (the prior behavior). Plain `ResponseJSON()` (`json_object` mode) is unaffected and is not gated by this check.
 
 ## Provider Details
 
@@ -63,6 +65,8 @@ This document provides a comprehensive comparison of the AI providers supported 
 | o1-pro | o1 Pro | Yes | No | Enhanced reasoning |
 
 **Image Generation Models**: gpt-image-1.5, gpt-image-1, gpt-image-1-mini, dall-e-3, dall-e-2, chatgpt-image-latest
+
+**Structured Output**: `ResponseJSONSchema` works on both the Chat Completions API and the Responses API (GPT-5.x), mapped to each API's native `response_format`/`text.format` shape respectively. Requesting it against a Chat Completions-only model that lacks `core.FeatureStructuredOutput` (e.g. gpt-3.5-turbo) fails with `core.ErrStructuredOutputUnsupported`.
 
 **Usage Example**:
 ```go

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -93,7 +93,7 @@ ks.MigrateToV2()
 
 ## Secret Type
 
-Iris uses a `core.Secret` type for API keys to prevent accidental exposure:
+Iris uses a `core.Secret` type for API keys to prevent accidental exposure. `core.NewSecret` trims leading and trailing whitespace from the input — including trailing newlines that secret managers such as Azure Key Vault commonly append — so `Expose()` never returns a padded credential. `IsEmpty()` is whitespace-aware too: a value consisting only of whitespace is treated as empty, not as a present-but-blank secret.
 
 ```go
 import "github.com/petal-labs/iris/core"


### PR DESCRIPTION
## Summary

Syncs the human-facing docs with the behavior shipped in v0.15.0 (default execution timeout) and v0.16.0 (reliability hardening). Fixes one broken example and documents new/changed behavior. **Docs only — no source changes.**

## Broken example fixed

`README.md` "strict schema enforcement" example set `Strict: true` but omitted `"additionalProperties": false`. Under strict-by-default validation that example now always fails with `core.ErrInvalidSchema` before the request. Added `"additionalProperties": false` (it already listed all properties in `required`), so it validates and runs.

## Behavior now documented

- **README:** strict-by-default structured output (`ErrInvalidSchema`, `ResponseJSONSchemaNonStrict` opt-out), hard-error on unsupported provider/model (`ErrStructuredOutputUnsupported`), structured output now working on the Responses API (GPT-5.x); a Timeouts note (120s default on Chat/Stream, `core.WithTimeout`, `WithTimeout(0)` to disable, not applied to embeddings/batch/images); key trimming + empty-key `ErrUnauthorized`; the new error types + `ProviderError.Body` in the features list.
- **docs/ARCHITECTURE.md:** `ProviderError.Body` field; the three new sentinels (`ErrTimeout`, `ErrInvalidSchema`, `ErrStructuredOutputUnsupported`, with `ErrTimeout` wrapping `context.DeadlineExceeded`); a default-execution-timeout subsection; context errors shown non-retryable in the retry sample.
- **docs/PROVIDERS.md:** a Structured Output column (Yes: OpenAI, Gemini; No: Anthropic/xAI/Perplexity/Z.ai/Ollama/HuggingFace — now a fast `ErrStructuredOutputUnsupported` rather than silent ignore; N/A: VoyageAI); OpenAI note that structured output works on both Chat Completions and the Responses API.
- **docs/SECURITY.md:** `NewSecret` trims whitespace (trailing newlines from secret managers) and `IsEmpty()` is whitespace-aware.

## Verification

Examples audit found no runnable code broken (`go build`/`go vet ./examples/...` clean; the one structured-output example already uses a strict-compatible schema and a supported model). Every documented claim was independently verified against source, and the fixed README schema traced through `validateStrictSchema` to confirm it passes.

## Note

Azure AI Foundry (which also supports structured output) is absent from the PROVIDERS.md feature matrix entirely — a pre-existing omission left untouched to avoid overlapping the separate in-flight Azure Foundry doc.
