### PR TITLE
fix(keystore): honor IRIS_KEYSTORE_KEY in CLI and add keys migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Iris solves these problems by providing:
 
 ### CLI Features
 - `iris chat` - Send chat completions from the terminal
-- `iris keys` - Securely manage API keys with AES-256-GCM encryption and Argon2id key derivation
+- `iris keys` - Securely manage API keys with AES-256-GCM encryption and Argon2id key derivation (`set`, `list`, `delete`, `migrate`)
 - `iris init` - Scaffold new Iris projects
 ## Installation
 
@@ -718,6 +718,9 @@ iris keys set xai
 iris keys set zai
 iris keys set ollama  # Only needed for Ollama Cloud
 
+# Upgrade the keystore to master-key encryption (V2)
+iris keys migrate  # Requires IRIS_KEYSTORE_KEY (see Security below)
+
 # Chat with OpenAI
 iris chat --provider openai --model gpt-5.6 --prompt "Hello, world!"
 
@@ -814,12 +817,19 @@ export IRIS_KEYSTORE_KEY=$(openssl rand -base64 32)
 echo 'export IRIS_KEYSTORE_KEY="your-key-here"' >> ~/.bashrc
 ```
 
-When `IRIS_KEYSTORE_KEY` is set, Iris uses the V2 keystore format with:
+All keystore-backed commands (`iris keys`, `iris chat`) honor `IRIS_KEYSTORE_KEY`. When it is set, Iris uses the V2 keystore format with:
 - **Argon2id** key derivation (OWASP recommended parameters)
 - **AES-256-GCM** authenticated encryption
 - Per-file random salt and nonce
 
-Without `IRIS_KEYSTORE_KEY`, Iris falls back to V1 mode which derives keys from machine-specific data. This is convenient for development but less secure for production.
+Stores written by older versions remain readable (decryption falls back to the legacy key), and they are re-encrypted under your master key on the next write. To upgrade an existing store explicitly:
+
+```bash
+iris keys migrate
+# Re-encrypts ~/.iris/keys.enc in V2 format; the previous file is kept at ~/.iris/keys.enc.bak
+```
+
+Without `IRIS_KEYSTORE_KEY`, Iris falls back to V1 mode which derives keys from machine-specific data. This is convenient for development but less secure for production — the CLI prints a warning on every keystore operation while in this mode.
 
 ### API Key Protection
 

--- a/cli/commands/chat.go
+++ b/cli/commands/chat.go
@@ -57,7 +57,7 @@ func (a *App) runChat(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get API key from keystore.
-	ks, err := a.newKeystore()
+	ks, err := a.openKeystore()
 	if err != nil {
 		return exitWithCode(ExitValidation, fmt.Errorf("failed to open keystore: %w", err))
 	}

--- a/cli/commands/keys.go
+++ b/cli/commands/keys.go
@@ -39,8 +39,36 @@ func (a *App) newKeysCommand() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  a.runKeysDelete,
 	})
+	keysCmd.AddCommand(&cobra.Command{
+		Use:   "migrate",
+		Short: "Migrate the keystore to v2 format under the master key",
+		Long: `Re-encrypt the keystore at ~/.iris/keys.enc in v2 format using the
+IRIS_KEYSTORE_KEY master key (Argon2id + AES-256-GCM).
+
+This upgrades stores written by older versions, which were encrypted with a
+key derived from machine-specific data. The original file is preserved at
+~/.iris/keys.enc.bak; delete it once you have verified the migration.
+
+Requires IRIS_KEYSTORE_KEY to be set, e.g.:
+  export IRIS_KEYSTORE_KEY=$(openssl rand -base64 32)`,
+		RunE: a.runKeysMigrate,
+	})
 
 	return keysCmd
+}
+
+// openKeystore opens the keystore via the configured factory and warns when
+// it is running with the legacy machine-derived key.
+func (a *App) openKeystore() (keystore.Keystore, error) {
+	ks, err := a.newKeystore()
+	if err != nil {
+		return nil, err
+	}
+	if lk, ok := ks.(interface{ UsesLegacyKey() bool }); ok && lk.UsesLegacyKey() {
+		fmt.Fprintln(a.stderr, "Warning: IRIS_KEYSTORE_KEY is not set; API keys are encrypted with a predictable machine-derived key.")
+		fmt.Fprintln(a.stderr, "Set a master key and migrate: export IRIS_KEYSTORE_KEY=$(openssl rand -base64 32) && iris keys migrate")
+	}
+	return ks, nil
 }
 
 func (a *App) runKeysSet(cmd *cobra.Command, args []string) error {
@@ -57,7 +85,7 @@ func (a *App) runKeysSet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("API key cannot be empty")
 	}
 
-	ks, err := a.newKeystore()
+	ks, err := a.openKeystore()
 	if err != nil {
 		return fmt.Errorf("failed to open keystore: %w", err)
 	}
@@ -70,10 +98,12 @@ func (a *App) runKeysSet(cmd *cobra.Command, args []string) error {
 }
 
 func (a *App) runKeysList(cmd *cobra.Command, args []string) error {
-	ks, err := a.newKeystore()
+	ks, err := a.openKeystore()
 	if err != nil {
 		return fmt.Errorf("failed to open keystore: %w", err)
 	}
+
+	a.printKeystoreStatus(ks)
 
 	names, err := ks.List()
 	if err != nil {
@@ -93,10 +123,32 @@ func (a *App) runKeysList(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// printKeystoreStatus prints a one-line summary of the keystore encryption
+// state, and nudges the user toward migrating when needed.
+func (a *App) printKeystoreStatus(ks keystore.Keystore) {
+	fk, ok := ks.(*keystore.FileKeystore)
+	if !ok {
+		return
+	}
+	if fk.UsesLegacyKey() {
+		fmt.Fprintln(a.stdout, "Keystore: legacy machine-derived key (set IRIS_KEYSTORE_KEY and run 'iris keys migrate' to upgrade).")
+		return
+	}
+	needs, err := fk.NeedsMigration()
+	if err != nil {
+		return
+	}
+	if needs {
+		fmt.Fprintln(a.stdout, "Keystore: pending migration to the IRIS_KEYSTORE_KEY master key (run 'iris keys migrate').")
+		return
+	}
+	fmt.Fprintln(a.stdout, "Keystore: v2 format, IRIS_KEYSTORE_KEY master key.")
+}
+
 func (a *App) runKeysDelete(cmd *cobra.Command, args []string) error {
 	provider := args[0]
 
-	ks, err := a.newKeystore()
+	ks, err := a.openKeystore()
 	if err != nil {
 		return fmt.Errorf("failed to open keystore: %w", err)
 	}
@@ -109,6 +161,40 @@ func (a *App) runKeysDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Fprintf(a.stdout, "API key for %s deleted.\n", provider)
+	return nil
+}
+
+func (a *App) runKeysMigrate(cmd *cobra.Command, args []string) error {
+	ks, err := a.newKeystore()
+	if err != nil {
+		return fmt.Errorf("failed to open keystore: %w", err)
+	}
+
+	fk, ok := ks.(*keystore.FileKeystore)
+	if !ok {
+		return fmt.Errorf("keystore does not support migration (%T)", ks)
+	}
+
+	if fk.UsesLegacyKey() {
+		return fmt.Errorf("IRIS_KEYSTORE_KEY is not set; migration requires a master key.\n\nSet one first, e.g.:\n  export IRIS_KEYSTORE_KEY=$(openssl rand -base64 32)\n\nThen re-run: iris keys migrate")
+	}
+
+	result, err := fk.MigrateToV2()
+	if err != nil {
+		return fmt.Errorf("migration failed: %w", err)
+	}
+
+	switch result {
+	case keystore.MigrateNone:
+		fmt.Fprintln(a.stdout, "No keystore found; nothing to migrate.")
+	case keystore.MigrateAlreadyCurrent:
+		fmt.Fprintln(a.stdout, "Keystore is already in v2 format under the current master key.")
+	case keystore.MigrateRekeyed:
+		fmt.Fprintf(a.stdout, "Keystore migrated to v2 format under the IRIS_KEYSTORE_KEY master key.\n")
+		fmt.Fprintf(a.stdout, "Backup of the previous store saved to %s.bak\n", fk.Path())
+		fmt.Fprintf(a.stdout, "Delete the backup once verified: rm %s.bak\n", fk.Path())
+	}
+
 	return nil
 }
 

--- a/cli/commands/keys_test.go
+++ b/cli/commands/keys_test.go
@@ -1,0 +1,199 @@
+package commands
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/petal-labs/iris/cli/keystore"
+)
+
+// newKeysTestApp builds an App whose keystore points at a temp file and whose
+// I/O is captured. The factory replicates keystore.NewKeystoreAtPath so tests
+// can control both the path and the master key environment.
+func newKeysTestApp(t *testing.T, path string, envKey string, stdin string) (*App, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+
+	if envKey != "" {
+		t.Setenv(keystore.DefaultMasterKeyEnvVar, envKey)
+	} else {
+		t.Setenv(keystore.DefaultMasterKeyEnvVar, "")
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := NewApp(
+		WithKeystoreFactory(func() (keystore.Keystore, error) {
+			return keystore.NewKeystoreAtPath(path)
+		}),
+		WithIO(strings.NewReader(stdin), stdout, stderr),
+	)
+	return app, stdout, stderr
+}
+
+func TestKeysSetAndListLegacyModeWarns(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keys.enc")
+	app, stdout, stderr := newKeysTestApp(t, path, "", "sk-test-key-123\n")
+
+	if err := app.runKeysSet(nil, []string{"openai"}); err != nil {
+		t.Fatalf("runKeysSet() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "stored successfully") {
+		t.Errorf("set output = %q, want 'stored successfully'", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "Warning: IRIS_KEYSTORE_KEY is not set") {
+		t.Errorf("stderr = %q, want legacy-key warning", stderr.String())
+	}
+
+	stdout.Reset()
+	if err := app.runKeysList(nil, nil); err != nil {
+		t.Fatalf("runKeysList() error = %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "openai") {
+		t.Errorf("list output = %q, want 'openai'", out)
+	}
+	if !strings.Contains(out, "legacy machine-derived key") {
+		t.Errorf("list output = %q, want legacy status line", out)
+	}
+}
+
+func TestKeysSetListDeleteWithMasterKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keys.enc")
+	app, stdout, stderr := newKeysTestApp(t, path, "test-master-key", "sk-test-key-123\n")
+
+	if err := app.runKeysSet(nil, []string{"openai"}); err != nil {
+		t.Fatalf("runKeysSet() error = %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want no warning with master key set", stderr.String())
+	}
+
+	stdout.Reset()
+	if err := app.runKeysList(nil, nil); err != nil {
+		t.Fatalf("runKeysList() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "v2 format, IRIS_KEYSTORE_KEY master key") {
+		t.Errorf("list output = %q, want v2 status line", stdout.String())
+	}
+
+	if err := app.runKeysDelete(nil, []string{"openai"}); err != nil {
+		t.Fatalf("runKeysDelete() error = %v", err)
+	}
+
+	stdout.Reset()
+	if err := app.runKeysList(nil, nil); err != nil {
+		t.Fatalf("runKeysList() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "No API keys stored.") {
+		t.Errorf("list output = %q after delete, want empty", stdout.String())
+	}
+}
+
+func TestKeysSetEmptyKeyRejected(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keys.enc")
+	app, _, _ := newKeysTestApp(t, path, "test-master-key", "\n")
+
+	err := app.runKeysSet(nil, []string{"openai"})
+	if err == nil {
+		t.Fatal("runKeysSet() should reject empty keys")
+	}
+}
+
+func TestKeysListPendingMigration(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keys.enc")
+
+	// Create a store with the legacy machine key (no master key set).
+	t.Setenv(keystore.DefaultMasterKeyEnvVar, "")
+	legacy, err := keystore.NewFileKeystore(path)
+	if err != nil {
+		t.Fatalf("NewFileKeystore() error = %v", err)
+	}
+	if err := legacy.Set("openai", "sk-old"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	app, stdout, _ := newKeysTestApp(t, path, "test-master-key", "")
+	if err := app.runKeysList(nil, nil); err != nil {
+		t.Fatalf("runKeysList() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "pending migration") {
+		t.Errorf("list output = %q, want pending-migration status line", stdout.String())
+	}
+}
+
+func TestKeysMigrateRequiresMasterKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keys.enc")
+	app, _, _ := newKeysTestApp(t, path, "", "")
+
+	err := app.runKeysMigrate(nil, nil)
+	if err == nil {
+		t.Fatal("runKeysMigrate() should fail without IRIS_KEYSTORE_KEY")
+	}
+	if !strings.Contains(err.Error(), "IRIS_KEYSTORE_KEY") {
+		t.Errorf("error = %q, want mention of IRIS_KEYSTORE_KEY", err.Error())
+	}
+}
+
+func TestKeysMigrateRekeysStore(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keys.enc")
+
+	// Seed a legacy machine-keyed store.
+	t.Setenv(keystore.DefaultMasterKeyEnvVar, "")
+	legacy, err := keystore.NewFileKeystore(path)
+	if err != nil {
+		t.Fatalf("NewFileKeystore() error = %v", err)
+	}
+	if err := legacy.Set("openai", "sk-legacy-value"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	app, stdout, _ := newKeysTestApp(t, path, "test-master-key", "")
+	if err := app.runKeysMigrate(nil, nil); err != nil {
+		t.Fatalf("runKeysMigrate() error = %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "migrated to v2 format") {
+		t.Errorf("migrate output = %q, want migration confirmation", out)
+	}
+	if !strings.Contains(out, path+".bak") {
+		t.Errorf("migrate output = %q, want backup path %q", out, path+".bak")
+	}
+	if _, err := os.Stat(path + ".bak"); err != nil {
+		t.Fatalf("backup file not created: %v", err)
+	}
+
+	// The migrated store must be readable by a strict master-key store.
+	strict, err := keystore.NewFileKeystoreWithSource(path, &staticKeySource{key: "test-master-key"})
+	if err != nil {
+		t.Fatalf("NewFileKeystoreWithSource() error = %v", err)
+	}
+	value, err := strict.Get("openai")
+	if err != nil {
+		t.Fatalf("strict Get() error = %v", err)
+	}
+	if value != "sk-legacy-value" {
+		t.Errorf("strict Get() = %q, want sk-legacy-value", value)
+	}
+
+	// Second run is a no-op.
+	stdout.Reset()
+	if err := app.runKeysMigrate(nil, nil); err != nil {
+		t.Fatalf("second runKeysMigrate() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "already in v2 format") {
+		t.Errorf("second migrate output = %q, want already-current message", stdout.String())
+	}
+}
+
+// staticKeySource adapts a string key to keystore.MasterKeySource for tests
+// in this package.
+type staticKeySource struct {
+	key string
+}
+
+func (s *staticKeySource) GetMasterKey() ([]byte, error) {
+	return []byte(s.key), nil
+}

--- a/cli/keystore/file.go
+++ b/cli/keystore/file.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -42,7 +43,12 @@ const (
 type FileKeystore struct {
 	path      string
 	masterKey []byte
-	mu        sync.RWMutex
+	// legacyKey, when set, is tried when decryption with masterKey fails so
+	// stores written by older versions remain readable during migration.
+	legacyKey []byte
+	// legacyMode reports whether masterKey is the machine-derived v1 key.
+	legacyMode bool
+	mu         sync.RWMutex
 }
 
 // NewFileKeystore creates a new file-based keystore at the given path.
@@ -55,8 +61,9 @@ func NewFileKeystore(path string) (*FileKeystore, error) {
 	}
 
 	return &FileKeystore{
-		path:      path,
-		masterKey: key,
+		path:       path,
+		masterKey:  key,
+		legacyMode: true,
 	}, nil
 }
 
@@ -72,6 +79,53 @@ func NewFileKeystoreWithSource(path string, source MasterKeySource) (*FileKeysto
 		path:      path,
 		masterKey: masterKey,
 	}, nil
+}
+
+// WithLegacyKeyFallback enables reading stores encrypted by older versions:
+// v1-format files and v2-format files keyed with the machine-derived legacy
+// key. Decryption is attempted with the master key first; the legacy key is
+// only tried when that fails. Writes always use the master key, so any
+// Set or Delete transparently re-encrypts the store.
+func (f *FileKeystore) WithLegacyKeyFallback() *FileKeystore {
+	if key, err := deriveKeyV1(); err == nil {
+		f.legacyKey = key
+	}
+	return f
+}
+
+// UsesLegacyKey reports whether the keystore was opened with the insecure
+// machine-derived v1 key (i.e., no master key source was provided).
+func (f *FileKeystore) UsesLegacyKey() bool {
+	return f.legacyMode
+}
+
+// NeedsMigration reports whether the store file cannot be decrypted with the
+// current master key alone, meaning it is v1-format or was encrypted under
+// the legacy machine-derived key. Running MigrateToV2 re-encrypts it.
+func (f *FileKeystore) NeedsMigration() (bool, error) {
+	ciphertext, err := os.ReadFile(f.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	if len(ciphertext) == 0 {
+		return false, nil
+	}
+
+	if isV2Format(ciphertext) {
+		_, err := decryptV2WithKey(f.masterKey, ciphertext)
+		return err != nil, nil
+	}
+	_, err = decryptV1WithKey(f.masterKey, ciphertext)
+	return err != nil, nil
+}
+
+// Path returns the keystore file path.
+func (f *FileKeystore) Path() string {
+	return f.path
 }
 
 // Set stores a key-value pair.
@@ -160,13 +214,22 @@ func (f *FileKeystore) loadData() (map[string]string, error) {
 		return data, nil
 	}
 
-	// Detect format version
+	// Detect format version and decrypt. The master key is tried first; if it
+	// fails and a legacy fallback key is configured (see WithLegacyKeyFallback),
+	// the legacy machine-derived key is tried so pre-migration stores remain
+	// readable. Writes always re-encrypt under the master key.
 	var plaintext []byte
 	if isV2Format(ciphertext) {
-		plaintext, err = f.decryptV2(ciphertext)
+		plaintext, err = decryptV2WithKey(f.masterKey, ciphertext)
+		if err != nil && len(f.legacyKey) > 0 {
+			plaintext, err = decryptV2WithKey(f.legacyKey, ciphertext)
+		}
 	} else {
 		// Legacy v1 format
-		plaintext, err = f.decryptV1(ciphertext)
+		plaintext, err = decryptV1WithKey(f.masterKey, ciphertext)
+		if err != nil && len(f.legacyKey) > 0 {
+			plaintext, err = decryptV1WithKey(f.legacyKey, ciphertext)
+		}
 	}
 	if err != nil {
 		return nil, err
@@ -254,8 +317,10 @@ func (f *FileKeystore) encryptV2(plaintext []byte) ([]byte, error) {
 	return append(header, ciphertext...), nil
 }
 
-// decryptV2 decrypts data using AES-256-GCM with Argon2id key derivation.
-func (f *FileKeystore) decryptV2(ciphertext []byte) ([]byte, error) {
+// decryptV2WithKey decrypts v2-format data using AES-256-GCM with Argon2id
+// key derivation from the given master key.
+// Format: [magic (4)] [version (1)] [salt (16)] [nonce (12)] [ciphertext]
+func decryptV2WithKey(masterKey, ciphertext []byte) ([]byte, error) {
 	headerLen := len(magicHeader) + 1 + saltLength + nonceLength
 	if len(ciphertext) < headerLen {
 		return nil, errors.New("ciphertext too short")
@@ -271,7 +336,7 @@ func (f *FileKeystore) decryptV2(ciphertext []byte) ([]byte, error) {
 	header := ciphertext[:offset]
 
 	// Derive key using Argon2id
-	key := deriveKeyV2(f.masterKey, salt)
+	key := deriveKeyV2(masterKey, salt)
 
 	block, err := aes.NewCipher(key)
 	if err != nil {
@@ -286,10 +351,10 @@ func (f *FileKeystore) decryptV2(ciphertext []byte) ([]byte, error) {
 	return gcm.Open(nil, nonce, encrypted, header)
 }
 
-// decryptV1 decrypts data using AES-256-GCM (legacy v1 format).
-func (f *FileKeystore) decryptV1(ciphertext []byte) ([]byte, error) {
-	key := f.deriveKeyFromMasterV1()
-
+// decryptV1WithKey decrypts v1-format data using AES-256-GCM with the given
+// key used directly (the schedule used by the original v1 implementation).
+// Format: [nonce (12)] [ciphertext]
+func decryptV1WithKey(key, ciphertext []byte) ([]byte, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
@@ -307,13 +372,6 @@ func (f *FileKeystore) decryptV1(ciphertext []byte) ([]byte, error) {
 
 	nonce, ciphertext := ciphertext[:nonceSize], ciphertext[nonceSize:]
 	return gcm.Open(nil, nonce, ciphertext, nil)
-}
-
-// deriveKeyFromMasterV1 hashes the master key to get a 32-byte key for v1 format.
-// This provides backward compatibility when using NewFileKeystoreWithSource with v1 files.
-func (f *FileKeystore) deriveKeyFromMasterV1() []byte {
-	hash := sha256.Sum256(f.masterKey)
-	return hash[:]
 }
 
 // deriveKeyV1 creates a machine-specific encryption key (legacy v1 method).
@@ -337,9 +395,27 @@ func deriveKeyV1() ([]byte, error) {
 	return hash[:], nil
 }
 
-// MigrateToV2 migrates a v1 keystore to v2 format.
-// The keystore must be opened with the new master key source.
-func (f *FileKeystore) MigrateToV2() error {
+// MigrateResult reports the outcome of a MigrateToV2 call.
+type MigrateResult int
+
+const (
+	// MigrateNone means no keystore file existed (or it was empty).
+	MigrateNone MigrateResult = iota
+	// MigrateAlreadyCurrent means the store is already v2-format and
+	// encrypted under the current master key.
+	MigrateAlreadyCurrent
+	// MigrateRekeyed means the store was decrypted (via the master key or the
+	// legacy fallback) and re-encrypted under the current master key.
+	MigrateRekeyed
+)
+
+// MigrateToV2 migrates a legacy keystore to v2 format encrypted under this
+// keystore's master key. It handles both v1-format files and v2-format files
+// encrypted with the legacy machine-derived key (requires
+// WithLegacyKeyFallback, which NewKeystore enables automatically).
+// The original file is preserved at <path>.bak before the new one is written.
+// The call is idempotent: an already-current store returns MigrateAlreadyCurrent.
+func (f *FileKeystore) MigrateToV2() (MigrateResult, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -347,50 +423,67 @@ func (f *FileKeystore) MigrateToV2() error {
 	ciphertext, err := os.ReadFile(f.path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil // Nothing to migrate
+			return MigrateNone, nil // Nothing to migrate
 		}
-		return err
+		return MigrateNone, err
 	}
 
 	if len(ciphertext) == 0 {
-		return nil // Empty file, nothing to migrate
+		return MigrateNone, nil // Empty file, nothing to migrate
 	}
 
-	// Already v2 format
+	// Already v2 under the current master key: nothing to do.
 	if isV2Format(ciphertext) {
-		return nil
+		if _, err := decryptV2WithKey(f.masterKey, ciphertext); err == nil {
+			return MigrateAlreadyCurrent, nil
+		}
 	}
 
-	// Read data using v1 format
-	plaintext, err := f.decryptV1(ciphertext)
+	// Decrypt via any available key: master first, then the legacy fallback.
+	var plaintext []byte
+	if isV2Format(ciphertext) {
+		plaintext, err = decryptV2WithKey(f.masterKey, ciphertext)
+		if err != nil && len(f.legacyKey) > 0 {
+			plaintext, err = decryptV2WithKey(f.legacyKey, ciphertext)
+		}
+	} else {
+		plaintext, err = decryptV1WithKey(f.masterKey, ciphertext)
+		if err != nil && len(f.legacyKey) > 0 {
+			plaintext, err = decryptV1WithKey(f.legacyKey, ciphertext)
+		}
+	}
 	if err != nil {
-		return err
+		return MigrateNone, fmt.Errorf("cannot decrypt keystore with the current master key (or the legacy machine key): %w", err)
 	}
 
 	var data map[string]string
 	if err := json.Unmarshal(plaintext, &data); err != nil {
-		return err
+		return MigrateNone, err
 	}
 
-	// Re-encrypt with v2 format
+	// Re-encrypt under the current master key.
 	newPlaintext, err := json.Marshal(data)
 	if err != nil {
-		return err
+		return MigrateNone, err
 	}
 
 	newCiphertext, err := f.encryptV2(newPlaintext)
 	if err != nil {
-		return err
+		return MigrateNone, err
 	}
 
-	// Backup old file
-	backupPath := f.path + ".v1.bak"
+	// Backup old file before replacing it.
+	backupPath := f.path + ".bak"
 	if err := os.WriteFile(backupPath, ciphertext, 0600); err != nil {
-		return err
+		return MigrateNone, err
 	}
 
 	// Write new file
-	return os.WriteFile(f.path, newCiphertext, 0600)
+	if err := os.WriteFile(f.path, newCiphertext, 0600); err != nil {
+		return MigrateNone, err
+	}
+
+	return MigrateRekeyed, nil
 }
 
 // IsV2Format checks if the keystore file is in v2 format.

--- a/cli/keystore/keystore.go
+++ b/cli/keystore/keystore.go
@@ -115,6 +115,27 @@ func DefaultKeystorePath() string {
 }
 
 // NewKeystore creates a new keystore using file-based encrypted storage.
+//
+// It is master-key aware: when DefaultMasterKeyEnvVar (IRIS_KEYSTORE_KEY) is
+// set, the store is encrypted with that master key (v2 format, Argon2id +
+// AES-256-GCM) and legacy stores written by older versions remain readable
+// via a decryption fallback, so they can be migrated with MigrateToV2 (or
+// transparently on the next write). When the environment variable is not set,
+// it falls back to the legacy machine-derived key (v1 mode), which is
+// convenient for development but predictable; callers can detect this via
+// FileKeystore.UsesLegacyKey.
 func NewKeystore() (Keystore, error) {
-	return NewFileKeystore(DefaultKeystorePath())
+	return NewKeystoreAtPath(DefaultKeystorePath())
+}
+
+// NewKeystoreAtPath is like NewKeystore but opens the store at path.
+func NewKeystoreAtPath(path string) (Keystore, error) {
+	if os.Getenv(DefaultMasterKeyEnvVar) != "" {
+		ks, err := NewFileKeystoreWithSource(path, &EnvMasterKeySource{})
+		if err != nil {
+			return nil, err
+		}
+		return ks.WithLegacyKeyFallback(), nil
+	}
+	return NewFileKeystore(path)
 }

--- a/cli/keystore/keystore_test.go
+++ b/cli/keystore/keystore_test.go
@@ -1,6 +1,11 @@
 package keystore
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -643,5 +648,324 @@ func TestIsV2Format(t *testing.T) {
 				t.Errorf("isV2Format() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// --- Master-key-aware NewKeystore Tests ---
+
+// redirectHome points DefaultKeystorePath at a temp directory for the test.
+func redirectHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+	}
+	return home
+}
+
+func TestNewKeystoreEnvAware(t *testing.T) {
+	redirectHome(t)
+	t.Setenv(DefaultMasterKeyEnvVar, "env-master-key")
+
+	ks, err := NewKeystore()
+	if err != nil {
+		t.Fatalf("NewKeystore() error = %v", err)
+	}
+
+	fk, ok := ks.(*FileKeystore)
+	if !ok {
+		t.Fatalf("NewKeystore() returned %T, want *FileKeystore", ks)
+	}
+	if fk.UsesLegacyKey() {
+		t.Error("UsesLegacyKey() = true with IRIS_KEYSTORE_KEY set, want false")
+	}
+
+	if err := ks.Set("openai", "sk-env-mode"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	// A strict env-keyed store (no legacy fallback) must be able to read it.
+	strict, err := NewFileKeystoreWithSource(DefaultKeystorePath(), &staticMasterKeySource{key: []byte("env-master-key")})
+	if err != nil {
+		t.Fatalf("NewFileKeystoreWithSource() error = %v", err)
+	}
+	value, err := strict.Get("openai")
+	if err != nil {
+		t.Fatalf("strict Get() error = %v", err)
+	}
+	if value != "sk-env-mode" {
+		t.Errorf("strict Get() = %q, want sk-env-mode", value)
+	}
+
+	needs, err := fk.NeedsMigration()
+	if err != nil {
+		t.Fatalf("NeedsMigration() error = %v", err)
+	}
+	if needs {
+		t.Error("NeedsMigration() = true for a store written under the current master key, want false")
+	}
+}
+
+func TestNewKeystoreLegacyMode(t *testing.T) {
+	redirectHome(t)
+
+	ks, err := NewKeystore()
+	if err != nil {
+		t.Fatalf("NewKeystore() error = %v", err)
+	}
+
+	fk, ok := ks.(*FileKeystore)
+	if !ok {
+		t.Fatalf("NewKeystore() returned %T, want *FileKeystore", ks)
+	}
+	if !fk.UsesLegacyKey() {
+		t.Error("UsesLegacyKey() = false without IRIS_KEYSTORE_KEY, want true")
+	}
+
+	if err := ks.Set("openai", "sk-legacy-mode"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	needs, err := fk.NeedsMigration()
+	if err != nil {
+		t.Fatalf("NeedsMigration() error = %v", err)
+	}
+	if needs {
+		t.Error("NeedsMigration() = true in legacy mode (same key), want false")
+	}
+}
+
+// writeLegacyMachineKeyedStore writes a v2-format file encrypted under the
+// machine-derived key, i.e. what stores written by older CLI versions contain.
+func writeLegacyMachineKeyedStore(t *testing.T, path string, entries map[string]string) {
+	t.Helper()
+
+	legacy, err := NewFileKeystore(path)
+	if err != nil {
+		t.Fatalf("NewFileKeystore() error = %v", err)
+	}
+	for name, value := range entries {
+		if err := legacy.Set(name, value); err != nil {
+			t.Fatalf("legacy Set(%q) error = %v", name, err)
+		}
+	}
+}
+
+// writeV1FormatStore writes a file in the original v1 wire format (nonce ||
+// ciphertext, AES-256-GCM with the machine-derived key used directly).
+func writeV1FormatStore(t *testing.T, path string, entries map[string]string) {
+	t.Helper()
+
+	key, err := deriveKeyV1()
+	if err != nil {
+		t.Fatalf("deriveKeyV1() error = %v", err)
+	}
+	plaintext, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("NewCipher() error = %v", err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("NewGCM() error = %v", err)
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		t.Fatalf("rand error = %v", err)
+	}
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+	if err := os.WriteFile(path, ciphertext, 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func openEnvKeyedWithFallback(t *testing.T, path, masterKey string) *FileKeystore {
+	t.Helper()
+
+	ks, err := NewFileKeystoreWithSource(path, &staticMasterKeySource{key: []byte(masterKey)})
+	if err != nil {
+		t.Fatalf("NewFileKeystoreWithSource() error = %v", err)
+	}
+	return ks.WithLegacyKeyFallback()
+}
+
+func TestLegacyFallbackReadAndAutoUpgrade(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "keys.enc")
+	writeLegacyMachineKeyedStore(t, path, map[string]string{"openai": "sk-old-key"})
+
+	ks := openEnvKeyedWithFallback(t, path, "new-master-key")
+
+	needs, err := ks.NeedsMigration()
+	if err != nil {
+		t.Fatalf("NeedsMigration() error = %v", err)
+	}
+	if !needs {
+		t.Fatal("NeedsMigration() = false for machine-keyed store, want true")
+	}
+
+	// Fallback read must succeed before migration.
+	value, err := ks.Get("openai")
+	if err != nil {
+		t.Fatalf("Get() with legacy fallback error = %v", err)
+	}
+	if value != "sk-old-key" {
+		t.Errorf("Get() = %q, want sk-old-key", value)
+	}
+
+	// Any write re-encrypts under the master key.
+	if err := ks.Set("anthropic", "sk-new-entry"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	needs, err = ks.NeedsMigration()
+	if err != nil {
+		t.Fatalf("NeedsMigration() error = %v", err)
+	}
+	if needs {
+		t.Error("NeedsMigration() = true after write, want false")
+	}
+
+	// A strict store (no fallback) can now read everything.
+	strict, err := NewFileKeystoreWithSource(path, &staticMasterKeySource{key: []byte("new-master-key")})
+	if err != nil {
+		t.Fatalf("NewFileKeystoreWithSource() error = %v", err)
+	}
+	for name, want := range map[string]string{"openai": "sk-old-key", "anthropic": "sk-new-entry"} {
+		got, err := strict.Get(name)
+		if err != nil {
+			t.Fatalf("strict Get(%q) error = %v", name, err)
+		}
+		if got != want {
+			t.Errorf("strict Get(%q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestMigrateToV2RekeysMachineKeyedStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "keys.enc")
+	writeLegacyMachineKeyedStore(t, path, map[string]string{"openai": "sk-old-key", "zai": "sk-zai"})
+
+	ks := openEnvKeyedWithFallback(t, path, "new-master-key")
+
+	result, err := ks.MigrateToV2()
+	if err != nil {
+		t.Fatalf("MigrateToV2() error = %v", err)
+	}
+	if result != MigrateRekeyed {
+		t.Fatalf("MigrateToV2() = %v, want MigrateRekeyed", result)
+	}
+
+	// Backup preserved.
+	backup := path + ".bak"
+	if _, err := os.Stat(backup); err != nil {
+		t.Fatalf("backup not created: %v", err)
+	}
+
+	// Strict store (no fallback) can read the migrated file.
+	strict, err := NewFileKeystoreWithSource(path, &staticMasterKeySource{key: []byte("new-master-key")})
+	if err != nil {
+		t.Fatalf("NewFileKeystoreWithSource() error = %v", err)
+	}
+	value, err := strict.Get("openai")
+	if err != nil {
+		t.Fatalf("strict Get() error = %v", err)
+	}
+	if value != "sk-old-key" {
+		t.Errorf("strict Get() = %q, want sk-old-key", value)
+	}
+
+	// Idempotent.
+	result, err = ks.MigrateToV2()
+	if err != nil {
+		t.Fatalf("second MigrateToV2() error = %v", err)
+	}
+	if result != MigrateAlreadyCurrent {
+		t.Errorf("second MigrateToV2() = %v, want MigrateAlreadyCurrent", result)
+	}
+}
+
+func TestMigrateToV2FromV1Format(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "keys.enc")
+	writeV1FormatStore(t, path, map[string]string{"openai": "sk-ancient-key"})
+
+	ks := openEnvKeyedWithFallback(t, path, "new-master-key")
+
+	// Fallback read of the original v1 wire format.
+	value, err := ks.Get("openai")
+	if err != nil {
+		t.Fatalf("Get() on v1-format file error = %v", err)
+	}
+	if value != "sk-ancient-key" {
+		t.Errorf("Get() = %q, want sk-ancient-key", value)
+	}
+
+	result, err := ks.MigrateToV2()
+	if err != nil {
+		t.Fatalf("MigrateToV2() error = %v", err)
+	}
+	if result != MigrateRekeyed {
+		t.Fatalf("MigrateToV2() = %v, want MigrateRekeyed", result)
+	}
+
+	strict, err := NewFileKeystoreWithSource(path, &staticMasterKeySource{key: []byte("new-master-key")})
+	if err != nil {
+		t.Fatalf("NewFileKeystoreWithSource() error = %v", err)
+	}
+	if value, err := strict.Get("openai"); err != nil || value != "sk-ancient-key" {
+		t.Errorf("strict Get() = %q, %v; want sk-ancient-key, nil", value, err)
+	}
+}
+
+func TestMigrateToV2NoStore(t *testing.T) {
+	tmpDir := t.TempDir()
+	ks := openEnvKeyedWithFallback(t, filepath.Join(tmpDir, "missing.enc"), "new-master-key")
+
+	result, err := ks.MigrateToV2()
+	if err != nil {
+		t.Fatalf("MigrateToV2() error = %v", err)
+	}
+	if result != MigrateNone {
+		t.Errorf("MigrateToV2() = %v, want MigrateNone", result)
+	}
+}
+
+func TestMigrateToV2WrongKeyFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "keys.enc")
+
+	// Store encrypted with an unrelated master key (not the machine key).
+	other, err := NewFileKeystoreWithSource(path, &staticMasterKeySource{key: []byte("someone-elses-key")})
+	if err != nil {
+		t.Fatalf("NewFileKeystoreWithSource() error = %v", err)
+	}
+	if err := other.Set("openai", "sk-locked"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	ks := openEnvKeyedWithFallback(t, path, "new-master-key")
+	if _, err := ks.MigrateToV2(); err == nil {
+		t.Error("MigrateToV2() should fail for a store encrypted with an unrelated master key")
+	}
+}
+
+func TestStrictStoreCannotReadLegacyWithoutFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "keys.enc")
+	writeLegacyMachineKeyedStore(t, path, map[string]string{"openai": "sk-old-key"})
+
+	strict, err := NewFileKeystoreWithSource(path, &staticMasterKeySource{key: []byte("new-master-key")})
+	if err != nil {
+		t.Fatalf("NewFileKeystoreWithSource() error = %v", err)
+	}
+	if _, err := strict.Get("openai"); err == nil {
+		t.Error("Get() without legacy fallback should fail for machine-keyed store")
 	}
 }

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -73,22 +73,30 @@ If `IRIS_KEYSTORE_KEY` is not set, Iris falls back to V1 mode which derives the 
 - Current username
 - A static salt
 
-**Security Note**: V1 is convenient for development but the key is predictable. Anyone with access to your machine can derive the same key. Use V2 with `IRIS_KEYSTORE_KEY` for production.
+**Security Note**: V1 is convenient for development but the key is predictable. Anyone with access to your machine can derive the same key. Use V2 with `IRIS_KEYSTORE_KEY` for production. The CLI prints a warning on every keystore operation while in V1 mode.
 
 ### Migrating from V1 to V2
 
-Existing V1 keystores are automatically read when you set `IRIS_KEYSTORE_KEY`. On the next write operation, the keystore is upgraded to V2 format. A backup of the V1 file is created at `~/.iris/keys.enc.v1.bak`.
+All CLI commands (`iris keys`, `iris chat`) honor `IRIS_KEYSTORE_KEY`. Existing stores written in legacy mode remain readable after you set it: decryption falls back to the machine-derived key, and the store is re-encrypted under your master key on the next write.
 
-To manually migrate:
+To migrate explicitly (recommended):
+
+```bash
+export IRIS_KEYSTORE_KEY=$(openssl rand -base64 32)
+iris keys migrate
+```
+
+`iris keys migrate` re-encrypts `~/.iris/keys.enc` in V2 format under the master key and preserves the previous file at `~/.iris/keys.enc.bak`. Delete the backup once you have verified the migration (`rm ~/.iris/keys.enc.bak`) — it still contains the weakly-encrypted data. `iris keys list` reports the keystore format and warns when a migration is pending.
+
+The same operation is available programmatically:
 
 ```go
 import "github.com/petal-labs/iris/cli/keystore"
 
-ks, _ := keystore.NewFileKeystoreWithSource(
-    keystore.DefaultKeystorePath(),
-    &keystore.EnvMasterKeySource{},
-)
-ks.MigrateToV2()
+ks, _ := keystore.NewKeystoreAtPath(keystore.DefaultKeystorePath())
+if fk, ok := ks.(*keystore.FileKeystore); ok {
+    result, err := fk.MigrateToV2() // keystore.MigrateRekeyed on success
+}
 ```
 
 ## Secret Type

--- a/docs/changes/2026-08-17_v0.18.0_keystore-master-key-wiring.md
+++ b/docs/changes/2026-08-17_v0.18.0_keystore-master-key-wiring.md
@@ -1,0 +1,148 @@
+---
+date: 2026-08-17
+version: v0.18.0
+feature: Keystore Master Key Wiring and Migration (Issue #54)
+product: iris
+change_type: security
+affected_components: [cli/keystore/keystore.go, cli/keystore/file.go, cli/keystore/keystore_test.go, cli/commands/keys.go, cli/commands/keys_test.go, cli/commands/chat.go, README.md, docs/SECURITY.md]
+related_frds: []
+---
+
+## Summary
+
+This change closes issue #54 by wiring the CLI's keystore to the master-key machinery that previously existed but was dead code. `keystore.NewKeystore()` now honors the `IRIS_KEYSTORE_KEY` environment variable (V2 format: Argon2id + AES-256-GCM), a new `iris keys migrate` command re-encrypts legacy stores under the master key, and legacy stores remain readable during the transition via a decryption fallback plus automatic re-encryption on the next write. A latent bug in the V1 decryption key schedule (a double hash that could not decrypt files written by the original v1 implementation) is also fixed.
+
+## Motivation
+
+`README.md` and `docs/SECURITY.md` documented production-grade keystore encryption (`IRIS_KEYSTORE_KEY`, Argon2id, AES-256-GCM), but every CLI invocation went through `NewKeystore()` → `NewFileKeystore()` → the insecure machine-derived V1 key. The secure path (`EnvMasterKeySource`, `NewFileKeystoreWithSource`, `MigrateToV2`) was implemented and tested but never reachable from the CLI. Users following the docs believed their API keys were strongly encrypted when the key was derivable from public machine data (hostname + username + static salt).
+
+## What Changed
+
+### New Additions
+
+- `keystore.NewKeystoreAtPath(path string) (Keystore, error)` — like `NewKeystore()` but opens the store at an explicit path; both are now master-key aware.
+- `func (f *FileKeystore) WithLegacyKeyFallback() *FileKeystore` — enables decryption of stores written by older versions (v1-format files and v2-format files keyed with the machine-derived key). The master key is tried first; the legacy key only on failure.
+- `func (f *FileKeystore) UsesLegacyKey() bool` — reports whether the keystore was opened with the insecure machine-derived key.
+- `func (f *FileKeystore) NeedsMigration() (bool, error)` — reports whether the store file can be decrypted with the current master key alone.
+- `func (f *FileKeystore) Path() string` — returns the keystore file path.
+- `keystore.MigrateResult` with `MigrateNone`, `MigrateAlreadyCurrent`, `MigrateRekeyed` — outcome codes for `MigrateToV2`.
+- `iris keys migrate` CLI command (`cli/commands/keys.go`) — re-encrypts `~/.iris/keys.enc` in V2 format under `IRIS_KEYSTORE_KEY`, preserving the previous file at `~/.iris/keys.enc.bak`. Errors with setup instructions if `IRIS_KEYSTORE_KEY` is not set.
+- Legacy-mode warning: every keystore-backed command (`iris keys set/list/delete`, `iris chat`) prints a warning to stderr when running with the machine-derived key.
+- `iris keys list` now prints a status line: current V2 state, pending migration, or legacy mode.
+
+### Modifications
+
+- `keystore.NewKeystore()` — before: always `NewFileKeystore(DefaultKeystorePath())` (machine key). After: if `IRIS_KEYSTORE_KEY` is set, uses `NewFileKeystoreWithSource(..., &EnvMasterKeySource{}).WithLegacyKeyFallback()`; otherwise falls back to the previous behavior (machine key, V1 mode).
+- `FileKeystore.MigrateToV2()` — signature changed from `error` to `(MigrateResult, error)`, and semantics changed from "convert v1-format to v2-format using the same master key" to "re-key: decrypt via master key or legacy fallback, re-encrypt under the master key". Backup renamed from `<path>.v1.bak` to `<path>.bak`. The call is idempotent. The previous semantics could not migrate any real store: it returned early ("already v2") for machine-keyed V2 files, which is what all current CLI users have.
+- `FileKeystore` decryption internals — `decryptV2`/`decryptV1` methods replaced by package functions `decryptV2WithKey(masterKey, ciphertext)` and `decryptV1WithKey(key, ciphertext)`; `loadData` now falls back to the legacy machine key when the master key fails.
+- **V1 key schedule fix**: `decryptV1WithKey` uses the given key directly as the AES key, matching the original v1 implementation (initial commit). The removed `deriveKeyFromMasterV1` computed `SHA256(masterKey)`; under `NewFileKeystore` (where masterKey is already `SHA256(machine-data)`) that double hash could not decrypt any file ever written by a released version.
+- `cli/commands/chat.go` — opens the keystore via the new `a.openKeystore()` helper (adds the legacy-mode warning).
+
+### Removals
+
+- `FileKeystore.deriveKeyFromMasterV1` (unexported, superseded by `decryptV1WithKey`; matched no real file format).
+- The `<path>.v1.bak` backup naming (replaced by `<path>.bak`).
+
+## Technical Specification
+
+### Keystore Construction Flow
+
+```
+IRIS_KEYSTORE_KEY set?    master key              legacy fallback key     mode
+yes                       IRIS_KEYSTORE_KEY       machine-derived         V2 (writes re-key legacy stores)
+no (unset/empty)          machine-derived          none                   V1 legacy (warned on every op)
+```
+
+### Read/Write Semantics (master key set)
+
+- Read: try master key → on failure, try machine-derived key (both v2 and v1 wire formats).
+- Write: always V2 format under the master key. Any `Set`/`Delete` on a legacy store transparently re-keys it.
+- `MigrateToV2()`: no file/empty → `MigrateNone`; v2 + master-key decryptable → `MigrateAlreadyCurrent`; else decrypt (master, then legacy), backup to `<path>.bak` (0600), write V2 → `MigrateRekeyed`.
+
+### CLI Interface
+
+```
+iris keys migrate
+  Re-encrypts ~/.iris/keys.enc in V2 format using the IRIS_KEYSTORE_KEY master key.
+  Preserves the previous file at ~/.iris/keys.enc.bak.
+  Fails with setup instructions when IRIS_KEYSTORE_KEY is not set.
+
+iris keys list
+  First line is now a status line:
+    "Keystore: v2 format, IRIS_KEYSTORE_KEY master key."
+    "Keystore: pending migration to the IRIS_KEYSTORE_KEY master key (run 'iris keys migrate')."
+    "Keystore: legacy machine-derived key (set IRIS_KEYSTORE_KEY and run 'iris keys migrate' to upgrade)."
+```
+
+stderr warning on any keystore operation without `IRIS_KEYSTORE_KEY`:
+
+```
+Warning: IRIS_KEYSTORE_KEY is not set; API keys are encrypted with a predictable machine-derived key.
+Set a master key and migrate: export IRIS_KEYSTORE_KEY=$(openssl rand -base64 32) && iris keys migrate
+```
+
+## Usage Examples
+
+### Example: fresh setup with a master key
+
+```bash
+export IRIS_KEYSTORE_KEY=$(openssl rand -base64 32)
+iris keys set openai        # prompted; stored V2/Argon2id
+iris keys list              # "Keystore: v2 format, IRIS_KEYSTORE_KEY master key."
+iris chat --provider openai --model gpt-5.6 --prompt "Hi"
+```
+
+### Example: migrating an existing store
+
+```bash
+export IRIS_KEYSTORE_KEY=$(openssl rand -base64 32)
+iris keys migrate
+# Keystore migrated to v2 format under the IRIS_KEYSTORE_KEY master key.
+# Backup of the previous store saved to /home/you/.iris/keys.enc.bak
+# Delete the backup once verified: rm /home/you/.iris/keys.enc.bak
+```
+
+### Example: without a master key (legacy mode)
+
+```bash
+unset IRIS_KEYSTORE_KEY
+iris keys list
+# stderr: Warning: IRIS_KEYSTORE_KEY is not set; API keys are encrypted with a predictable machine-derived key.
+# stdout: Keystore: legacy machine-derived key (set IRIS_KEYSTORE_KEY and run 'iris keys migrate' to upgrade).
+```
+
+### Error case: migrate without a master key
+
+```bash
+$ iris keys migrate
+Error: IRIS_KEYSTORE_KEY is not set; migration requires a master key.
+
+Set one first, e.g.:
+  export IRIS_KEYSTORE_KEY=$(openssl rand -base64 32)
+
+Then re-run: iris keys migrate
+```
+
+## Integration Notes
+
+- CLI-only change; the SDK (`core/`, `providers/`) is untouched. No config-file changes.
+- Existing stores (machine-keyed V2 format from v0.9.0+, and original v1-format files from the initial release) remain readable after setting `IRIS_KEYSTORE_KEY`, via the fallback. The v1-format path was previously broken (double-hash bug); this change restores genuine compatibility with those files.
+- `MigrateToV2`'s signature change is breaking for direct callers of `cli/keystore`; no such callers exist in the repository, and the package is CLI-internal tooling.
+- Docs (README "Security" section, docs/SECURITY.md "Migrating from V1 to V2") updated to match behavior; the old docs described a `.v1.bak` backup name that no longer exists.
+
+## Breaking Changes & Migration
+
+- `FileKeystore.MigrateToV2()` now returns `(MigrateResult, error)` instead of `error`. In-repo consumers: none. External users of `cli/keystore` (unusual; it is CLI tooling) must adapt to the two-value return.
+- Migrate backup path changed from `<path>.v1.bak` to `<path>.bak`.
+- `iris keys list` output gained a leading status line; scripts parsing its output strictly may need updating.
+
+## Deferred / Out of Scope
+
+- `PromptMasterKeySource` remains library-only (no interactive prompt flow in the CLI); the env-var flow covers the acceptance criteria.
+- No `iris keys get`/`export` commands, and no config-file support for the master key (env var only) — both deferred.
+
+## Testing Notes
+
+- `cli/keystore/keystore_test.go` additions: `TestNewKeystoreEnvAware`, `TestNewKeystoreLegacyMode`, `TestLegacyFallbackReadAndAutoUpgrade`, `TestMigrateToV2RekeysMachineKeyedStore`, `TestMigrateToV2FromV1Format` (writes a byte-exact original-v1-format file), `TestMigrateToV2NoStore`, `TestMigrateToV2WrongKeyFails`, `TestStrictStoreCannotReadLegacyWithoutFallback`.
+- `cli/commands/keys_test.go` (new): `TestKeysSetAndListLegacyModeWarns`, `TestKeysSetListDeleteWithMasterKey`, `TestKeysSetEmptyKeyRejected`, `TestKeysListPendingMigration`, `TestKeysMigrateRequiresMasterKey`, `TestKeysMigrateRekeysStore` (verifies backup file on disk and readability by a strict master-key store).
+- Existing suites re-run green: `go test ./cli/...`, `go build ./...`, `go vet ./cli/...`, `gofmt` clean. Integration CLI tests (`tests/integration/cli_test.go`) unaffected: they run without `IRIS_KEYSTORE_KEY`, exercising the unchanged legacy fallback path.


### PR DESCRIPTION
## Summary

Closes #54.

The README and `docs/SECURITY.md` documented master-key keystore encryption (`IRIS_KEYSTORE_KEY`, Argon2id, AES-256-GCM), but the CLI never used it — every invocation encrypted API keys with the predictable machine-derived V1 key, and the secure path (`EnvMasterKeySource`, `NewFileKeystoreWithSource`, `MigrateToV2`) was dead code outside tests.

This PR wires the secure path into the CLI and adds migration tooling.

## Changes

**Keystore** (`cli/keystore/`)
- `NewKeystore()` / new `NewKeystoreAtPath(path)`: use `IRIS_KEYSTORE_KEY` (V2) when set; documented machine-key fallback when not
- `WithLegacyKeyFallback()`: decryption tries the master key first, then the legacy machine key — stores written by older versions stay readable and are transparently re-encrypted on the next write
- `MigrateToV2()` reworked into a true re-key returning `(MigrateResult, error)`: handles machine-keyed V2 files (what all current users have) and original v1-format files, idempotent, backup at `<path>.bak`
- **Bug fix**: the old v1 decryption path double-hashed the key and could never decrypt files written by the original v1 implementation; restored the original key schedule
- New accessors: `UsesLegacyKey()`, `NeedsMigration()`, `Path()`

**CLI** (`cli/commands/`)
- New `iris keys migrate` — re-keys `~/.iris/keys.enc` under the master key; errors with setup instructions if `IRIS_KEYSTORE_KEY` is unset
- Legacy-mode warning printed to stderr on every keystore-backed command (`keys set/list/delete`, `chat`)
- `iris keys list` prints a keystore status line (v2 / pending migration / legacy)

**Docs**
- README Security section + CLI examples, `docs/SECURITY.md` migration section, `docs/changes/2026-08-17_v0.18.0_keystore-master-key-wiring.md` per repo policy

## Acceptance criteria (from #54)

- [x] With `IRIS_KEYSTORE_KEY` set, `iris keys set` writes a V2 file and `iris keys list` reads it back
- [x] `iris keys migrate` upgrades an existing V1 store non-destructively (backup at `keys.enc.bak`)
- [x] Without a master key, behavior is documented and warns the user they are on V1
- [x] README/SECURITY docs match actual behavior

## Testing

- 14 new tests: keystore env-aware construction, legacy fallback read + auto-upgrade on write, re-key migration (machine-keyed and v1-format stores), idempotency, wrong-key failure, strict-store isolation; command-level tests for set/list/delete, warnings, status lines, and migrate flows
- `go build ./...`, `go vet ./...`, `gofmt` clean; full `go test ./...` green
- Manual end-to-end run of the built binary: legacy warn → pending-migration → migrate → v2 → idempotent re-run, plus both error paths (no master key, wrong master key)

## Breaking notes

- `FileKeystore.MigrateToV2()` signature changed (`error` → `(MigrateResult, error)`); no in-repo callers, package is CLI-internal tooling
- Migrate backup renamed `.v1.bak` → `.bak`; `iris keys list` gained a leading status line