### PR TITLE
fix: harden provider API key handling (issue #47)

### DIFF
--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -18,8 +18,7 @@ type Config struct {
 
 // ProviderConfig holds configuration for a specific provider.
 type ProviderConfig struct {
-	APIKeyRef string `yaml:"api_key_ref"`
-	BaseURL   string `yaml:"base_url,omitempty"`
+	BaseURL string `yaml:"base_url,omitempty"`
 }
 
 // DefaultConfigPath returns the default configuration file path for the current platform.

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -76,10 +76,8 @@ default_model: gpt-4o
 
 providers:
   openai:
-    api_key_ref: openai_key
     base_url: https://api.openai.com/v1
   anthropic:
-    api_key_ref: anthropic_key
 `
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "config.yaml")
@@ -103,9 +101,6 @@ providers:
 	}
 
 	openai := cfg.Providers["openai"]
-	if openai.APIKeyRef != "openai_key" {
-		t.Errorf("openai.APIKeyRef = %q, want openai_key", openai.APIKeyRef)
-	}
 	if openai.BaseURL != "https://api.openai.com/v1" {
 		t.Errorf("openai.BaseURL = %q, want https://api.openai.com/v1", openai.BaseURL)
 	}
@@ -172,8 +167,7 @@ func TestConfigGetProvider(t *testing.T) {
 	cfg := &Config{
 		Providers: map[string]ProviderConfig{
 			"openai": {
-				APIKeyRef: "openai_key",
-				BaseURL:   "https://api.openai.com/v1",
+				BaseURL: "https://api.openai.com/v1",
 			},
 		},
 	}
@@ -182,8 +176,8 @@ func TestConfigGetProvider(t *testing.T) {
 	if pc == nil {
 		t.Fatal("GetProvider(openai) returned nil")
 	}
-	if pc.APIKeyRef != "openai_key" {
-		t.Errorf("APIKeyRef = %q, want openai_key", pc.APIKeyRef)
+	if pc.BaseURL != "https://api.openai.com/v1" {
+		t.Errorf("BaseURL = %q, want https://api.openai.com/v1", pc.BaseURL)
 	}
 
 	pc = cfg.GetProvider("nonexistent")

--- a/docs/changes/2026-08-01_v0.17.0_issue-47-key-handling.md
+++ b/docs/changes/2026-08-01_v0.17.0_issue-47-key-handling.md
@@ -1,0 +1,247 @@
+---
+date: 2026-08-01
+version: v0.17.0
+feature: Provider API Key Handling Hardening (Issue #47)
+product: iris
+change_type: feature
+affected_components: [providers/internal/normalize/errors.go, providers/openai/provider.go, providers/anthropic/provider.go, providers/anthropic/options.go, providers/gemini/provider.go, providers/gemini/options.go, providers/xai/provider.go, providers/xai/options.go, providers/perplexity/provider.go, providers/perplexity/options.go, providers/huggingface/provider.go, providers/huggingface/options.go, providers/zai/provider.go, providers/zai/options.go, providers/voyageai/client_embeddings.go, providers/voyageai/client_contextualized.go, providers/voyageai/client_rerank.go, providers/voyageai/options.go, providers/azurefoundry/provider.go, providers/azurefoundry/options.go, cli/config/config.go]
+related_frds: [docs/superpowers/plans/2026-08-01-issue-47-key-handling.md]
+---
+
+## Summary
+
+This change closes out issue #47 by making empty/missing API keys fail fast and consistently across every Iris provider that requires one. A new shared helper, `normalize.RequireAPIKey`, is now called at the top of `Chat`/`StreamChat` (or the equivalent request-entry method) for eight providers, returning `core.ErrUnauthorized` before any HTTP request is attempted. Every one of those eight providers also gained a `WithAPIKey(key string) Option` so a key can be set or overridden via functional options, not just the `New(...)` constructor argument. Azure AI Foundry's existing "no auth configured" error now additionally wraps `core.ErrUnauthorized` alongside its own `ErrNoAuth`, so callers can check for the shared sentinel across all providers uniformly. Finally, the dead `ProviderConfig.APIKeyRef` field was removed from the CLI config struct, since it was never read anywhere.
+
+## Motivation
+
+Prior to this work, only OpenAI had an empty-key preflight (added in the previous `v0.16.0` SDK reliability pass); every other provider let an empty key reach the HTTP layer and discovered the problem only via the provider's own 401 response, which is slower, makes a wasted network call, and produces provider-specific (rather than uniform) error messages. Issue #47 tracked closing that gap consistently. `normalize.RequireAPIKey` centralizes the check so all providers report the same shape of error (`*core.ProviderError` wrapping `core.ErrUnauthorized`) instead of each provider hand-rolling its own check (as OpenAI previously did). The `WithAPIKey` options give callers a way to set the key through the same functional-options pattern already used for every other per-provider setting, instead of forcing the key through the constructor's positional argument only. The `APIKeyRef` removal is unrelated to auth flow but was bundled in because it was a silent no-op field discovered during this audit — no code in the repo ever read `ProviderConfig.APIKeyRef` to resolve a secret, so keeping it around was actively misleading to anyone writing a `config.yaml`.
+
+## What Changed
+
+### New Additions
+
+- `normalize.RequireAPIKey(provider string, key core.Secret) error` (`providers/internal/normalize/errors.go`) — returns a `*core.ProviderError` wrapping `core.ErrUnauthorized` when `key.IsEmpty()` (whitespace-only counts as empty, per `core.Secret.IsEmpty()`'s existing `strings.TrimSpace` behavior). Returns `nil` when the key is present. Message: `"API key is empty; provide a non-empty key to <provider>.New or configure your secret source"`.
+- `WithAPIKey(key string) Option` added to eight providers (all in each provider's `options.go`, each setting `c.APIKey = core.NewSecret(key)`): `providers/anthropic`, `providers/gemini`, `providers/xai`, `providers/perplexity`, `providers/huggingface`, `providers/voyageai`, `providers/zai`, `providers/azurefoundry`. (`providers/ollama` already had `WithAPIKey`; `providers/openai` sets its key only via the constructor and was not changed in this pass.)
+- Preflight checks added at the top of the request-entry methods below, each calling `normalize.RequireAPIKey("<provider>", p.config.APIKey)` and returning immediately on error:
+  - `providers/anthropic`: `Chat`, `StreamChat`
+  - `providers/gemini`: `Chat`, `StreamChat`
+  - `providers/xai`: `Chat`, `StreamChat`
+  - `providers/perplexity`: `Chat`, `StreamChat`
+  - `providers/huggingface`: `Chat`, `StreamChat`
+  - `providers/zai`: `Chat`, `StreamChat`
+  - `providers/voyageai`: `CreateEmbeddings`, `CreateContextualizedEmbeddings`, `Rerank`
+
+### Modifications
+
+- `providers/openai/provider.go`: `(*OpenAI) requireAPIKey()` (added in the prior `v0.16.0` pass) now delegates to the shared helper instead of duplicating the empty-key check inline:
+  ```go
+  // before
+  func (p *OpenAI) requireAPIKey() error {
+      if p.config.APIKey.IsEmpty() {
+          return &core.ProviderError{
+              Provider: "openai",
+              Message:  "API key is empty; pass it to openai.New(key) or configure your secret source",
+              Err:      core.ErrUnauthorized,
+          }
+      }
+      return nil
+  }
+
+  // after
+  func (p *OpenAI) requireAPIKey() error {
+      return normalize.RequireAPIKey("openai", p.config.APIKey)
+  }
+  ```
+  Note the message text changed slightly (`"API key is empty; provide a non-empty key to openai.New or configure your secret source"`) since it now comes from the shared helper's generic template rather than OpenAI's original hand-written copy. Callers matching on message text (rather than `errors.Is(err, core.ErrUnauthorized)`) will see a different string.
+- `providers/azurefoundry/provider.go`, `buildHeaders`: the no-auth branch now wraps both sentinels instead of just `ErrNoAuth`:
+  ```go
+  // before
+  } else {
+      return nil, ErrNoAuth
+  }
+
+  // after
+  } else {
+      return nil, fmt.Errorf("%w: %w", core.ErrUnauthorized, ErrNoAuth)
+  }
+  ```
+  `errors.Is(err, ErrNoAuth)` continues to hold (existing behavior preserved), and `errors.Is(err, core.ErrUnauthorized)` now also holds (new). The dual-auth flow itself (API key vs. `TokenCredential`) is unchanged — this only affects the error returned when *neither* is configured.
+- `cli/config/config.go`: `ProviderConfig.APIKeyRef string` (tag `yaml:"api_key_ref"`) removed. `ProviderConfig` now has only `BaseURL string`.
+
+### Removals
+
+- `cli/config.ProviderConfig.APIKeyRef` (field + its `yaml:"api_key_ref"` tag) — removed. It was never read by any code path (grep confirmed no consumer); a `config.yaml` with an `api_key_ref:` key under a provider entry parsed into this field and then went nowhere. Test assertions on the field in `cli/config/config_test.go` were removed alongside it.
+
+## Technical Specification
+
+### Data Schemas / Types
+
+```go
+// providers/internal/normalize/errors.go
+
+// RequireAPIKey returns a descriptive *core.ProviderError wrapping
+// core.ErrUnauthorized when the API key is empty (or whitespace-only), so a
+// provider can fail fast before making an unauthenticated request. Returns nil
+// when the key is present.
+func RequireAPIKey(provider string, key core.Secret) error
+```
+
+```go
+// cli/config/config.go
+
+// ProviderConfig holds configuration for a specific provider.
+type ProviderConfig struct {
+    BaseURL string `yaml:"base_url,omitempty"`
+    // APIKeyRef removed in this change — was unread dead config.
+}
+```
+
+### API Endpoints
+
+N/A — Iris is an SDK with no daemon HTTP API surface in this repo. This change only affects when Iris returns a local error versus making an outbound HTTP request to a provider.
+
+### CLI Interface
+
+N/A — no CLI commands were added or changed. The only CLI-adjacent change is the removal of the `api_key_ref` YAML key's backing field (see Removals and Breaking Changes below); no command signature or output format changed.
+
+### Go Package API
+
+```go
+// providers/internal/normalize/errors.go
+func RequireAPIKey(provider string, key core.Secret) error
+
+// Added identically (same signature, same semantics) to each of:
+// providers/anthropic, providers/gemini, providers/xai, providers/perplexity,
+// providers/huggingface, providers/voyageai, providers/zai, providers/azurefoundry
+func WithAPIKey(key string) Option
+```
+
+Usage contract: `WithAPIKey` follows the same last-option-wins semantics as every other functional option in Iris — each provider's `New(...)` constructor sets `Config.APIKey` from its positional argument first, then applies `opts ...Option` in order, so `WithAPIKey` passed after construction always overrides the constructor argument, and if `WithAPIKey` is passed more than once, the last one in the `opts` slice wins.
+
+### Configuration
+
+No new configuration fields were added. One field was removed: `providers:.<name>.api_key_ref` in `config.yaml` is still accepted by the YAML parser (unknown-field tolerance is unchanged), but it no longer has a backing Go field, so it is fully ignored — the same runtime behavior as before this change (it was never wired to a secret resolver), just without the misleading struct field. `base_url` under each provider entry is unaffected.
+
+## Usage Examples
+
+### Example: Empty key fails fast on a previously-unguarded provider (anthropic)
+
+```go
+provider := anthropic.New("") // empty key
+client := core.NewClient(provider)
+
+_, err := client.Chat(anthropic.ModelClaudeOpus45).User("hi").GetResponse(ctx)
+// err wraps core.ErrUnauthorized:
+// "API key is empty; provide a non-empty key to anthropic.New or configure your secret source"
+// No HTTP request is made.
+```
+
+### Example: WithAPIKey overrides the constructor argument (last-wins)
+
+```go
+provider := gemini.New(
+    "constructor-key",
+    gemini.WithAPIKey("override-key"), // wins — applied after New's initial assignment
+)
+// provider's effective API key is "override-key"
+
+providerTwo := gemini.New(
+    "constructor-key",
+    gemini.WithAPIKey("first-key"),
+    gemini.WithAPIKey("second-key"), // last WithAPIKey wins
+)
+// providerTwo's effective API key is "second-key"
+```
+
+### Example: azurefoundry no-auth error satisfies both sentinels
+
+```go
+provider := azurefoundry.New("https://test.openai.azure.com", "") // no key, no TokenCredential
+client := core.NewClient(provider)
+
+_, err := client.Chat(model).User("hi").GetResponse(ctx)
+if errors.Is(err, azurefoundry.ErrNoAuth) {
+    // still true — azurefoundry-specific check keeps working
+}
+if errors.Is(err, core.ErrUnauthorized) {
+    // now also true — generic cross-provider check works too
+}
+```
+
+### Example: deliberately-excluded paths still reach the provider with an empty key
+
+```go
+// voyageai Chat/StreamChat return core.ErrNotSupported regardless of key state —
+// not guarded by RequireAPIKey because they never make an HTTP call either way.
+p := voyageai.New("")
+_, err := p.Chat(ctx, req)
+// err is core.ErrNotSupported, not core.ErrUnauthorized.
+
+// huggingface's discovery methods (anonymous Hub API access) are also unguarded:
+hf := huggingface.New("")
+_, err = hf.ListModels(ctx, huggingface.ListModelsOptions{})
+// proceeds to the Hub API call even with an empty key, since these endpoints
+// support anonymous/unauthenticated access.
+
+// ollama's key is optional by design (local instances need none) and was
+// excluded entirely from this pass.
+o := ollama.New(ollama.WithAPIKey(""))
+_, err = o.Chat(ctx, req)
+// proceeds normally against a local Ollama instance; empty key is expected, not an error.
+```
+
+## Integration Notes
+
+- `normalize.RequireAPIKey` reuses `core.Secret.IsEmpty()`, which already `strings.TrimSpace`s before checking (from the `v0.16.0` hardening pass), so a whitespace-only key (e.g., a trailing newline from a secret manager) is treated as empty and caught by this preflight too, not just a literal `""`.
+- The preflight is placed at the very top of each guarded method, before any request-building or HTTP-client work, so it is a synchronous, side-effect-free check — no partial state is created and no network call happens when it fires.
+- `providers/openai` was not re-guarded in this pass; its `requireAPIKey()` (added previously) was refactored to call the new shared helper for consistency, but its call sites (`Chat`, `StreamChat`, `CreateEmbeddings`) are unchanged.
+- Every guarded provider's `New(...)` constructor was verified to set `Config.APIKey` before applying `opts ...Option`, which is what makes `WithAPIKey`'s last-wins semantics hold uniformly across all eight providers — this was a specific verification step in this task's implementation, not an assumption.
+- The three deliberate exclusions from this pass, and why each is safe to leave unguarded:
+  - **`providers/ollama`**: API key is optional by design (local instances typically need none; Ollama Cloud is the only case that uses one). Guarding `Chat`/`StreamChat` with a hard `ErrUnauthorized` on empty key would break the common local-instance use case.
+  - **`providers/huggingface` discovery methods** (`GetModelStatus`, `GetModelProviders`, `ListModels` in `providers/huggingface/discovery.go`): these call the public Hugging Face Hub API, which supports anonymous, unauthenticated access for public model metadata. Guarding them would incorrectly reject valid anonymous calls.
+  - **`providers/voyageai` `Chat`/`StreamChat`**: these already return `core.ErrNotSupported` unconditionally (Voyage AI is an embeddings/rerank-only provider with no chat capability), so they never reach an HTTP call regardless of key state — a `RequireAPIKey` check there would be dead code ahead of an already-guaranteed error.
+
+## Breaking Changes & Migration
+
+1. **Providers now hard-error on an empty API key before the request, for eight additional providers.** Previously, `anthropic`, `gemini`, `xai`, `perplexity`, `huggingface`, `zai`, and `voyageai` (embeddings/rerank/contextualized-embeddings paths) would send an unauthenticated request and let the provider's API return its own 401/403. That request now never leaves the process — the call returns synchronously with a `*core.ProviderError` wrapping `core.ErrUnauthorized`. **Migration:** any caller that was relying on the old round-trip behavior (e.g., asserting on a specific provider HTTP status code, or a mock/test server that expected to receive the unauthenticated request and respond with its own error body) must instead check for `errors.Is(err, core.ErrUnauthorized)` before the call reaches the network, and update any test fixtures that assumed the request would be sent. Callers already using `errors.Is(err, core.ErrUnauthorized)` (the recommended pattern) need no changes — the sentinel is unchanged, only the point at which it's returned moved earlier.
+2. **`azurefoundry`'s no-auth error message changed shape via double-wrapping**, from a bare `ErrNoAuth` to `fmt.Errorf("%w: %w", core.ErrUnauthorized, ErrNoAuth)`. `errors.Is(err, ErrNoAuth)` still passes (unchanged), but `err.Error()` now reads as `"unauthorized: azurefoundry: no authentication configured (provide API key or token credential)"` instead of just `"azurefoundry: no authentication configured (provide API key or token credential)"`. **Migration:** code that string-matches the exact error text must update to the new prefixed string, or switch to `errors.Is`.
+3. **`cli/config.ProviderConfig.APIKeyRef` field removed.** Any Go code outside this repo that referenced `config.ProviderConfig{}.APIKeyRef` directly (as a struct field, not via YAML) will fail to compile. A `config.yaml` file with an `api_key_ref:` entry under a provider still parses without error (YAML decoding tolerates the unknown key), and its value is silently ignored — identical runtime behavior to before this change, since the field was never wired to anything. **Migration:** remove any direct Go references to `.APIKeyRef`; no `config.yaml` file changes are required, since the key was already inert.
+
+## Deferred / Out of Scope
+
+- **Files and images entry points.** No provider's file-upload or image-generation/editing methods (e.g., OpenAI's Files API, image endpoints) were audited or guarded with an empty-key preflight in this pass. Scope was limited to `Chat`/`StreamChat` and VoyageAI's embeddings/rerank surface, per the issue #47 plan.
+- **`providers/ollama` intentionally excluded.** Its API key is optional by design for local instances; adding a hard preflight would be a behavior regression for the common case, not a fix. If a future need arises to validate an Ollama Cloud key specifically (as opposed to a local instance with no key), that would need a way to distinguish the two configurations, which does not currently exist.
+- **`providers/huggingface` discovery methods excluded.** `GetModelStatus`, `GetModelProviders`, and `ListModels` remain unguarded because they support anonymous access to the public Hub API; only `Chat`/`StreamChat` (which require an authenticated Inference Providers call) were guarded.
+- **`providers/voyageai` `Chat`/`StreamChat` excluded.** Both already return `core.ErrNotSupported` unconditionally, so adding `RequireAPIKey` there would be unreachable dead code.
+- **`providers/openai`'s message text left unreconciled with the new generic wording elsewhere.** OpenAI's `requireAPIKey()` now delegates to `normalize.RequireAPIKey`, which changed its exact error string (see Breaking Changes #1 context) to match the new shared wording. This was accepted as within scope for OpenAI specifically (it already had the check; this pass only unified the implementation), but no attempt was made to preserve OpenAI's original wording as a special case.
+
+## Testing Notes
+
+- `go test -race ./...` — all packages pass, no data races reported. Full output:
+  ```
+  ok  	github.com/petal-labs/iris	1.220s
+  ok  	github.com/petal-labs/iris/cli/commands	1.375s
+  ok  	github.com/petal-labs/iris/cli/config	1.177s
+  ok  	github.com/petal-labs/iris/cli/keystore	(cached)
+  ok  	github.com/petal-labs/iris/core	(cached)
+  ok  	github.com/petal-labs/iris/internal/gen/models	(cached)
+  ok  	github.com/petal-labs/iris/providers	(cached)
+  ok  	github.com/petal-labs/iris/providers/anthropic	1.915s
+  ok  	github.com/petal-labs/iris/providers/azurefoundry	1.826s
+  ok  	github.com/petal-labs/iris/providers/gemini	4.086s
+  ok  	github.com/petal-labs/iris/providers/huggingface	2.283s
+  ok  	github.com/petal-labs/iris/providers/internal/normalize	1.525s
+  ok  	github.com/petal-labs/iris/providers/internal/toolcalls	(cached)
+  ok  	github.com/petal-labs/iris/providers/ollama	2.426s
+  ok  	github.com/petal-labs/iris/providers/openai	2.320s
+  ok  	github.com/petal-labs/iris/providers/perplexity	1.847s
+  ok  	github.com/petal-labs/iris/providers/voyageai	1.775s
+  ok  	github.com/petal-labs/iris/providers/xai	1.847s
+  ok  	github.com/petal-labs/iris/providers/zai	1.777s
+  ok  	github.com/petal-labs/iris/testing	(cached)
+  ok  	github.com/petal-labs/iris/tests	1.624s
+  ok  	github.com/petal-labs/iris/tools	(cached)
+  ```
+- `go build ./...` succeeds. `gofmt -l .` reports no files needing formatting on this branch's changes (the pre-existing untracked `CLAUDE.md` and `docs/changes/2026-03-18_*azure*` files are unrelated to this branch and were not touched by this work).
+- New test coverage added across Tasks 1–6: `providers/internal/normalize/errors_test.go` (`TestRequireAPIKey`), and a new `auth_test.go` per provider — `providers/anthropic/auth_test.go`, `providers/gemini/auth_test.go`, `providers/xai/auth_test.go`, `providers/perplexity/auth_test.go`, `providers/huggingface/auth_test.go`, `providers/zai/auth_test.go`, `providers/voyageai/auth_test.go`, `providers/azurefoundry/auth_test.go` (asserts both `errors.Is(err, ErrNoAuth)` and `errors.Is(err, core.ErrUnauthorized)`). Each provider's `options_test.go` gained coverage for `WithAPIKey`. `cli/config/config_test.go` had its `APIKeyRef` assertions removed in `TestConfigGetProvider` and the YAML-parsing test.
+- Verification steps run for this task (Task 7): `git log --oneline main..HEAD` and `git diff --stat main...HEAD` were used to enumerate every file touched by Tasks 1–6 and cross-checked against this doc's `affected_components` and per-provider preflight/option lists above; each provider's `Chat`/`StreamChat` (or embeddings/rerank) diff was read directly (not inferred) to confirm the exact guard placement and error wrapping described here.

--- a/docs/superpowers/plans/2026-08-01-issue-47-key-handling.md
+++ b/docs/superpowers/plans/2026-08-01-issue-47-key-handling.md
@@ -1,0 +1,252 @@
+# Issue #47 Key Handling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Resolve issue #47 — (13) empty-key preflight for non-OpenAI providers, (14) remove the dead `api_key_ref` config field, (15) add `WithAPIKey` consistently across providers.
+
+**Architecture:** A shared `normalize.RequireAPIKey(provider, key)` helper produces a descriptive `core.ProviderError{Err: core.ErrUnauthorized}`. Providers that require a key call it at the top of their HTTP entry points before any request. `WithAPIKey` is a trivial functional option mirroring Ollama's existing one.
+
+**Tech Stack:** Go 1.24, stdlib + `net/http/httptest` for tests.
+
+## Global Constraints
+
+- Module `github.com/petal-labs/iris` (go 1.24). Branch: `fix/47-key-handling`.
+- New exported symbol: `normalize.RequireAPIKey(provider string, key core.Secret) error`; a `WithAPIKey(key string) Option` per provider (8 new).
+- Behavior change: providers that require a key now fail fast with `core.ErrUnauthorized` before any HTTP call when the key is empty/whitespace.
+- **Exclusions (do NOT add a hard preflight):** Ollama (key optional for local), huggingface discovery methods (`GetModelStatus`/`GetModelProviders`/`ListModels` — anonymous access by design), voyageai `Chat`/`StreamChat` (already return `core.ErrNotSupported` with no HTTP).
+- `WithAPIKey` mirrors `providers/ollama/options.go`: `func WithAPIKey(key string) Option { return func(c *Config) { c.APIKey = core.NewSecret(key) } }`. Every provider's `New` sets `APIKey` before the opts loop, so last-wins works.
+- Conventional commits, subject ≤ 72 chars, no trailing period/backticks/emoji.
+- Every task ends green: `go test ./...`, `go build ./...`, `gofmt -l` clean.
+
+---
+
+### Task 1: Shared RequireAPIKey helper + refactor OpenAI
+
+**Files:**
+- Modify: `providers/internal/normalize/errors.go`
+- Modify: `providers/openai/provider.go` (refactor `requireAPIKey` to delegate)
+- Test: `providers/internal/normalize/errors_test.go`
+
+**Interfaces:**
+- Produces: `func RequireAPIKey(provider string, key core.Secret) error` — returns `*core.ProviderError{Provider, Message, Err: core.ErrUnauthorized}` when `key.IsEmpty()`, else nil.
+
+- [ ] **Step 1: Failing test** in `providers/internal/normalize/errors_test.go`:
+
+```go
+func TestRequireAPIKey(t *testing.T) {
+	if err := RequireAPIKey("acme", core.NewSecret("sk-x")); err != nil {
+		t.Fatalf("non-empty key should pass: %v", err)
+	}
+	err := RequireAPIKey("acme", core.NewSecret("  "))
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("empty key err = %v, want ErrUnauthorized", err)
+	}
+	var pe *core.ProviderError
+	if !errors.As(err, &pe) || pe.Provider != "acme" {
+		t.Errorf("want *core.ProviderError with Provider=acme, got %#v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement** in `normalize/errors.go`:
+
+```go
+// RequireAPIKey returns a descriptive *core.ProviderError wrapping
+// core.ErrUnauthorized when the API key is empty (or whitespace-only), so a
+// provider can fail fast before making an unauthenticated request. Returns nil
+// when the key is present.
+func RequireAPIKey(provider string, key core.Secret) error {
+	if key.IsEmpty() {
+		return &core.ProviderError{
+			Provider: provider,
+			Message:  "API key is empty; provide a non-empty key to " + provider + ".New or configure your secret source",
+			Err:      core.ErrUnauthorized,
+		}
+	}
+	return nil
+}
+```
+
+Refactor `providers/openai/provider.go` `requireAPIKey()` to delegate: `return normalize.RequireAPIKey("openai", p.config.APIKey)`. Confirm `normalize` is already imported in that file (it is, for error helpers). Keep the three call sites (`Chat`, `StreamChat`, `CreateEmbeddings`) unchanged.
+
+- [ ] **Step 4: Run** `go test ./providers/internal/normalize/ ./providers/openai/ -run 'RequireAPIKey|EmptyKey|Auth' -v` — expect PASS (OpenAI's existing auth tests must still pass with the delegated message; they assert `errors.Is(_, ErrUnauthorized)` + no HTTP, not the exact string — verify by reading `providers/openai/auth_test.go`).
+- [ ] **Step 5: Commit** `git commit -m "feat(providers): add shared RequireAPIKey preflight helper"`
+
+---
+
+### Task 2: Empty-key preflight for chat providers
+
+**Files:**
+- Modify: `providers/{anthropic,gemini,xai,perplexity,huggingface,zai}/provider.go` (guard `Chat` + `StreamChat`)
+- Test: one new `auth_test.go` per provider (or a shared representative) — at minimum anthropic + gemini + one Bearer provider
+
+**Interfaces:**
+- Consumes: `normalize.RequireAPIKey` (Task 1).
+
+- [ ] **Step 1: Failing test** — add `providers/anthropic/auth_test.go` (mirror `providers/openai/auth_test.go`):
+
+```go
+package anthropic
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.Chat(context.Background(), &core.ChatRequest{
+		Model: "claude-3-5-sonnet-20241022", Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}
+```
+
+Use a real model constant for each provider (grep its `models.go` for a valid `Model*` const or use a plausible id string). Add an equivalent test for gemini and one Bearer provider (xai). For the remaining providers, at minimum ensure `go test ./...` covers compilation; a per-provider auth test is preferred but the shared pattern is proven by these three.
+
+- [ ] **Step 2: Run — expect FAIL** (request currently goes through).
+- [ ] **Step 3: Implement** — at the top of each provider's `Chat` and `StreamChat` methods, add:
+
+```go
+	if err := normalize.RequireAPIKey("<provider>", p.config.APIKey); err != nil {
+		return nil, err
+	}
+```
+
+Use the correct provider-name string per package (`"anthropic"`, `"gemini"`, `"xai"`, `"perplexity"`, `"huggingface"`, `"zai"`). Read each `provider.go` first to place the guard correctly (before `doChat`/`doStreamChat`). Confirm `normalize` is imported in each (add the import if missing). **Do NOT touch huggingface `discovery.go` methods.**
+
+- [ ] **Step 4: Run** `go test ./providers/... -run 'EmptyKey|Auth' -v` then `go test ./...` — expect PASS.
+- [ ] **Step 5: Commit** `git commit -m "feat(providers): fail fast on empty API key for chat providers"`
+
+---
+
+### Task 3: Empty-key preflight for voyageai
+
+**Files:**
+- Modify: `providers/voyageai/client_embeddings.go`, `client_contextualized.go`, `client_rerank.go`
+- Test: `providers/voyageai/auth_test.go`
+
+**Interfaces:** Consumes `normalize.RequireAPIKey`.
+
+- [ ] **Step 1: Failing test** — `providers/voyageai/auth_test.go` asserting `CreateEmbeddings` with an empty key returns `core.ErrUnauthorized` before HTTP (mirror the Task 2 test, using `p.CreateEmbeddings(ctx, &core.EmbeddingRequest{...})`; read `core.EmbeddingRequest` shape and a valid voyage model id from `providers/voyageai/models.go`). Add cases for `Rerank` and `CreateContextualizedEmbeddings` too.
+- [ ] **Step 2: Run — expect FAIL.**
+- [ ] **Step 3: Implement** — add the `normalize.RequireAPIKey("voyageai", p.config.APIKey)` guard at the top of `CreateEmbeddings`, `CreateContextualizedEmbeddings`, and `Rerank` (return `nil, err`). Read each method for the correct return signature.
+- [ ] **Step 4: Run** `go test ./providers/voyageai/ -v` — expect PASS.
+- [ ] **Step 5: Commit** `git commit -m "feat(voyageai): fail fast on empty API key for embeddings"`
+
+---
+
+### Task 4: Align azurefoundry ErrNoAuth with ErrUnauthorized
+
+**Files:**
+- Modify: `providers/azurefoundry/provider.go` (the `ErrNoAuth` return in `buildHeaders`)
+- Test: `providers/azurefoundry/errors_test.go` or a new auth test
+
+**Interfaces:** none new.
+
+- [ ] **Step 1: Failing test** — assert that the no-auth error (from a provider built with an empty key and no token credential, triggering `buildHeaders`) satisfies BOTH `errors.Is(err, ErrNoAuth)` AND `errors.Is(err, core.ErrUnauthorized)`. Read `providers/azurefoundry/errors_test.go` for the existing `ErrNoAuth` test pattern and how to trigger `buildHeaders` (e.g. via `Chat` with empty key + no credential against an httptest server).
+- [ ] **Step 2: Run — expect FAIL** (currently `ErrNoAuth` is a plain sentinel, so `errors.Is(_, core.ErrUnauthorized)` is false).
+- [ ] **Step 3: Implement** — keep `ErrNoAuth` as-is, but where `buildHeaders` returns it, wrap so both hold:
+
+```go
+	} else {
+		return nil, fmt.Errorf("%w: %w", core.ErrUnauthorized, ErrNoAuth)
+	}
+```
+
+Confirm `fmt` and `core` are imported. Do NOT change azurefoundry's dual-auth logic (token-credential path stays first). Any existing test asserting `errors.Is(err, ErrNoAuth)` must still pass (multi-`%w` preserves it).
+
+- [ ] **Step 4: Run** `go test ./providers/azurefoundry/ -v` — expect PASS.
+- [ ] **Step 5: Commit** `git commit -m "fix(azurefoundry): make no-auth error satisfy ErrUnauthorized"`
+
+---
+
+### Task 5: WithAPIKey option for all providers
+
+**Files:**
+- Modify: `providers/{anthropic,gemini,xai,perplexity,huggingface,voyageai,zai,azurefoundry}/options.go`
+- Test: `providers/anthropic/options_test.go` (+ representative others)
+
+**Interfaces:**
+- Produces: `WithAPIKey(key string) Option` in each of the 8 packages.
+
+- [ ] **Step 1: Failing test** — add to `providers/anthropic/options_test.go`:
+
+```go
+func TestWithAPIKeyOverridesConstructorArg(t *testing.T) {
+	p := New("ctor-key", WithAPIKey("opt-key"))
+	if got := p.config.APIKey.Expose(); got != "opt-key" {
+		t.Errorf("APIKey = %q, want opt-key (option should win over constructor)", got)
+	}
+}
+```
+
+(Confirm the field access path — `p.config.APIKey.Expose()` — matches the package; same-package white-box test.) Add an equivalent test for at least gemini and azurefoundry.
+
+- [ ] **Step 2: Run — expect FAIL** (`WithAPIKey` undefined).
+- [ ] **Step 3: Implement** — add to each provider's `options.go` (mirror `providers/ollama/options.go:45-51`):
+
+```go
+// WithAPIKey sets the API key, overriding any value passed to New.
+func WithAPIKey(key string) Option {
+	return func(c *Config) {
+		c.APIKey = core.NewSecret(key)
+	}
+}
+```
+
+Confirm `core` is imported in each `options.go` (add if missing). For azurefoundry, place it near `WithTokenCredential`.
+
+- [ ] **Step 4: Run** `go test ./providers/... -run 'WithAPIKey' -v` then `go build ./...` — expect PASS.
+- [ ] **Step 5: Commit** `git commit -m "feat(providers): add WithAPIKey option across providers"`
+
+---
+
+### Task 6: Remove dead api_key_ref config field
+
+**Files:**
+- Modify: `cli/config/config.go` (remove `APIKeyRef` from `ProviderConfig`)
+- Modify: `cli/config/config_test.go` (remove the 5 references)
+
+**Interfaces:** Removes `ProviderConfig.APIKeyRef`.
+
+- [ ] **Step 1: Confirm dead** — `rg -n "APIKeyRef" .` must show only `cli/config/config.go` (definition) and `cli/config/config_test.go`. If any production reference appears, STOP and report.
+- [ ] **Step 2: Implement** — delete the `APIKeyRef string \`yaml:"api_key_ref"\`` line from `ProviderConfig` (leaving `BaseURL`). Remove the field from the test structs/assertions at `cli/config/config_test.go:106,107,175,185,186` (read the file to remove cleanly without breaking surrounding test logic).
+- [ ] **Step 3: Run** `go test ./cli/config/ -v` then `go build ./...` — expect PASS.
+- [ ] **Step 4: Commit** `git commit -m "refactor(cli): remove unused api_key_ref config field"`
+
+---
+
+### Task 7: Change doc + full verification
+
+**Files:**
+- Create: `docs/changes/2026-08-01_v0.0.0-dev_issue-47-key-handling.md` (version: use the next unreleased — `v0.17.0` if a release is planned, else `v0.0.0-dev`; check latest tag with `git tag --sort=-v:refname | head -1` and use the next minor)
+
+- [ ] **Step 1:** `go test -race ./...` — expect PASS.
+- [ ] **Step 2:** `go build ./...`; `gofmt -l .` (ignore pre-existing untracked files).
+- [ ] **Step 3:** Write the change doc per repo `CLAUDE.md` structure. `product: iris`, `change_type: feature`. `affected_components` lists every file touched across Tasks 1-6. Document: the new `normalize.RequireAPIKey`, the per-provider empty-key preflight (and the deliberate exclusions: Ollama, huggingface discovery, voyageai chat), the azurefoundry `ErrNoAuth` alignment, the 8 new `WithAPIKey` options (last-wins), and the `api_key_ref` removal. Include a "Breaking Changes & Migration" note: providers now hard-error on an empty key before the request. Include a "Deferred" note: files/images entry points not yet guarded.
+- [ ] **Step 4: Commit** `git commit -m "docs: change doc for issue 47 key handling"`
+
+---
+
+## Self-Review
+
+**Spec coverage:** Item 13 → Tasks 1-4 (helper + chat providers + voyageai + azurefoundry). Item 14 → Task 6. Item 15 → Task 5. Change doc → Task 7. Exclusions (Ollama, hf discovery, voyageai chat) are encoded in the Global Constraints and Task scoping.
+
+**Placeholder scan:** No TBD. Model-id/field-shape lookups (per-provider model constants, `core.EmbeddingRequest`) are called out with explicit "read/grep" instructions and fallbacks.
+
+**Type consistency:** `RequireAPIKey(provider string, key core.Secret) error`, `WithAPIKey(key string) Option`, `core.ErrUnauthorized`, `core.ProviderError` used consistently. Every `New` sets `APIKey` before the opts loop (verified in investigation), so `WithAPIKey` last-wins holds across all 8 providers.

--- a/providers/anthropic/auth_test.go
+++ b/providers/anthropic/auth_test.go
@@ -1,0 +1,47 @@
+package anthropic
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.Chat(context.Background(), &core.ChatRequest{
+		Model:    ModelClaudeSonnet5,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}
+
+func TestStreamChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    ModelClaudeSonnet5,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}

--- a/providers/anthropic/options.go
+++ b/providers/anthropic/options.go
@@ -46,6 +46,13 @@ const DefaultFilesAPIBeta = "files-api-2025-04-14"
 // Option configures the Anthropic provider.
 type Option func(*Config)
 
+// WithAPIKey sets the API key, overriding any value passed to New.
+func WithAPIKey(key string) Option {
+	return func(c *Config) {
+		c.APIKey = core.NewSecret(key)
+	}
+}
+
 // WithBaseURL sets the API base URL.
 func WithBaseURL(url string) Option {
 	return func(c *Config) {

--- a/providers/anthropic/options_test.go
+++ b/providers/anthropic/options_test.go
@@ -81,3 +81,10 @@ func TestDefaultFilesAPIBeta(t *testing.T) {
 		t.Errorf("DefaultFilesAPIBeta = %q, want 'files-api-2025-04-14'", DefaultFilesAPIBeta)
 	}
 }
+
+func TestWithAPIKeyOverridesConstructorArg(t *testing.T) {
+	p := New("ctor-key", WithAPIKey("opt-key"))
+	if got := p.config.APIKey.Expose(); got != "opt-key" {
+		t.Errorf("APIKey = %q, want opt-key (option should win over constructor)", got)
+	}
+}

--- a/providers/anthropic/provider.go
+++ b/providers/anthropic/provider.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
 )
 
 // DefaultAPIKeyEnvVar is the environment variable name for the Anthropic API key.
@@ -100,11 +101,17 @@ func (p *Anthropic) buildHeaders() http.Header {
 
 // Chat sends a non-streaming chat request.
 func (p *Anthropic) Chat(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	if err := normalize.RequireAPIKey("anthropic", p.config.APIKey); err != nil {
+		return nil, err
+	}
 	return p.doChat(ctx, req)
 }
 
 // StreamChat sends a streaming chat request.
 func (p *Anthropic) StreamChat(ctx context.Context, req *core.ChatRequest) (*core.ChatStream, error) {
+	if err := normalize.RequireAPIKey("anthropic", p.config.APIKey); err != nil {
+		return nil, err
+	}
 	return p.doStreamChat(ctx, req)
 }
 

--- a/providers/azurefoundry/auth_test.go
+++ b/providers/azurefoundry/auth_test.go
@@ -1,0 +1,66 @@
+package azurefoundry
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+// TestBuildHeadersNoAuth verifies that buildHeaders returns ErrNoAuth when
+// neither a token credential nor an API key is configured, and that the
+// returned error also satisfies errors.Is(err, core.ErrUnauthorized) so
+// callers can use the shared sentinel across all providers.
+func TestBuildHeadersNoAuth(t *testing.T) {
+	p := New("https://test.openai.azure.com", "")
+
+	_, err := p.buildHeaders(context.Background())
+	if err == nil {
+		t.Fatal("buildHeaders() error = nil, want error")
+	}
+
+	if !errors.Is(err, ErrNoAuth) {
+		t.Errorf("expected error to wrap ErrNoAuth, got %v", err)
+	}
+
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Errorf("expected error to wrap core.ErrUnauthorized, got %v", err)
+	}
+}
+
+// TestChatNoAuthSatisfiesErrUnauthorized verifies the no-auth error surfaces
+// through the public Chat path (empty API key, no token credential) and
+// still satisfies both errors.Is(err, ErrNoAuth) and
+// errors.Is(err, core.ErrUnauthorized). The request must never reach the
+// server since buildHeaders fails first.
+func TestChatNoAuthSatisfiesErrUnauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("server should not be called when no auth is configured")
+	}))
+	defer server.Close()
+
+	p := New(server.URL, "")
+
+	req := &core.ChatRequest{
+		Model: "test-model",
+		Messages: []core.Message{
+			{Role: core.RoleUser, Content: "hello"},
+		},
+	}
+
+	_, err := p.Chat(context.Background(), req)
+	if err == nil {
+		t.Fatal("Chat() error = nil, want error")
+	}
+
+	if !errors.Is(err, ErrNoAuth) {
+		t.Errorf("expected error to wrap ErrNoAuth, got %v", err)
+	}
+
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Errorf("expected error to wrap core.ErrUnauthorized, got %v", err)
+	}
+}

--- a/providers/azurefoundry/options.go
+++ b/providers/azurefoundry/options.go
@@ -134,3 +134,10 @@ func WithTokenCredential(credential TokenCredential) Option {
 		c.TokenCredential = credential
 	}
 }
+
+// WithAPIKey sets the API key, overriding any value passed to New.
+func WithAPIKey(key string) Option {
+	return func(c *Config) {
+		c.APIKey = core.NewSecret(key)
+	}
+}

--- a/providers/azurefoundry/options_test.go
+++ b/providers/azurefoundry/options_test.go
@@ -1,0 +1,10 @@
+package azurefoundry
+
+import "testing"
+
+func TestWithAPIKeyOverridesConstructorArg(t *testing.T) {
+	p := New("https://x", "ctor-key", WithAPIKey("opt-key"))
+	if got := p.config.APIKey.Expose(); got != "opt-key" {
+		t.Errorf("APIKey = %q, want opt-key (option should win over constructor)", got)
+	}
+}

--- a/providers/azurefoundry/provider.go
+++ b/providers/azurefoundry/provider.go
@@ -3,6 +3,7 @@ package azurefoundry
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -177,7 +178,7 @@ func (p *AzureFoundry) buildHeaders(ctx context.Context) (http.Header, error) {
 	} else if !p.config.APIKey.IsEmpty() {
 		headers.Set("api-key", p.config.APIKey.Expose())
 	} else {
-		return nil, ErrNoAuth
+		return nil, fmt.Errorf("%w: %w", core.ErrUnauthorized, ErrNoAuth)
 	}
 
 	// Copy any extra headers

--- a/providers/gemini/auth_test.go
+++ b/providers/gemini/auth_test.go
@@ -1,0 +1,47 @@
+package gemini
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.Chat(context.Background(), &core.ChatRequest{
+		Model:    ModelGemini35Flash,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}
+
+func TestStreamChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    ModelGemini35Flash,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}

--- a/providers/gemini/options.go
+++ b/providers/gemini/options.go
@@ -34,6 +34,13 @@ const DefaultBaseURL = "https://generativelanguage.googleapis.com"
 // Option configures the Gemini provider.
 type Option func(*Config)
 
+// WithAPIKey sets the API key, overriding any value passed to New.
+func WithAPIKey(key string) Option {
+	return func(c *Config) {
+		c.APIKey = core.NewSecret(key)
+	}
+}
+
 // WithBaseURL sets the API base URL.
 func WithBaseURL(url string) Option {
 	return func(c *Config) {

--- a/providers/gemini/options_test.go
+++ b/providers/gemini/options_test.go
@@ -42,3 +42,10 @@ func TestWithTimeout(t *testing.T) {
 		t.Errorf("Timeout = %v, want 60s", cfg.Timeout)
 	}
 }
+
+func TestWithAPIKeyOverridesConstructorArg(t *testing.T) {
+	p := New("ctor-key", WithAPIKey("opt-key"))
+	if got := p.config.APIKey.Expose(); got != "opt-key" {
+		t.Errorf("APIKey = %q, want opt-key (option should win over constructor)", got)
+	}
+}

--- a/providers/gemini/provider.go
+++ b/providers/gemini/provider.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
 )
 
 // Environment variable names for the Gemini API key.
@@ -103,11 +104,17 @@ func (p *Gemini) buildHeaders() http.Header {
 
 // Chat sends a non-streaming chat request.
 func (p *Gemini) Chat(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	if err := normalize.RequireAPIKey("gemini", p.config.APIKey); err != nil {
+		return nil, err
+	}
 	return p.doChat(ctx, req)
 }
 
 // StreamChat sends a streaming chat request.
 func (p *Gemini) StreamChat(ctx context.Context, req *core.ChatRequest) (*core.ChatStream, error) {
+	if err := normalize.RequireAPIKey("gemini", p.config.APIKey); err != nil {
+		return nil, err
+	}
 	return p.doStreamChat(ctx, req)
 }
 

--- a/providers/huggingface/auth_test.go
+++ b/providers/huggingface/auth_test.go
@@ -1,0 +1,47 @@
+package huggingface
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.Chat(context.Background(), &core.ChatRequest{
+		Model:    "meta-llama/Llama-3.1-8B-Instruct",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}
+
+func TestStreamChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    "meta-llama/Llama-3.1-8B-Instruct",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}

--- a/providers/huggingface/options.go
+++ b/providers/huggingface/options.go
@@ -61,6 +61,13 @@ type Config struct {
 // Option configures the Hugging Face provider.
 type Option func(*Config)
 
+// WithAPIKey sets the API key, overriding any value passed to New.
+func WithAPIKey(key string) Option {
+	return func(c *Config) {
+		c.APIKey = core.NewSecret(key)
+	}
+}
+
 // WithBaseURL sets the inference API base URL.
 func WithBaseURL(url string) Option {
 	return func(c *Config) {

--- a/providers/huggingface/options_test.go
+++ b/providers/huggingface/options_test.go
@@ -1,0 +1,10 @@
+package huggingface
+
+import "testing"
+
+func TestWithAPIKeyOverridesConstructorArg(t *testing.T) {
+	p := New("ctor-key", WithAPIKey("opt-key"))
+	if got := p.config.APIKey.Expose(); got != "opt-key" {
+		t.Errorf("APIKey = %q, want opt-key (option should win over constructor)", got)
+	}
+}

--- a/providers/huggingface/provider.go
+++ b/providers/huggingface/provider.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
 )
 
 // Environment variable names for the Hugging Face API token.
@@ -103,11 +104,17 @@ func (p *HuggingFace) buildHeaders() http.Header {
 
 // Chat sends a non-streaming chat request.
 func (p *HuggingFace) Chat(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	if err := normalize.RequireAPIKey("huggingface", p.config.APIKey); err != nil {
+		return nil, err
+	}
 	return p.doChat(ctx, req)
 }
 
 // StreamChat sends a streaming chat request.
 func (p *HuggingFace) StreamChat(ctx context.Context, req *core.ChatRequest) (*core.ChatStream, error) {
+	if err := normalize.RequireAPIKey("huggingface", p.config.APIKey); err != nil {
+		return nil, err
+	}
 	return p.doStreamChat(ctx, req)
 }
 

--- a/providers/internal/normalize/errors.go
+++ b/providers/internal/normalize/errors.go
@@ -110,6 +110,21 @@ func ProviderError(provider string, status int, requestID, code, message string,
 	}
 }
 
+// RequireAPIKey returns a descriptive *core.ProviderError wrapping
+// core.ErrUnauthorized when the API key is empty (or whitespace-only), so a
+// provider can fail fast before making an unauthenticated request. Returns nil
+// when the key is present.
+func RequireAPIKey(provider string, key core.Secret) error {
+	if key.IsEmpty() {
+		return &core.ProviderError{
+			Provider: provider,
+			Message:  "API key is empty; provide a non-empty key to " + provider + ".New or configure your secret source",
+			Err:      core.ErrUnauthorized,
+		}
+	}
+	return nil
+}
+
 // SentinelForStatus maps an HTTP status code to a core sentinel error.
 func SentinelForStatus(status int) error {
 	return SentinelForStatusWithOverrides(status, nil)

--- a/providers/internal/normalize/errors_test.go
+++ b/providers/internal/normalize/errors_test.go
@@ -175,3 +175,17 @@ func TestSentinelForStatusWithOverrides(t *testing.T) {
 		t.Errorf("sentinel = %v, want ErrNotFound", sentinel)
 	}
 }
+
+func TestRequireAPIKey(t *testing.T) {
+	if err := RequireAPIKey("acme", core.NewSecret("sk-x")); err != nil {
+		t.Fatalf("non-empty key should pass: %v", err)
+	}
+	err := RequireAPIKey("acme", core.NewSecret("  "))
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("empty key err = %v, want ErrUnauthorized", err)
+	}
+	var pe *core.ProviderError
+	if !errors.As(err, &pe) || pe.Provider != "acme" {
+		t.Errorf("want *core.ProviderError with Provider=acme, got %#v", err)
+	}
+}

--- a/providers/openai/provider.go
+++ b/providers/openai/provider.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
 )
 
 // DefaultAPIKeyEnvVar is the environment variable name for the OpenAI API key.
@@ -87,14 +88,7 @@ func (p *OpenAI) Supports(feature core.Feature) bool {
 // HTTP request so misconfigured clients fail fast instead of round-tripping
 // to the API for a guaranteed 401.
 func (p *OpenAI) requireAPIKey() error {
-	if p.config.APIKey.IsEmpty() {
-		return &core.ProviderError{
-			Provider: "openai",
-			Message:  "API key is empty; pass it to openai.New(key) or configure your secret source",
-			Err:      core.ErrUnauthorized,
-		}
-	}
-	return nil
+	return normalize.RequireAPIKey("openai", p.config.APIKey)
 }
 
 // buildHeaders constructs the HTTP headers for an API request.

--- a/providers/perplexity/auth_test.go
+++ b/providers/perplexity/auth_test.go
@@ -1,0 +1,47 @@
+package perplexity
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.Chat(context.Background(), &core.ChatRequest{
+		Model:    ModelSonar,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}
+
+func TestStreamChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    ModelSonar,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}

--- a/providers/perplexity/options.go
+++ b/providers/perplexity/options.go
@@ -34,6 +34,13 @@ const DefaultBaseURL = "https://api.perplexity.ai"
 // Option configures the Perplexity provider.
 type Option func(*Config)
 
+// WithAPIKey sets the API key, overriding any value passed to New.
+func WithAPIKey(key string) Option {
+	return func(c *Config) {
+		c.APIKey = core.NewSecret(key)
+	}
+}
+
 // WithBaseURL sets the API base URL.
 func WithBaseURL(url string) Option {
 	return func(c *Config) {

--- a/providers/perplexity/options_test.go
+++ b/providers/perplexity/options_test.go
@@ -1,0 +1,10 @@
+package perplexity
+
+import "testing"
+
+func TestWithAPIKeyOverridesConstructorArg(t *testing.T) {
+	p := New("ctor-key", WithAPIKey("opt-key"))
+	if got := p.config.APIKey.Expose(); got != "opt-key" {
+		t.Errorf("APIKey = %q, want opt-key (option should win over constructor)", got)
+	}
+}

--- a/providers/perplexity/provider.go
+++ b/providers/perplexity/provider.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
 )
 
 // DefaultAPIKeyEnvVar is the environment variable name for the Perplexity API key.
@@ -95,11 +96,17 @@ func (p *Perplexity) buildHeaders() http.Header {
 
 // Chat sends a non-streaming chat request.
 func (p *Perplexity) Chat(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	if err := normalize.RequireAPIKey("perplexity", p.config.APIKey); err != nil {
+		return nil, err
+	}
 	return p.doChat(ctx, req)
 }
 
 // StreamChat sends a streaming chat request.
 func (p *Perplexity) StreamChat(ctx context.Context, req *core.ChatRequest) (*core.ChatStream, error) {
+	if err := normalize.RequireAPIKey("perplexity", p.config.APIKey); err != nil {
+		return nil, err
+	}
 	return p.doStreamChat(ctx, req)
 }
 

--- a/providers/voyageai/auth_test.go
+++ b/providers/voyageai/auth_test.go
@@ -1,0 +1,66 @@
+package voyageai
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestCreateEmbeddingsEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: ModelVoyage3Large,
+		Input: []core.EmbeddingInput{{Text: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}
+
+func TestCreateContextualizedEmbeddingsEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.CreateContextualizedEmbeddings(context.Background(), &core.ContextualizedEmbeddingRequest{
+		Model:  ModelVoyageContext3,
+		Inputs: [][]string{{"hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}
+
+func TestRerankEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.Rerank(context.Background(), &core.RerankRequest{
+		Model:     ModelRerank25,
+		Query:     "hi",
+		Documents: []string{"doc one", "doc two"},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}

--- a/providers/voyageai/client_contextualized.go
+++ b/providers/voyageai/client_contextualized.go
@@ -9,12 +9,17 @@ import (
 	"net/http"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
 )
 
 const contextualizedEmbeddingsPath = "/contextualizedembeddings"
 
 // CreateContextualizedEmbeddings generates context-aware embeddings for document chunks.
 func (p *VoyageAI) CreateContextualizedEmbeddings(ctx context.Context, req *core.ContextualizedEmbeddingRequest) (*core.ContextualizedEmbeddingResponse, error) {
+	if err := normalize.RequireAPIKey("voyageai", p.config.APIKey); err != nil {
+		return nil, err
+	}
+
 	voyageReq := buildContextualizedRequest(req)
 
 	body, err := json.Marshal(voyageReq)

--- a/providers/voyageai/client_embeddings.go
+++ b/providers/voyageai/client_embeddings.go
@@ -9,12 +9,17 @@ import (
 	"net/http"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
 )
 
 const embeddingsPath = "/embeddings"
 
 // CreateEmbeddings generates embeddings for the given input texts.
 func (p *VoyageAI) CreateEmbeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	if err := normalize.RequireAPIKey("voyageai", p.config.APIKey); err != nil {
+		return nil, err
+	}
+
 	voyageReq := buildEmbeddingRequest(req)
 
 	body, err := json.Marshal(voyageReq)

--- a/providers/voyageai/client_rerank.go
+++ b/providers/voyageai/client_rerank.go
@@ -9,12 +9,17 @@ import (
 	"net/http"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
 )
 
 const rerankPath = "/rerank"
 
 // Rerank scores and sorts documents by relevance to the query.
 func (p *VoyageAI) Rerank(ctx context.Context, req *core.RerankRequest) (*core.RerankResponse, error) {
+	if err := normalize.RequireAPIKey("voyageai", p.config.APIKey); err != nil {
+		return nil, err
+	}
+
 	voyageReq := buildRerankRequest(req)
 
 	body, err := json.Marshal(voyageReq)

--- a/providers/voyageai/options.go
+++ b/providers/voyageai/options.go
@@ -34,6 +34,13 @@ const DefaultBaseURL = "https://api.voyageai.com/v1"
 // Option configures the Voyage AI provider.
 type Option func(*Config)
 
+// WithAPIKey sets the API key, overriding any value passed to New.
+func WithAPIKey(key string) Option {
+	return func(c *Config) {
+		c.APIKey = core.NewSecret(key)
+	}
+}
+
 // WithBaseURL sets the API base URL.
 func WithBaseURL(url string) Option {
 	return func(c *Config) {

--- a/providers/voyageai/options_test.go
+++ b/providers/voyageai/options_test.go
@@ -1,0 +1,10 @@
+package voyageai
+
+import "testing"
+
+func TestWithAPIKeyOverridesConstructorArg(t *testing.T) {
+	p := New("ctor-key", WithAPIKey("opt-key"))
+	if got := p.config.APIKey.Expose(); got != "opt-key" {
+		t.Errorf("APIKey = %q, want opt-key (option should win over constructor)", got)
+	}
+}

--- a/providers/xai/auth_test.go
+++ b/providers/xai/auth_test.go
@@ -1,0 +1,47 @@
+package xai
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.Chat(context.Background(), &core.ChatRequest{
+		Model:    ModelGrok43,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}
+
+func TestStreamChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    ModelGrok43,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}

--- a/providers/xai/options.go
+++ b/providers/xai/options.go
@@ -34,6 +34,13 @@ const DefaultBaseURL = "https://api.x.ai/v1"
 // Option configures the xAI provider.
 type Option func(*Config)
 
+// WithAPIKey sets the API key, overriding any value passed to New.
+func WithAPIKey(key string) Option {
+	return func(c *Config) {
+		c.APIKey = core.NewSecret(key)
+	}
+}
+
 // WithBaseURL sets the API base URL.
 func WithBaseURL(url string) Option {
 	return func(c *Config) {

--- a/providers/xai/options_test.go
+++ b/providers/xai/options_test.go
@@ -1,0 +1,10 @@
+package xai
+
+import "testing"
+
+func TestWithAPIKeyOverridesConstructorArg(t *testing.T) {
+	p := New("ctor-key", WithAPIKey("opt-key"))
+	if got := p.config.APIKey.Expose(); got != "opt-key" {
+		t.Errorf("APIKey = %q, want opt-key (option should win over constructor)", got)
+	}
+}

--- a/providers/xai/provider.go
+++ b/providers/xai/provider.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
 )
 
 // DefaultAPIKeyEnvVar is the environment variable name for the xAI API key.
@@ -95,11 +96,17 @@ func (p *Xai) buildHeaders() http.Header {
 
 // Chat sends a non-streaming chat request.
 func (p *Xai) Chat(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	if err := normalize.RequireAPIKey("xai", p.config.APIKey); err != nil {
+		return nil, err
+	}
 	return p.doChat(ctx, req)
 }
 
 // StreamChat sends a streaming chat request.
 func (p *Xai) StreamChat(ctx context.Context, req *core.ChatRequest) (*core.ChatStream, error) {
+	if err := normalize.RequireAPIKey("xai", p.config.APIKey); err != nil {
+		return nil, err
+	}
 	return p.doStreamChat(ctx, req)
 }
 

--- a/providers/zai/auth_test.go
+++ b/providers/zai/auth_test.go
@@ -1,0 +1,47 @@
+package zai
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.Chat(context.Background(), &core.ChatRequest{
+		Model:    ModelGLM5,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}
+
+func TestStreamChatEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer srv.Close()
+
+	p := New("", WithBaseURL(srv.URL))
+	_, err := p.StreamChat(context.Background(), &core.ChatRequest{
+		Model:    ModelGLM5,
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("no HTTP request should be made with an empty key")
+	}
+}

--- a/providers/zai/options.go
+++ b/providers/zai/options.go
@@ -35,6 +35,13 @@ type Config struct {
 // Option is a functional option for configuring the Z.ai provider.
 type Option func(*Config)
 
+// WithAPIKey sets the API key, overriding any value passed to New.
+func WithAPIKey(key string) Option {
+	return func(c *Config) {
+		c.APIKey = core.NewSecret(key)
+	}
+}
+
 // WithBaseURL sets the base URL for the API.
 func WithBaseURL(url string) Option {
 	return func(c *Config) {

--- a/providers/zai/options_test.go
+++ b/providers/zai/options_test.go
@@ -80,3 +80,10 @@ func TestMultipleOptions(t *testing.T) {
 		t.Errorf("Timeout = %v, want %v", p.config.Timeout, timeout)
 	}
 }
+
+func TestWithAPIKeyOverridesConstructorArg(t *testing.T) {
+	p := New("ctor-key", WithAPIKey("opt-key"))
+	if got := p.config.APIKey.Expose(); got != "opt-key" {
+		t.Errorf("APIKey = %q, want opt-key (option should win over constructor)", got)
+	}
+}

--- a/providers/zai/provider.go
+++ b/providers/zai/provider.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
 )
 
 // DefaultAPIKeyEnvVar is the environment variable name for the Z.ai API key.
@@ -96,11 +97,17 @@ func (p *Zai) buildHeaders() http.Header {
 
 // Chat sends a non-streaming chat request.
 func (p *Zai) Chat(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	if err := normalize.RequireAPIKey("zai", p.config.APIKey); err != nil {
+		return nil, err
+	}
 	return p.doChat(ctx, req)
 }
 
 // StreamChat sends a streaming chat request.
 func (p *Zai) StreamChat(ctx context.Context, req *core.ChatRequest) (*core.ChatStream, error) {
+	if err := normalize.RequireAPIKey("zai", p.config.APIKey); err != nil {
+		return nil, err
+	}
 	return p.doStreamChat(ctx, req)
 }
 


### PR DESCRIPTION
Closes #47.

Implements the three items from the issue, guided by the issue comments.

## Item 13 — empty-key preflight for non-OpenAI providers
- New shared helper `normalize.RequireAPIKey(provider, key)` → returns a descriptive `*core.ProviderError` wrapping `core.ErrUnauthorized` when the key is empty/whitespace, else nil. OpenAI's existing `requireAPIKey` now delegates to it (message text changed, failure semantics identical).
- Wired into `Chat` **and** `StreamChat` for: anthropic, gemini, xai, perplexity, huggingface, zai.
- Wired into voyageai's `CreateEmbeddings`, `CreateContextualizedEmbeddings`, `Rerank`.
- azurefoundry's no-auth error now satisfies `errors.Is(err, core.ErrUnauthorized)` too (dual-wrapped with `ErrNoAuth`); its token-credential path is unchanged.
- **Deliberate exclusions:** Ollama (key is optional for local instances), huggingface *discovery* methods (intentional anonymous access), voyageai `Chat`/`StreamChat` (already `ErrNotSupported`, no HTTP).

Each guarded path has an `auth_test.go` asserting the empty-key call returns `ErrUnauthorized` **and makes no HTTP request** (httptest hit flag).

## Item 14 — remove dead `api_key_ref`
`ProviderConfig.APIKeyRef` was parsed from YAML but never read by any production code (only tests). Removed the field and its test references.

## Item 15 — `WithAPIKey` consistency
Added `WithAPIKey(key string) Option` to the 8 providers that lacked it (Ollama already had it). Every provider's `New` sets the key from the positional arg before applying options, so `WithAPIKey` reliably wins (last-wins) — each has a test proving the override.

## Behavior changes (documented in the change doc)
- Key-requiring providers now fail fast with `core.ErrUnauthorized` **before** the HTTP call on an empty key, instead of sending an unauthenticated request and surfacing a raw 401.
- `ProviderConfig.APIKeyRef` removed from the CLI config struct.

## Deferred (documented)
File/image/batch/vector-store entry points are not yet guarded with the preflight (pre-existing surfaces; noted in the change doc's Deferred section).

## Verification
Full `go test -race ./...` passes; `go build ./...` and `gofmt` clean. Each change is TDD'd with tests that assert the real no-HTTP / last-wins / dual-sentinel properties.
