### PR TITLE
feat(perplexity): surface citations and wire core search options

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,31 @@ func main() {
 }
 ```
 
+#### Search Options and Citations
+
+Control how Perplexity grounds its search and retrieve the sources it used. Domain filters accept a `-` prefix to exclude a domain, and `Recency` limits result freshness (`hour`, `day`, `week`, `month`, `year`):
+
+```go
+resp, err := client.Chat(perplexity.ModelSonar).
+    User("Summarize the latest Go release notes").
+    SearchOptions(&core.SearchOptions{
+        SearchDomainFilter: []string{"go.dev", "-old.docs.example.com"},
+        Recency:            core.SearchRecencyMonth,
+        Mode:               core.SearchModeWeb, // or SearchModeAcademic / SearchModeSEC
+    }).
+    GetResponse(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Println(resp.Output)
+for _, url := range resp.Citations {
+    fmt.Println("source:", url)
+}
+```
+
+Citations are also populated on the final response of a stream (`core.DrainStream` returns them). Requests carrying `SearchOptions` against providers without web-search support fail fast with `core.ErrSearchUnsupported` before any HTTP call is made.
+
 ### Using Ollama
 
 ```go

--- a/core/client.go
+++ b/core/client.go
@@ -202,6 +202,32 @@ func (b *ChatBuilder) ReasoningEffort(level ReasoningEffort) *ChatBuilder {
 	return b
 }
 
+// SearchOptions configures web-search grounding for providers that support
+// FeatureWebSearch (currently Perplexity). Passing a nil pointer clears any
+// previously set options. Requests carrying search options against a
+// provider without the capability fail validation with ErrSearchUnsupported
+// before any HTTP call is made.
+//
+// Note: this is distinct from WebSearch(), which enables OpenAI's built-in
+// web_search tool on the Responses API. SearchOptions controls how
+// search-native providers ground their results.
+//
+//	resp, err := client.Chat(perplexity.ModelSonar).
+//	    User("Latest Go release notes").
+//	    SearchOptions(&core.SearchOptions{
+//	        SearchDomainFilter: []string{"go.dev"},
+//	        Recency:            core.SearchRecencyMonth,
+//	    }).
+//	    GetResponse(ctx)
+//
+//	for _, url := range resp.Citations {
+//	    fmt.Println(url)
+//	}
+func (b *ChatBuilder) SearchOptions(opts *SearchOptions) *ChatBuilder {
+	b.req.SearchOptions = opts
+	return b
+}
+
 // BuiltInTool adds a built-in tool to the request.
 func (b *ChatBuilder) BuiltInTool(toolType string) *ChatBuilder {
 	b.req.BuiltInTools = append(b.req.BuiltInTools, BuiltInTool{Type: toolType})
@@ -342,6 +368,16 @@ func (b *ChatBuilder) Clone() *ChatBuilder {
 			}
 			copy(clone.req.ToolResources.FileSearch.VectorStoreIDs, b.req.ToolResources.FileSearch.VectorStoreIDs)
 		}
+	}
+
+	// Deep copy SearchOptions
+	if b.req.SearchOptions != nil {
+		searchCopy := *b.req.SearchOptions
+		if len(b.req.SearchOptions.SearchDomainFilter) > 0 {
+			searchCopy.SearchDomainFilter = make([]string, len(b.req.SearchOptions.SearchDomainFilter))
+			copy(searchCopy.SearchDomainFilter, b.req.SearchOptions.SearchDomainFilter)
+		}
+		clone.req.SearchOptions = &searchCopy
 	}
 
 	return clone
@@ -550,6 +586,17 @@ func (b *ChatBuilder) validate() error {
 				}
 				break
 			}
+		}
+	}
+
+	// Capability gate: reject requests carrying web-search options against
+	// a provider that does not support core.FeatureWebSearch. This fails
+	// fast instead of silently sending a request whose search directives
+	// the provider would ignore.
+	if b.req.SearchOptions != nil {
+		if !b.client.provider.Supports(FeatureWebSearch) {
+			return fmt.Errorf("%w: provider %s model %s",
+				ErrSearchUnsupported, b.client.provider.ID(), b.req.Model)
 		}
 	}
 

--- a/core/errors.go
+++ b/core/errors.go
@@ -75,6 +75,12 @@ var ErrInvalidSchema = errors.New("invalid json schema for strict structured out
 // output.
 var ErrStructuredOutputUnsupported = errors.New("structured output not supported by this provider or model")
 
+// ErrSearchUnsupported indicates a request carried core.SearchOptions
+// targeting a provider that does not support core.FeatureWebSearch.
+// validate() returns this before the request is sent so callers fail fast
+// instead of sending a request whose search directives would be ignored.
+var ErrSearchUnsupported = errors.New("web search options not supported by this provider")
+
 // ErrTimeout indicates an Iris-imposed execution timeout elapsed before the
 // provider call completed. It wraps context.DeadlineExceeded, so
 // errors.Is(err, context.DeadlineExceeded) also holds.

--- a/core/search.go
+++ b/core/search.go
@@ -1,0 +1,44 @@
+package core
+
+// SearchRecencyFilter limits web-search results by freshness for
+// search-grounded providers (currently Perplexity).
+type SearchRecencyFilter string
+
+// Supported search recency filters.
+const (
+	SearchRecencyHour  SearchRecencyFilter = "hour"
+	SearchRecencyDay   SearchRecencyFilter = "day"
+	SearchRecencyWeek  SearchRecencyFilter = "week"
+	SearchRecencyMonth SearchRecencyFilter = "month"
+	SearchRecencyYear  SearchRecencyFilter = "year"
+)
+
+// SearchMode selects the corpus searched by search-grounded providers.
+type SearchMode string
+
+// Supported search modes.
+const (
+	// SearchModeWeb searches the general web (default).
+	SearchModeWeb SearchMode = "web"
+	// SearchModeAcademic searches academic sources (Perplexity).
+	SearchModeAcademic SearchMode = "academic"
+	// SearchModeSEC searches SEC filings (Perplexity).
+	SearchModeSEC SearchMode = "sec"
+)
+
+// SearchOptions configures web-search grounding for providers that support
+// FeatureWebSearch (currently Perplexity). Set them via
+// ChatBuilder.SearchOptions; requests carrying search options against a
+// provider without the capability are rejected with ErrSearchUnsupported
+// before any HTTP call is made.
+type SearchOptions struct {
+	// SearchDomainFilter restricts results to the listed domains. A domain
+	// prefixed with "-" is excluded instead of included (e.g. "-example.com").
+	SearchDomainFilter []string `json:"search_domain_filter,omitempty"`
+
+	// Recency limits results by freshness (hour, day, week, month, year).
+	Recency SearchRecencyFilter `json:"search_recency_filter,omitempty"`
+
+	// Mode selects the search corpus: web (default), academic, or sec.
+	Mode SearchMode `json:"search_mode,omitempty"`
+}

--- a/core/search_test.go
+++ b/core/search_test.go
@@ -1,0 +1,146 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// searchProvider accepts any request and records the last one it saw.
+type searchProvider struct {
+	lastReq *ChatRequest
+}
+
+func (p *searchProvider) ID() string          { return "searchy" }
+func (p *searchProvider) Models() []ModelInfo { return nil }
+func (p *searchProvider) Supports(feature Feature) bool {
+	return feature == FeatureChat || feature == FeatureWebSearch
+}
+
+func (p *searchProvider) Chat(ctx context.Context, req *ChatRequest) (*ChatResponse, error) {
+	p.lastReq = req
+	return &ChatResponse{ID: "resp-1", Model: req.Model, Output: "ok"}, nil
+}
+
+func (p *searchProvider) StreamChat(ctx context.Context, req *ChatRequest) (*ChatStream, error) {
+	p.lastReq = req
+	ch := make(chan ChatChunk, 1)
+	errCh := make(chan error, 1)
+	finalCh := make(chan *ChatResponse, 1)
+	go func() {
+		ch <- ChatChunk{Delta: "ok"}
+		close(ch)
+		finalCh <- &ChatResponse{ID: "resp-1", Model: req.Model, Output: "ok"}
+		close(finalCh)
+		close(errCh)
+	}()
+	return &ChatStream{Ch: ch, Err: errCh, Final: finalCh}, nil
+}
+
+func TestSearchOptionsReachProvider(t *testing.T) {
+	p := &searchProvider{}
+	c := NewClient(p)
+
+	opts := &SearchOptions{
+		SearchDomainFilter: []string{"go.dev", "-example.com"},
+		Recency:            SearchRecencyMonth,
+		Mode:               SearchModeAcademic,
+	}
+	_, err := c.Chat("sonar").User("hi").SearchOptions(opts).GetResponse(context.Background())
+	if err != nil {
+		t.Fatalf("GetResponse() error = %v", err)
+	}
+
+	if p.lastReq == nil || p.lastReq.SearchOptions == nil {
+		t.Fatal("request reached provider without SearchOptions")
+	}
+	got := p.lastReq.SearchOptions
+	if len(got.SearchDomainFilter) != 2 || got.SearchDomainFilter[0] != "go.dev" || got.SearchDomainFilter[1] != "-example.com" {
+		t.Errorf("SearchDomainFilter = %v, want [go.dev -example.com]", got.SearchDomainFilter)
+	}
+	if got.Recency != SearchRecencyMonth {
+		t.Errorf("Recency = %q, want %q", got.Recency, SearchRecencyMonth)
+	}
+	if got.Mode != SearchModeAcademic {
+		t.Errorf("Mode = %q, want %q", got.Mode, SearchModeAcademic)
+	}
+}
+
+func TestSearchOptionsUnsupportedIsHardError(t *testing.T) {
+	// nonStructuredProvider.Supports returns false for everything, so it
+	// lacks FeatureWebSearch; Chat must never be reached.
+	c := NewClient(nonStructuredProvider{t: t})
+	_, err := c.Chat("sonar").User("hi").
+		SearchOptions(&SearchOptions{Recency: SearchRecencyDay}).
+		GetResponse(context.Background())
+	if !errors.Is(err, ErrSearchUnsupported) {
+		t.Fatalf("err = %v, want ErrSearchUnsupported", err)
+	}
+}
+
+func TestSearchOptionsNilAllowedOnAnyProvider(t *testing.T) {
+	// No SearchOptions set: no gating, even on providers without the feature.
+	c := NewClient(nonStructuredButChattyProvider{})
+	_, err := c.Chat("m").User("hi").GetResponse(context.Background())
+	if err != nil {
+		t.Fatalf("GetResponse() error = %v", err)
+	}
+}
+
+func TestSearchOptionsClearWithNil(t *testing.T) {
+	b := NewClient(&searchProvider{}).Chat("sonar").
+		SearchOptions(&SearchOptions{Recency: SearchRecencyWeek})
+	if b.req.SearchOptions == nil {
+		t.Fatal("SearchOptions not set")
+	}
+	b.SearchOptions(nil)
+	if b.req.SearchOptions != nil {
+		t.Errorf("SearchOptions = %v after nil, want nil", b.req.SearchOptions)
+	}
+}
+
+func TestCloneWithSearchOptions(t *testing.T) {
+	p := &searchProvider{}
+	client := NewClient(p)
+
+	original := client.Chat("sonar").
+		User("Test").
+		SearchOptions(&SearchOptions{
+			SearchDomainFilter: []string{"go.dev"},
+			Recency:            SearchRecencyMonth,
+			Mode:               SearchModeWeb,
+		})
+
+	clone := original.Clone()
+
+	if clone.req.SearchOptions == nil {
+		t.Fatal("clone.SearchOptions is nil")
+	}
+	if clone.req.SearchOptions.Recency != SearchRecencyMonth {
+		t.Errorf("clone.Recency = %q, want %q", clone.req.SearchOptions.Recency, SearchRecencyMonth)
+	}
+	if clone.req.SearchOptions.Mode != SearchModeWeb {
+		t.Errorf("clone.Mode = %q, want %q", clone.req.SearchOptions.Mode, SearchModeWeb)
+	}
+
+	// Independence: mutating the clone's options must not affect the original.
+	clone.req.SearchOptions.Recency = SearchRecencyYear
+	clone.req.SearchOptions.SearchDomainFilter[0] = "mutated.dev"
+	if original.req.SearchOptions.Recency != SearchRecencyMonth {
+		t.Errorf("original.Recency = %q, want %q (clone mutation leaked)", original.req.SearchOptions.Recency, SearchRecencyMonth)
+	}
+	if original.req.SearchOptions.SearchDomainFilter[0] != "go.dev" {
+		t.Errorf("original.SearchDomainFilter[0] = %q, want go.dev (clone mutation leaked)", original.req.SearchOptions.SearchDomainFilter[0])
+	}
+}
+
+func TestChatResponseHasCitations(t *testing.T) {
+	r := &ChatResponse{}
+	if r.HasCitations() {
+		t.Error("HasCitations() = true for nil citations")
+	}
+	r.Citations = []string{"https://example.com"}
+	if !r.HasCitations() {
+		t.Error("HasCitations() = false with one citation")
+	}
+}

--- a/core/types.go
+++ b/core/types.go
@@ -18,6 +18,7 @@ const (
 	FeatureReranking                Feature = "reranking"
 	FeatureStructuredOutput         Feature = "structured_output"
 	FeatureBatch                    Feature = "batch"
+	FeatureWebSearch                Feature = "web_search"
 )
 
 // ResponseFormat specifies the output format constraint for chat responses.
@@ -282,6 +283,12 @@ type ChatRequest struct {
 	PreviousResponseID string          `json:"previous_response_id,omitempty"`
 	Truncation         string          `json:"truncation,omitempty"`
 	ToolResources      *ToolResources  `json:"tool_resources,omitempty"`
+
+	// Web-search grounding options for providers that support
+	// FeatureWebSearch (currently Perplexity). Requests carrying search
+	// options against a provider without the capability are rejected by the
+	// builder with ErrSearchUnsupported before any HTTP call is made.
+	SearchOptions *SearchOptions `json:"search_options,omitempty"`
 }
 
 // ChatResponse represents a response from a chat model.
@@ -292,6 +299,10 @@ type ChatResponse struct {
 	Output    string     `json:"output"`
 	Usage     TokenUsage `json:"usage"`
 	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
+
+	// Citations contains the source URLs consulted by search-grounded
+	// providers (currently Perplexity). Empty for providers without search.
+	Citations []string `json:"citations,omitempty"`
 
 	// Responses API fields
 	Reasoning *ReasoningOutput `json:"reasoning,omitempty"`
@@ -319,6 +330,11 @@ func (r *ChatResponse) FirstToolCall() *ToolCall {
 // HasReasoning reports whether the response contains reasoning output.
 func (r *ChatResponse) HasReasoning() bool {
 	return r.Reasoning != nil && len(r.Reasoning.Summary) > 0
+}
+
+// HasCitations reports whether the response carries search citations.
+func (r *ChatResponse) HasCitations() bool {
+	return len(r.Citations) > 0
 }
 
 // ChatChunk represents an incremental streaming response.

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -217,7 +217,8 @@ resp, err := client.Chat(xai.ModelGrok4).
 
 **Special Features**:
 - Built-in web search and grounding
-- Citation support
+- Search controls via `core.SearchOptions` (domain filter with `-` exclusion, recency, search mode) — set with `ChatBuilder.SearchOptions`
+- Citation support: response and streamed-final `Citations []string` on `core.ChatResponse`
 - Research report generation
 
 **Usage Example**:
@@ -227,7 +228,19 @@ client := core.NewClient(provider)
 
 resp, err := client.Chat(perplexity.ModelSonarPro).
     User("What are the latest developments in AI?").
+    SearchOptions(&core.SearchOptions{
+        SearchDomainFilter: []string{"arxiv.org"},
+        Recency:            core.SearchRecencyMonth,
+    }).
     GetResponse(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Println(resp.Output)
+for _, url := range resp.Citations {
+    fmt.Println("source:", url)
+}
 ```
 
 ---

--- a/docs/changes/2026-08-17_v0.18.0_perplexity-citations-search-options.md
+++ b/docs/changes/2026-08-17_v0.18.0_perplexity-citations-search-options.md
@@ -1,0 +1,146 @@
+---
+date: 2026-08-17
+version: v0.18.0
+feature: Perplexity Citations and Search Options (Issue #55)
+product: iris
+change_type: feature
+affected_components: [core/types.go, core/search.go, core/search_test.go, core/errors.go, core/client.go, providers/perplexity/provider.go, providers/perplexity/mapping.go, providers/perplexity/mapping_test.go, providers/perplexity/streaming.go, providers/perplexity/streaming_test.go, tests/integration/perplexity_test.go, README.md, docs/PROVIDERS.md]
+related_frds: []
+---
+
+## Summary
+
+This change closes issue #55 by surfacing Perplexity's search grounding in the Iris API. `core.ChatResponse` gains a `Citations []string` field populated by Perplexity for both unary and streaming calls, and a new provider-agnostic `core.SearchOptions` type (domain filter, recency, search mode) can be attached to any chat request via `ChatBuilder.SearchOptions`. Requests carrying search options against providers without web-search support fail fast with the new `core.ErrSearchUnsupported` sentinel instead of silently sending directives the provider would ignore.
+
+## Motivation
+
+Perplexity is the SDK's only search-grounded provider, but its two most valuable outputs and inputs were unreachable. Citations were parsed from the wire format (`providers/perplexity/types.go`) and then dropped by `mapResponse`, with no field on `core.ChatResponse` to carry them — citations are generally the main reason to use Perplexity. Symmetrically, `perplexityRequest` defined rich search controls (domain filter, recency, date filters, location, search mode) that nothing in `core.ChatRequest` could set, making them dead code.
+
+## What Changed
+
+### New Additions
+
+- `core.SearchOptions` (`core/search.go`) with fields:
+  - `SearchDomainFilter []string` — restrict results to the listed domains; a `-` prefix excludes (Perplexity semantics)
+  - `Recency SearchRecencyFilter` — `hour|day|week|month|year` (typed consts `core.SearchRecencyHour` …)
+  - `Mode SearchMode` — `core.SearchModeWeb` (default), `core.SearchModeAcademic`, `core.SearchModeSEC`
+- `core.FeatureWebSearch Feature = "web_search"` capability constant.
+- `core.ErrSearchUnsupported` sentinel error (`core/errors.go`).
+- `ChatBuilder.SearchOptions(opts *SearchOptions)` builder method (nil clears).
+- `ChatResponse.Citations []string` field + `HasCitations()` helper (`core/types.go`).
+
+### Modifications
+
+- `ChatBuilder.validate()` (`core/client.go`): requests with `SearchOptions` against a provider where `Supports(FeatureWebSearch)` is false are rejected with `ErrSearchUnsupported` before any HTTP call, mirroring the structured-output gate.
+- `ChatBuilder.Clone()`: deep-copies `SearchOptions` (including the domain-filter slice), preserving clone independence.
+- `providers/perplexity/provider.go`: `Supports` now returns true for `core.FeatureWebSearch`.
+- `providers/perplexity/mapping.go`:
+  - `buildRequest` maps `req.SearchOptions` → `search_domain_filter`, `search_recency_filter`, `search_mode` wire fields.
+  - `mapResponse` copies `citations` into `result.Citations`.
+- `providers/perplexity/streaming.go`: citations observed on SSE chunks (Perplexity sends them on the final chunk) are accumulated and delivered on the stream's `Final` response.
+
+### Removals
+
+None.
+
+## Technical Specification
+
+### Data Schemas / Types
+
+```go
+// core/search.go
+type SearchRecencyFilter string // "hour"|"day"|"week"|"month"|"year"
+type SearchMode string          // "web"|"academic"|"sec"
+
+type SearchOptions struct {
+    SearchDomainFilter []string          `json:"search_domain_filter,omitempty"`
+    Recency            SearchRecencyFilter `json:"search_recency_filter,omitempty"`
+    Mode               SearchMode        `json:"search_mode,omitempty"`
+}
+
+// core/types.go (ChatRequest addition)
+SearchOptions *SearchOptions `json:"search_options,omitempty"`
+
+// core/types.go (ChatResponse addition)
+Citations []string `json:"citations,omitempty"`
+func (r *ChatResponse) HasCitations() bool
+```
+
+### Capability Gating
+
+`FeatureWebSearch` is implemented only by Perplexity today. The builder gate is provider-level (not model-level): all Perplexity catalog models are search-grounded, so a per-model check would add no information.
+
+### Wire Mapping (Perplexity)
+
+| core.SearchOptions | Perplexity request field |
+|---|---|
+| `SearchDomainFilter` | `search_domain_filter` (top-level; `-` prefix excludes) |
+| `Recency` | `search_recency_filter` |
+| `Mode` | `search_mode` |
+
+Response `citations` (unary and final SSE chunk) → `ChatResponse.Citations`.
+
+## Usage Examples
+
+### Example: search-grounded request with citations
+
+```go
+resp, err := client.Chat(perplexity.ModelSonar).
+    User("Summarize the latest Go release notes").
+    SearchOptions(&core.SearchOptions{
+        SearchDomainFilter: []string{"go.dev"},
+        Recency:            core.SearchRecencyMonth,
+    }).
+    GetResponse(ctx)
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(resp.Output)
+for _, url := range resp.Citations {
+    fmt.Println("source:", url)
+}
+```
+
+### Example: streaming citations via DrainStream
+
+```go
+stream, _ := client.Chat(perplexity.ModelSonar).User("Latest AI news").Stream(ctx)
+resp, err := core.DrainStream(ctx, stream)
+// resp.Citations is populated from the stream's final chunk
+```
+
+### Error case: search options on a provider without search
+
+```go
+// openai does not declare FeatureWebSearch
+_, err := client.Chat("gpt-5.6").
+    User("hi").
+    SearchOptions(&core.SearchOptions{Recency: core.SearchRecencyDay}).
+    GetResponse(ctx)
+// errors.Is(err, core.ErrSearchUnsupported) == true; no HTTP call was made
+```
+
+## Integration Notes
+
+- `Citations` and `SearchOptions` are additive to `core.ChatRequest`/`core.ChatResponse`; all other providers are unaffected (they never populated citations, and the gate prevents search options from reaching them).
+- `DrainStream` returns the provider's `Final` response, so citations flow through unchanged.
+- Perplexity structured-output wiring (`ResponseFormat` on the wire struct, `FeatureStructuredOutput`) remains out of scope here and is tracked by issue #45.
+- Date filters, location (lat/long/country), `ReturnImages`, `ReturnRelatedQuestions`, and `NumSearchResults` from the Perplexity API remain unexposed; `SearchOptions` covers the acceptance criteria (domain filter + recency). Extending the struct later is additive.
+
+## Breaking Changes & Migration
+
+None. All additions are new fields, methods, constants, and one new capability constant. The capability gate only rejects requests that previously would have been sent with ignored directives.
+
+## Deferred / Out of Scope
+
+- Additional Perplexity search controls (date filters, location, images, related questions, num results) — can be added to `SearchOptions` incrementally.
+- Perplexity structured output (`response_format` wiring) — issue #45.
+- A `FeatureWebSearch`-gated model-level check — deferred until a provider ships mixed search/non-search catalogs.
+
+## Testing Notes
+
+- `core/search_test.go` (new): options reach the provider intact, hard-error gating with `ErrSearchUnsupported`, nil options never gated, nil clears options, `Clone` deep-copy independence, `HasCitations`.
+- `providers/perplexity/mapping_test.go`: `TestMapResponseCitations`, `TestMapResponseNoCitations`, `TestBuildRequestSearchOptions`, `TestBuildRequestNoSearchOptions`.
+- `providers/perplexity/streaming_test.go`: `TestDoStreamChatCitations` (fake SSE server delivers citations on the final chunk; asserted on `Final`).
+- `tests/integration/perplexity_test.go`: `TestPerplexity_ChatCompletion_Citations`, `TestPerplexity_ChatCompletion_StreamingCitations`, `TestPerplexity_ChatCompletion_SearchOptions` (domain filter + recency end-to-end; gated on `PERPLEXITY_API_KEY`).
+- Full suite green: `go build ./...`, `go vet` (incl. `-tags=integration` for tests), `gofmt` clean, `go test ./...`.

--- a/providers/perplexity/mapping.go
+++ b/providers/perplexity/mapping.go
@@ -99,14 +99,22 @@ func buildRequest(req *core.ChatRequest, stream bool) *perplexityRequest {
 		pReq.ReasoningEffort = mapReasoningEffort(req.ReasoningEffort)
 	}
 
+	// Map web-search grounding options if set
+	if req.SearchOptions != nil {
+		pReq.SearchDomainFilter = req.SearchOptions.SearchDomainFilter
+		pReq.SearchRecencyFilter = string(req.SearchOptions.Recency)
+		pReq.SearchMode = string(req.SearchOptions.Mode)
+	}
+
 	return pReq
 }
 
 // mapResponse converts a Perplexity response to an Iris ChatResponse.
 func mapResponse(resp *perplexityResponse) (*core.ChatResponse, error) {
 	result := &core.ChatResponse{
-		ID:    resp.ID,
-		Model: core.ModelID(resp.Model),
+		ID:        resp.ID,
+		Model:     core.ModelID(resp.Model),
+		Citations: resp.Citations,
 	}
 
 	// Map usage if present

--- a/providers/perplexity/mapping_test.go
+++ b/providers/perplexity/mapping_test.go
@@ -412,3 +412,105 @@ type mockTool struct {
 
 func (t *mockTool) Name() string        { return t.name }
 func (t *mockTool) Description() string { return t.description }
+
+func TestMapResponseCitations(t *testing.T) {
+	resp := &perplexityResponse{
+		ID:    "resp-cite",
+		Model: "sonar",
+		Choices: []perplexityChoice{
+			{
+				Index: 0,
+				Message: &perplexityRespMsg{
+					Role:    "assistant",
+					Content: "Paris is the capital of France.",
+				},
+			},
+		},
+		Citations: []string{
+			"https://en.wikipedia.org/wiki/Paris",
+			"https://www.britannica.com/place/Paris-France",
+		},
+	}
+
+	result, err := mapResponse(resp)
+	if err != nil {
+		t.Fatalf("mapResponse() error = %v", err)
+	}
+
+	if len(result.Citations) != 2 {
+		t.Fatalf("Citations length = %d, want 2", len(result.Citations))
+	}
+	if result.Citations[0] != "https://en.wikipedia.org/wiki/Paris" {
+		t.Errorf("Citations[0] = %q, want wikipedia URL", result.Citations[0])
+	}
+	if result.Citations[1] != "https://www.britannica.com/place/Paris-France" {
+		t.Errorf("Citations[1] = %q, want britannica URL", result.Citations[1])
+	}
+	if !result.HasCitations() {
+		t.Error("HasCitations() = false, want true")
+	}
+}
+
+func TestMapResponseNoCitations(t *testing.T) {
+	resp := &perplexityResponse{
+		ID:    "resp-nocite",
+		Model: "sonar",
+		Choices: []perplexityChoice{
+			{Index: 0, Message: &perplexityRespMsg{Role: "assistant", Content: "hi"}},
+		},
+	}
+
+	result, err := mapResponse(resp)
+	if err != nil {
+		t.Fatalf("mapResponse() error = %v", err)
+	}
+	if result.HasCitations() {
+		t.Error("HasCitations() = true for response without citations")
+	}
+}
+
+func TestBuildRequestSearchOptions(t *testing.T) {
+	req := &core.ChatRequest{
+		Model:    "sonar",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Latest Go release"}},
+		SearchOptions: &core.SearchOptions{
+			SearchDomainFilter: []string{"go.dev", "-example.com"},
+			Recency:            core.SearchRecencyMonth,
+			Mode:               core.SearchModeAcademic,
+		},
+	}
+
+	pReq := buildRequest(req, false)
+
+	if len(pReq.SearchDomainFilter) != 2 {
+		t.Fatalf("SearchDomainFilter length = %d, want 2", len(pReq.SearchDomainFilter))
+	}
+	if pReq.SearchDomainFilter[0] != "go.dev" || pReq.SearchDomainFilter[1] != "-example.com" {
+		t.Errorf("SearchDomainFilter = %v, want [go.dev -example.com]", pReq.SearchDomainFilter)
+	}
+	if pReq.SearchRecencyFilter != "month" {
+		t.Errorf("SearchRecencyFilter = %q, want month", pReq.SearchRecencyFilter)
+	}
+	if pReq.SearchMode != "academic" {
+		t.Errorf("SearchMode = %q, want academic", pReq.SearchMode)
+	}
+}
+
+func TestBuildRequestNoSearchOptions(t *testing.T) {
+	req := &core.ChatRequest{
+		Model:    "sonar",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Hi"}},
+	}
+
+	pReq := buildRequest(req, false)
+
+	if pReq.SearchDomainFilter != nil {
+		t.Errorf("SearchDomainFilter = %v, want nil", pReq.SearchDomainFilter)
+	}
+	if pReq.SearchRecencyFilter != "" {
+		t.Errorf("SearchRecencyFilter = %q, want empty", pReq.SearchRecencyFilter)
+	}
+	if pReq.SearchMode != "" {
+		t.Errorf("SearchMode = %q, want empty", pReq.SearchMode)
+	}
+}

--- a/providers/perplexity/provider.go
+++ b/providers/perplexity/provider.go
@@ -71,7 +71,7 @@ func (p *Perplexity) Models() []core.ModelInfo {
 // Supports reports whether the provider supports the given feature.
 func (p *Perplexity) Supports(feature core.Feature) bool {
 	switch feature {
-	case core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling, core.FeatureReasoning:
+	case core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling, core.FeatureReasoning, core.FeatureWebSearch:
 		return true
 	default:
 		return false

--- a/providers/perplexity/streaming.go
+++ b/providers/perplexity/streaming.go
@@ -122,6 +122,7 @@ func (p *Perplexity) processSSEStream(
 	var responseID string
 	var responseModel string
 	var usage *perplexityUsage
+	var citations []string
 
 	for {
 		// Check for context cancellation
@@ -179,6 +180,9 @@ func (p *Perplexity) processSSEStream(
 		if chunk.Usage != nil {
 			usage = chunk.Usage
 		}
+		if len(chunk.Citations) > 0 {
+			citations = chunk.Citations
+		}
 
 		// Process choices
 		for _, choice := range chunk.Choices {
@@ -211,6 +215,7 @@ func (p *Perplexity) processSSEStream(
 		ID:        responseID,
 		Model:     core.ModelID(responseModel),
 		ToolCalls: toolCalls,
+		Citations: citations,
 	}
 
 	if usage != nil {

--- a/providers/perplexity/streaming_test.go
+++ b/providers/perplexity/streaming_test.go
@@ -412,3 +412,51 @@ func TestNewToolCallAssembler(t *testing.T) {
 		t.Fatal("newToolCallAssembler().asm should not be nil")
 	}
 }
+
+func TestDoStreamChatCitations(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+
+		chunks := []string{
+			`data: {"id":"resp-cite","model":"sonar","choices":[{"index":0,"delta":{"role":"assistant","content":"Paris"}}]}`,
+			`data: {"id":"resp-cite","model":"sonar","choices":[{"index":0,"delta":{"content":" is the capital."}}]}`,
+			`data: {"id":"resp-cite","model":"sonar","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15},"citations":["https://en.wikipedia.org/wiki/Paris","https://www.britannica.com/place/Paris-France"]}`,
+			`data: [DONE]`,
+		}
+
+		for _, chunk := range chunks {
+			fmt.Fprintln(w, chunk)
+			fmt.Fprintln(w, "")
+		}
+	}))
+	defer server.Close()
+
+	p := New("test-key", WithBaseURL(server.URL))
+	stream, err := p.doStreamChat(context.Background(), &core.ChatRequest{
+		Model:    "sonar",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "Capital of France?"}},
+	})
+	if err != nil {
+		t.Fatalf("doStreamChat() error = %v", err)
+	}
+
+	for range stream.Ch {
+	}
+
+	finalResp := <-stream.Final
+	if finalResp == nil {
+		t.Fatal("Final response should not be nil")
+	}
+	if len(finalResp.Citations) != 2 {
+		t.Fatalf("Citations length = %d, want 2", len(finalResp.Citations))
+	}
+	if finalResp.Citations[0] != "https://en.wikipedia.org/wiki/Paris" {
+		t.Errorf("Citations[0] = %q, want wikipedia URL", finalResp.Citations[0])
+	}
+	if finalResp.Citations[1] != "https://www.britannica.com/place/Paris-France" {
+		t.Errorf("Citations[1] = %q, want britannica URL", finalResp.Citations[1])
+	}
+	if !finalResp.HasCitations() {
+		t.Error("HasCitations() = false, want true")
+	}
+}

--- a/tests/integration/perplexity_test.go
+++ b/tests/integration/perplexity_test.go
@@ -71,6 +71,98 @@ func TestPerplexity_ChatCompletion_SonarPro(t *testing.T) {
 	t.Logf("Model: %s", perplexity.ModelSonarPro)
 }
 
+func TestPerplexity_ChatCompletion_Citations(t *testing.T) {
+	skipIfNoPerplexityKey(t)
+
+	apiKey := getPerplexityKey(t)
+	provider := perplexity.New(apiKey)
+	client := core.NewClient(provider)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	resp, err := client.Chat(perplexity.ModelSonar).
+		User("What is the capital of France? Answer in one word.").
+		GetResponse(ctx)
+	if err != nil {
+		t.Fatalf("Chat() error = %v", err)
+	}
+
+	if !resp.HasCitations() {
+		t.Fatalf("expected citations in response, got none (output: %s)", resp.Output)
+	}
+	for _, c := range resp.Citations {
+		if !strings.HasPrefix(c, "http") {
+			t.Errorf("citation %q does not look like a URL", c)
+		}
+	}
+	t.Logf("Citations: %v", resp.Citations)
+}
+
+func TestPerplexity_ChatCompletion_StreamingCitations(t *testing.T) {
+	skipIfNoPerplexityKey(t)
+
+	apiKey := getPerplexityKey(t)
+	provider := perplexity.New(apiKey)
+	client := core.NewClient(provider)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	stream, err := client.Chat(perplexity.ModelSonar).
+		User("What is the capital of France? Answer in one word.").
+		Stream(ctx)
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+
+	resp, err := core.DrainStream(ctx, stream)
+	if err != nil {
+		t.Fatalf("DrainStream() error = %v", err)
+	}
+
+	if resp.Output == "" {
+		t.Error("Response output is empty")
+	}
+	if !resp.HasCitations() {
+		t.Fatalf("expected citations in streamed response, got none (output: %s)", resp.Output)
+	}
+	t.Logf("Citations: %v", resp.Citations)
+}
+
+func TestPerplexity_ChatCompletion_SearchOptions(t *testing.T) {
+	skipIfNoPerplexityKey(t)
+
+	apiKey := getPerplexityKey(t)
+	provider := perplexity.New(apiKey)
+	client := core.NewClient(provider)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Domain-filtered, recency-limited search must complete successfully and
+	// return citations drawn from the search.
+	resp, err := client.Chat(perplexity.ModelSonar).
+		User("What is Go? Answer in one sentence.").
+		SearchOptions(&core.SearchOptions{
+			SearchDomainFilter: []string{"go.dev"},
+			Recency:            core.SearchRecencyYear,
+		}).
+		GetResponse(ctx)
+	if err != nil {
+		t.Fatalf("Chat() with SearchOptions error = %v", err)
+	}
+
+	if resp.Output == "" {
+		t.Error("Response output is empty")
+	}
+	if !resp.HasCitations() {
+		t.Errorf("expected citations with search options, got none (output: %s)", resp.Output)
+	}
+	t.Logf("Response: %s", resp.Output)
+	t.Logf("Citations: %v", resp.Citations)
+}
+
 func perplexityChatConformanceConfig() chatConformanceConfig {
 	return chatConformanceConfig{
 		getAPIKey: func(t *testing.T) string {


### PR DESCRIPTION
Closes #55.

## Summary

Perplexity is the SDK's only search-grounded provider, but its most valuable output (citations) was parsed from the wire format and then dropped, and its search controls (domain filter, recency, mode) were dead code that nothing in `core.ChatRequest` could set. This PR surfaces both.

## Changes

**Core**
- `core.SearchOptions` (new, `core/search.go`): `SearchDomainFilter` (`-` prefix excludes), `Recency` (typed `hour|day|week|month|year`), `Mode` (`web|academic|sec`)
- `ChatBuilder.SearchOptions(opts)` — nil clears; `Clone()` deep-copies the options and domain slice
- `ChatResponse.Citations []string` + `HasCitations()` — populated on unary responses and stream finals (`DrainStream` passes them through)
- `core.FeatureWebSearch` capability + `core.ErrSearchUnsupported` sentinel; `validate()` rejects search options on providers without the capability **before any HTTP call**, mirroring the structured-output gate

**Perplexity**
- `Supports(FeatureWebSearch)` → true (only provider today)
- `buildRequest` maps `SearchOptions` → `search_domain_filter` / `search_recency_filter` / `search_mode`
- `mapResponse` and the SSE stream loop (citations ride the final chunk) now deliver citations on the response

## Acceptance criteria (from #55)

- [x] `resp.Citations` populated for `sonar` models (unary + streaming)
- [x] Domain filter and recency settable end-to-end
- [x] Conformance/integration coverage for citations (`PERPLEXITY_API_KEY`-gated)

## Testing

- `core/search_test.go` (new): options reach the provider intact, hard-error gating, nil-never-gated, nil-clears, clone independence, `HasCitations`
- Perplexity unit tests: `TestMapResponseCitations`, `TestMapResponseNoCitations`, `TestBuildRequestSearchOptions`, `TestBuildRequestNoSearchOptions`, `TestDoStreamChatCitations` (fake SSE server)
- Integration: `TestPerplexity_ChatCompletion_Citations`, `_StreamingCitations`, `_SearchOptions`
- Full `go test ./...` green (23 packages), build/vet/gofmt clean, `go vet -tags=integration` clean

## Out of scope (tracked separately)

- Additional Perplexity controls (date filters, location, images, related questions, num results) — additive to `SearchOptions` later
- Perplexity structured-output wiring — #45