### PR TITLE
fix(cli): correct docs drift and allow keyless local ollama chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ if errors.Is(err, core.ErrTimeout) {
 }
 ```
 
-Precedence: a deadline already on the caller's `ctx` always wins; otherwise the per-call `.Timeout(d)` applies; otherwise the client's default. This timeout only covers `Chat`/`Stream` — embeddings, batch, file, and image calls are not subject to it, so pass a `context.WithTimeout` deadline yourself for those. Per-provider `WithTimeout`/`Config.Timeout` options are deprecated in favor of `core.WithTimeout`.
+Precedence: a deadline already on the caller's `ctx` always wins; otherwise the per-call `.Timeout(d)` applies; otherwise the client's default. This timeout covers `Chat`/`Stream` only. Non-chat unary operations (embeddings, batch, files, images, vector stores) are instead bounded by the per-provider `WithTimeout`/`Config.Timeout` option (default 600s), or by a `context.WithTimeout` deadline you supply yourself.
 
 ### Streaming Responses
 
@@ -805,28 +805,25 @@ iris/
 
 ## Configuration
 
-Iris looks for configuration at `~/.iris/config.yaml`:
+Iris looks for configuration at `~/.iris/config.yaml`. The schema is:
+
+| Field | Purpose |
+|---|---|
+| `default_provider` | Provider used when `--provider` is omitted |
+| `default_model` | Model used when `--model` is omitted |
+| `providers.<id>.base_url` | Override a provider's API base URL |
 
 ```yaml
 default_provider: openai
 default_model: gpt-5.6  # or gpt-4o for older models
 
 providers:
-  openai:
-    api_key_env: OPENAI_API_KEY
-  anthropic:
-    api_key_env: ANTHROPIC_API_KEY
-  gemini:
-    api_key_env: GEMINI_API_KEY
-  xai:
-    api_key_env: XAI_API_KEY
-  zai:
-    api_key_env: ZAI_API_KEY
   ollama:
-    # For local Ollama, no API key needed
-    # For Ollama Cloud, set api_key_env: OLLAMA_API_KEY
-    # Custom base URL: base_url: http://localhost:11434
+    # Custom base URL for a remote/local Ollama instance (default: http://localhost:11434)
+    base_url: http://remote-host:11434
 ```
+
+API keys are **not** configured here. The CLI reads provider keys from the encrypted keystore (`iris keys set <provider>`, see [Security](#security)); the SDK reads them from environment variables when you use the provider packages directly.
 
 ## Security
 
@@ -1017,10 +1014,16 @@ make build-cli
 
 # Check version
 ./bin/iris version
-# Output: iris v0.3.0 (abc1234) built 2026-01-30T12:00:00Z
+# Output:
+# iris v0.18.0
+#   commit:     abc1234
+#   built:      2026-08-17T12:00:00Z
+#   go version: go1.24.0
+#   platform:   darwin/arm64
 
 # JSON output
 ./bin/iris version --json
+# Output: {"version":"v0.18.0","commit":"abc1234","buildDate":"2026-08-17T12:00:00Z","goVersion":"go1.24.0","platform":"darwin/arm64"}
 ```
 
 ### Building (without Make)

--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -128,7 +128,7 @@ Use Iris to manage API keys, chat with models, and scaffold projects.`,
 	root.PersistentFlags().StringVar(&a.provider, "provider", "", "provider ID (openai, anthropic, ollama)")
 	root.PersistentFlags().StringVar(&a.model, "model", "", "model ID (e.g. gpt-4o)")
 	root.PersistentFlags().BoolVar(&a.jsonOutput, "json", false, "emit JSON output")
-	root.PersistentFlags().BoolVar(&a.verbose, "verbose", false, "enable debug logging")
+	root.PersistentFlags().BoolVar(&a.verbose, "verbose", false, "print token usage summary after streaming responses")
 
 	root.AddCommand(a.newChatCommand())
 	root.AddCommand(a.newKeysCommand())

--- a/cli/commands/chat.go
+++ b/cli/commands/chat.go
@@ -65,9 +65,17 @@ func (a *App) runChat(cmd *cobra.Command, args []string) error {
 	apiKey, err := ks.Get(providerID)
 	if err != nil {
 		if _, ok := err.(*keystore.ErrKeyNotFound); ok {
-			return exitWithCode(ExitValidation, fmt.Errorf("no API key for %s: run 'iris keys set %s' first", providerID, providerID))
+			// Providers that run locally (e.g. Ollama) work without a stored
+			// key; proceed with an empty key and let the provider decide.
+			// Ollama Cloud still fails at request time with its own
+			// unauthorized error if a key was actually required.
+			if !providerAllowsEmptyAPIKey(providerID) {
+				return exitWithCode(ExitValidation, fmt.Errorf("no API key for %s: run 'iris keys set %s' first", providerID, providerID))
+			}
+			apiKey = ""
+		} else {
+			return exitWithCode(ExitValidation, fmt.Errorf("failed to get API key: %w", err))
 		}
-		return exitWithCode(ExitValidation, fmt.Errorf("failed to get API key: %w", err))
 	}
 
 	// Create provider.

--- a/cli/commands/chat_test.go
+++ b/cli/commands/chat_test.go
@@ -1,9 +1,17 @@
 package commands
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/petal-labs/iris/cli/config"
+	"github.com/petal-labs/iris/cli/keystore"
 	"github.com/petal-labs/iris/core"
 )
 
@@ -162,5 +170,79 @@ func TestHandleChatErrorProvider(t *testing.T) {
 
 	if exitErr.ExitCode() != ExitProvider {
 		t.Errorf("ExitCode() = %d, want %d (ExitProvider)", exitErr.ExitCode(), ExitProvider)
+	}
+}
+
+func TestProviderAllowsEmptyAPIKey(t *testing.T) {
+	if !providerAllowsEmptyAPIKey("ollama") {
+		t.Error("providerAllowsEmptyAPIKey(ollama) = false, want true")
+	}
+	for _, id := range []string{"openai", "anthropic", "gemini", "xai", "zai", "huggingface", ""} {
+		if providerAllowsEmptyAPIKey(id) {
+			t.Errorf("providerAllowsEmptyAPIKey(%q) = true, want false", id)
+		}
+	}
+}
+
+// TestRunChatKeylessOllama verifies that a missing keystore entry does not
+// abort the request for providers that run without an API key (local
+// Ollama). The fake Ollama server proves the request actually went out.
+func TestRunChatKeylessOllama(t *testing.T) {
+	var gotRequest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			http.NotFound(w, r)
+			return
+		}
+		gotRequest = true
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"model":"llama3.2","created_at":"2026-08-17T00:00:00Z","message":{"role":"assistant","content":"hello"},"done":true}`)
+	}))
+	defer server.Close()
+
+	// Keystore at an empty path: Get returns ErrKeyNotFound for everything.
+	app := NewApp(
+		WithKeystoreFactory(func() (keystore.Keystore, error) {
+			return keystore.NewKeystoreAtPath(filepath.Join(t.TempDir(), "keys.enc"))
+		}),
+		WithIO(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}),
+	)
+	// runChat is invoked directly, so config is assigned here instead of
+	// via the root command's PersistentPreRunE.
+	app.cfg = &config.Config{Providers: map[string]config.ProviderConfig{
+		"ollama": {BaseURL: server.URL},
+	}}
+	app.provider = "ollama"
+	app.model = "llama3.2"
+	app.chatPrompt = "hi"
+
+	err := app.runChat(nil, nil)
+	if err != nil {
+		t.Fatalf("runChat() error = %v; want success with no stored key (local ollama)", err)
+	}
+	if !gotRequest {
+		t.Error("no request reached the ollama server; keyless path did not proceed")
+	}
+}
+
+// TestRunChatMissingKeyFailsForKeyedProviders verifies the actionable
+// keystore hint still fires for providers that require a key.
+func TestRunChatMissingKeyFailsForKeyedProviders(t *testing.T) {
+	app := NewApp(
+		WithKeystoreFactory(func() (keystore.Keystore, error) {
+			return keystore.NewKeystoreAtPath(filepath.Join(t.TempDir(), "keys.enc"))
+		}),
+		WithIO(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}),
+	)
+	app.provider = "openai"
+	app.model = "gpt-4o"
+	app.chatPrompt = "hi"
+
+	err := app.runChat(nil, nil)
+	if err == nil {
+		t.Fatal("runChat() should fail for openai with no stored key")
+	}
+	if !strings.Contains(err.Error(), "iris keys set openai") {
+		t.Errorf("error = %q, want actionable 'iris keys set openai' hint", err.Error())
 	}
 }

--- a/cli/commands/provider_factory.go
+++ b/cli/commands/provider_factory.go
@@ -17,6 +17,21 @@ import (
 
 type providerConstructor func(apiKey, baseURL string) (core.Provider, error)
 
+// keylessProviders lists providers that can operate without an API key
+// (local inference). For these, a missing keystore entry is not an error:
+// the provider is constructed with an empty key, and its own behavior
+// decides what happens (local Ollama works; Ollama Cloud fails at request
+// time with the provider's unauthorized error).
+var keylessProviders = map[string]bool{
+	"ollama": true,
+}
+
+// providerAllowsEmptyAPIKey reports whether providerID can be used without
+// an API key stored in the keystore.
+func providerAllowsEmptyAPIKey(providerID string) bool {
+	return keylessProviders[providerID]
+}
+
 func defaultProviderFactory() ProviderFactory {
 	constructors := map[string]providerConstructor{
 		"openai": func(apiKey, baseURL string) (core.Provider, error) {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -303,7 +303,7 @@ When the Iris-applied timeout (not a caller-supplied ctx deadline) elapses, the 
 
 ### Migration Note
 
-Per-provider timeout options (e.g. `openai.WithTimeout`, `Config.Timeout` on each provider) are deprecated in favor of `core.WithTimeout` on the `Client`, which is provider-agnostic and composes with the precedence rules above.
+Per-provider timeout options (e.g. `openai.WithTimeout`, `Config.Timeout` on each provider) apply to that provider's **non-chat unary operations** (embeddings, files, images, batch, vector stores; default 600s). Chat and streaming calls are governed exclusively by `core.WithTimeout` on the `Client` and the precedence rules above. Use the provider option when a specific backend needs a tighter or looser bound on its auxiliary APIs, and `core.WithTimeout` for everything conversational.
 
 ### Alternatives Considered
 

--- a/docs/changes/2026-08-17_v0.18.0_readme-cli-drift-fixes.md
+++ b/docs/changes/2026-08-17_v0.18.0_readme-cli-drift-fixes.md
@@ -1,0 +1,104 @@
+---
+date: 2026-08-17
+version: v0.18.0
+feature: README and CLI Drift Fixes (Issue #56)
+product: iris
+change_type: docs
+affected_components: [cli/commands/chat.go, cli/commands/chat_test.go, cli/commands/provider_factory.go, cli/commands/app.go, README.md, docs/ARCHITECTURE.md]
+related_frds: []
+---
+
+## Summary
+
+This change closes issue #56 by eliminating five documentation-vs-code drift points. One item is fixed in code — `iris chat` no longer requires a keystore entry for local Ollama, making the documented "no API key needed" workflow actually work — and the rest are doc corrections: the config schema example now matches `cli/config` (the `api_key_env` field documented in the README never existed in code), the `iris version` sample output matches the actual multi-line format at a current version, the stale per-provider-timeout "deprecated" text (un-deprecated in v0.17.0) now describes real semantics, and `--verbose` no longer promises debug logging it does not implement.
+
+## Motivation
+
+Users following the README hit broken expectations: copied config YAML was silently ignored (`api_key_env` was removed from `cli/config` in v0.17.0), `iris chat --provider ollama` demanded a key the docs said wasn't needed, the version sample showed an output format and version 14 releases stale, and the timeout docs contradicted the code's behavior. Issue #56 catalogued all five.
+
+## What Changed
+
+### New Additions
+
+- `providerAllowsEmptyAPIKey(providerID string) bool` and the `keylessProviders` set (`cli/commands/provider_factory.go`) — declares which providers run without a stored API key (currently `ollama`).
+
+### Modifications
+
+- `cli/commands/chat.go` (`runChat`): on `keystore.ErrKeyNotFound`, providers in `keylessProviders` proceed with an empty API key instead of aborting; all other providers keep the actionable `no API key for X: run 'iris keys set X' first` error. Local Ollama now works keylessly; Ollama Cloud still fails at request time with the provider's own unauthorized error if a key was required.
+- `cli/commands/app.go`: `--verbose` flag help changed from "enable debug logging" to "print token usage summary after streaming responses" — matching what the flag actually does (`chat.go` usage summary). No behavior change.
+- `README.md`:
+  - **Configuration** section: removed the never-implemented `api_key_env` example; documented the real schema (`default_provider`, `default_model`, `providers.<id>.base_url`) as a table, and clarified that API keys come from the keystore (CLI) or environment variables (SDK), not this file.
+  - **Timeouts** section: replaced "Per-provider `WithTimeout`/`Config.Timeout` options are deprecated in favor of `core.WithTimeout`" with the v0.17.0+ semantics: `core.WithTimeout` governs `Chat`/`Stream`; per-provider `WithTimeout` bounds non-chat unary operations (embeddings, batch, files, images, vector stores; default 600s).
+  - **Building the CLI** section: version sample output updated to the actual multi-line format (`iris <v>` / `commit:` / `built:` / `go version:` / `platform:`) at v0.18.0, plus the `--json` single-line shape.
+- `docs/ARCHITECTURE.md` (Migration Note): same timeout-semantics correction as the README.
+
+### Removals
+
+- The `api_key_env` config example from the README (field does not exist in `cli/config`; its removal was deliberate in v0.17.0, issue #47).
+
+## Technical Specification
+
+### CLI Interface
+
+`iris chat --provider ollama --model <model> --prompt "..."` with **no keystore entry** and **no `IRIS_KEYSTORE_KEY`** now proceeds (previously: exit 1 with `no API key for ollama`). Behavior matrix:
+
+| Provider | No stored key | Result |
+|---|---|---|
+| ollama | empty key → local inference | works (or provider's own error if the server is unreachable / model missing) |
+| all others | exit 1 | `no API key for X: run 'iris keys set X' first` (unchanged) |
+
+`iris keys set ollama` remains the way to store an Ollama Cloud key; `WithAPIKey` is applied when present.
+
+### Configuration
+
+Documented schema (unchanged code, corrected docs):
+
+```yaml
+default_provider: openai      # provider for --provider omissions
+default_model: gpt-5.6        # model for --model omissions
+providers:
+  <provider-id>:
+    base_url: <url>           # optional base URL override
+```
+
+## Usage Examples
+
+### Example: keyless local Ollama chat (previously broken, now works)
+
+```bash
+$ iris chat --provider ollama --model llama3.2 --prompt "Hello"
+> Hello
+Hi there! How can I help you today?
+```
+
+### Example: keyed provider still gets the actionable hint
+
+```bash
+$ iris chat --provider openai --model gpt-5.6 --prompt "Hi"
+Error: no API key for openai: run 'iris keys set openai' first
+```
+
+## Integration Notes
+
+- CLI-only; no SDK surface changed. The `keylessProviders` set lives next to the provider constructor map in `provider_factory.go`, so adding future keyless providers (e.g. other local runtimes) is a one-line change in one file.
+- `tests/integration/cli_test.go` is unaffected: its flows use providers that require keys.
+- Docs changes keep README/ARCHITECTURE aligned with the timeout behavior shipped in v0.17.0 (#44) and the keystore behavior shipped in v0.18.0 (#54).
+
+## Breaking Changes & Migration
+
+None. The keystore-error relaxation only converts a hard CLI failure into a working local-Ollama path; keyed providers behave identically. The `--verbose` help text changed, but the flag's behavior did not.
+
+## Deferred / Out of Scope
+
+- Genuine debug logging behind `--verbose` (request/response wire logging) — would be a feature, tracked informally under CLI parity (issue #62).
+- `api_key_env` config support — deliberately not (re)implemented; removed in v0.17.0 (#47) in favor of the keystore. Docs now match that decision.
+- The remaining README provider-coverage drift (missing huggingface/azurefoundry/voyageai, `providers.List()` output) — separate issue #57.
+
+## Testing Notes
+
+- `cli/commands/chat_test.go` additions:
+  - `TestProviderAllowsEmptyAPIKey` — set membership.
+  - `TestRunChatKeylessOllama` — hermetic end-to-end: empty keystore + fake Ollama HTTP server (via `providers.<id>.base_url` config); asserts the request actually reached the server and `runChat` returned nil.
+  - `TestRunChatMissingKeyFailsForKeyedProviders` — openai with empty keystore still fails with the `iris keys set openai` hint.
+- Note for direct-`runChat` tests: the root command's `PersistentPreRunE` (which loads config) does not run when the runner is invoked directly, so tests must assign `app.cfg` themselves.
+- Full suite green: `go build ./...`, `go vet ./...`, `gofmt` clean, `go test ./...` (23 packages ok).


### PR DESCRIPTION
Closes #56.

## Summary

Five README/docs-vs-code drift points from issue #56. One is fixed in code (keyless local Ollama chat); the rest are doc corrections.

## Changes

**Code — keyless local Ollama (makes the docs true instead of weakening them)**
- `runChat`: on `keystore.ErrKeyNotFound`, providers in the new `keylessProviders` set (ollama) proceed with an empty key instead of aborting — the factory already tolerated empty keys; the command path just never reached it
- Keyed providers keep the actionable `no API key for X: run 'iris keys set X' first` error
- `--verbose` help text changed from "enable debug logging" to "print token usage summary after streaming responses" — matching actual behavior

**Docs**
- **Configuration**: removed the never-implemented `api_key_env` example (field doesn't exist in `cli/config`; deliberately removed in v0.17.0/#47). Documents the real schema — `default_provider`, `default_model`, `providers.<id>.base_url` — and clarifies keys come from the keystore (CLI) or env vars (SDK)
- **Timeouts** (README + `docs/ARCHITECTURE.md`): replaced stale "per-provider WithTimeout deprecated" text with v0.17.0 semantics — `core.WithTimeout` governs Chat/Stream; per-provider `WithTimeout` bounds non-chat unary ops (embeddings, batch, files, images, vector stores; default 600s)
- **Version sample**: updated to the actual multi-line output format at v0.18.0, including the `--json` shape

## Acceptance criteria (from #56)

- [x] Config documentation matches `cli/config` schema
- [x] CLI skips the keystore lookup for local ollama (code fix — README claim now true)
- [x] Version sample output matches actual format and a current version
- [x] Deprecation text updated (README + ARCHITECTURE)
- [x] `--verbose` help text matches behavior

## Testing

- `TestProviderAllowsEmptyAPIKey` — keyless set membership
- `TestRunChatKeylessOllama` — hermetic end-to-end: empty keystore + fake Ollama server via `providers.ollama.base_url` config; asserts the request reached the server and `runChat` succeeded
- `TestRunChatMissingKeyFailsForKeyedProviders` — openai still fails with the `iris keys set openai` hint
- Full `go test ./...` green (23 packages), build/vet/gofmt clean

## Out of scope

- Real debug logging behind `--verbose` (CLI parity, #62)
- README provider-coverage drift (#57)