### PR TITLE
docs(changelog): backfill compare links for 0.14-0.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,7 +181,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Telemetry hooks and retry policies
 - Typed error handling
 
-[Unreleased]: https://github.com/petal-labs/iris/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/petal-labs/iris/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/petal-labs/iris/compare/v0.15.0...v0.16.0
+[0.15.0]: https://github.com/petal-labs/iris/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/petal-labs/iris/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/petal-labs/iris/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/petal-labs/iris/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/petal-labs/iris/compare/v0.10.0...v0.11.0


### PR DESCRIPTION
Follow-up to the v0.16.0 release. The CHANGELOG's link-reference footer was stale (Unreleased pointed at v0.13.0 and the 0.14.0/0.15.0/0.16.0 compare links were missing). Backfills them so every version heading links to its diff.