### PR TITLE
docs(providers): cover all 10 providers, register perplexity, verify matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Building AI applications often requires:
 - Building reusable chat and tool-driven workflows
 
 Iris solves these problems by providing:
-- **Unified SDK**: A consistent Go API across providers (OpenAI, Anthropic, Google Gemini, xAI Grok, Z.ai GLM, Perplexity, Ollama)
+- **Unified SDK**: A consistent Go API across providers (OpenAI, Anthropic, Google Gemini, xAI Grok, Z.ai GLM, Perplexity, Ollama, Hugging Face, Azure AI Foundry, Voyage AI)
 - **Fluent Builder Pattern**: Intuitive, chainable API for constructing requests
 - **Built-in Streaming**: First-class support for streaming responses with proper channel handling
 - **Secure Key Management**: Encrypted local storage for API keys
@@ -785,15 +785,19 @@ iris/
 ├── core/           # Core SDK types and client
 ├── providers/      # LLM provider implementations
 │   ├── internal/   # Shared provider internals (normalize, toolcalls, etc.)
-│   ├── openai/     # OpenAI provider (includes Batch API)
+│   ├── openai/     # OpenAI provider (Batch API, files, vector stores, images)
 │   ├── anthropic/  # Anthropic Claude provider
-│   ├── gemini/     # Google Gemini provider
+│   ├── gemini/     # Google Gemini provider (images)
 │   ├── xai/        # xAI Grok provider
 │   ├── zai/        # Z.ai GLM provider
-│   ├── perplexity/ # Perplexity Search provider
-│   └── ollama/     # Ollama provider (local and cloud)
+│   ├── perplexity/ # Perplexity Search provider (web search + citations)
+│   ├── ollama/     # Ollama provider (local and cloud, embeddings)
+│   ├── huggingface/# Hugging Face Inference Providers router
+│   ├── azurefoundry/# Azure AI Foundry provider (Entra ID auth, embeddings)
+│   └── voyageai/   # Voyage AI provider (embeddings, reranking)
 ├── tools/          # Tool/function calling framework + middleware
 ├── testing/        # Test utilities (MockProvider, RecordingProvider)
+├── contrib/        # Optional integrations (OpenTelemetry hook)
 ├── cli/            # Command-line interface
 │   ├── cmd/iris/   # CLI entry point
 │   ├── commands/   # CLI commands
@@ -871,13 +875,16 @@ See [docs/SECURITY.md](docs/SECURITY.md) for comprehensive security documentatio
 
 | Provider | Status | Features |
 |----------|--------|----------|
-| OpenAI | Supported | Chat, Streaming, Tools, Batch API, Structured Output, Responses API (GPT-5+) |
-| Anthropic | Supported | Chat, Streaming, Tools |
-| Google Gemini | Supported | Chat, Streaming, Tools, Reasoning, Structured Output |
+| OpenAI | Supported | Chat, Streaming, Tools, Batch API, Structured Output, Embeddings, Images, Responses API (GPT-5+) |
+| Anthropic | Supported | Chat, Streaming, Tools, Reasoning |
+| Google Gemini | Supported | Chat, Streaming, Tools, Reasoning, Structured Output, Images |
 | xAI Grok | Supported | Chat, Streaming, Tools, Reasoning |
 | Z.ai GLM | Supported | Chat, Streaming, Tools, Thinking |
-| Perplexity | Supported | Chat, Streaming, Tools, Web Search |
-| Ollama | Supported | Chat, Streaming, Tools, Thinking |
+| Perplexity | Supported | Chat, Streaming, Tools, Reasoning, Web Search + Citations |
+| Ollama | Supported | Chat, Streaming, Tools, Thinking, Embeddings |
+| Hugging Face | Supported | Chat, Streaming, Tools (Inference Providers router, model discovery) |
+| Azure AI Foundry | Supported | Chat, Streaming, Tools, Reasoning, Structured Output, Embeddings (Entra ID auth) |
+| Voyage AI | Supported | Embeddings, Contextualized Embeddings, Reranking (no chat) |
 
 ### xAI Grok Models
 
@@ -1124,6 +1131,9 @@ import (
     "github.com/petal-labs/iris/providers/zai"
     "github.com/petal-labs/iris/providers/perplexity"
     "github.com/petal-labs/iris/providers/ollama"
+    "github.com/petal-labs/iris/providers/huggingface"
+    "github.com/petal-labs/iris/providers/azurefoundry"
+    "github.com/petal-labs/iris/providers/voyageai"
     "github.com/petal-labs/iris/tools"
     "github.com/petal-labs/iris/testing"  // Test utilities
 )
@@ -1167,10 +1177,28 @@ func init() {
 ```
 
 List registered providers:
-```go
-import "github.com/petal-labs/iris/providers"
 
-fmt.Println(providers.List()) // [anthropic gemini huggingface ollama openai perplexity xai zai]
+```go
+import (
+    // The registry itself.
+    "github.com/petal-labs/iris/providers"
+
+    // Provider packages register themselves via init(). Import the ones
+    // you want available — the registry is empty without these imports.
+    _ "github.com/petal-labs/iris/providers/anthropic"
+    _ "github.com/petal-labs/iris/providers/azurefoundry"
+    _ "github.com/petal-labs/iris/providers/gemini"
+    _ "github.com/petal-labs/iris/providers/huggingface"
+    _ "github.com/petal-labs/iris/providers/ollama"
+    _ "github.com/petal-labs/iris/providers/openai"
+    _ "github.com/petal-labs/iris/providers/perplexity"
+    _ "github.com/petal-labs/iris/providers/voyageai"
+    _ "github.com/petal-labs/iris/providers/xai"
+    _ "github.com/petal-labs/iris/providers/zai"
+)
+
+fmt.Println(providers.List())
+// [anthropic azurefoundry gemini huggingface ollama openai perplexity voyageai xai zai]
 ```
 
 ## License

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -4,17 +4,22 @@ This document provides a comprehensive comparison of the AI providers supported 
 
 ## Feature Support Matrix
 
-| Provider | Chat | Streaming | Tool Calling | Reasoning | Built-in Tools | Response Chain | Structured Output | Embeddings | Reranking |
-|----------|------|-----------|--------------|-----------|----------------|----------------|--------------------|------------|-----------|
-| OpenAI | Yes | Yes | Yes | Yes* | Yes* | Yes* | Yes | No | No |
-| Anthropic | Yes | Yes | Yes | No | No | No | No† | No | No |
-| Gemini | Yes | Yes | Yes | Yes | No | No | Yes | No | No |
-| xAI (Grok) | Yes | Yes | Yes | Yes* | No | No | No† | No | No |
-| Perplexity | Yes | Yes | Yes* | Yes* | No | No | No† | No | No |
-| Z.ai (GLM) | Yes | Yes | Yes | Yes* | No | No | No† | No | No |
-| Ollama | Yes | Yes | Yes* | Yes* | No | No | No† | No | No |
-| HuggingFace | Yes | Yes | Yes | No | No | No | No† | No | No |
-| VoyageAI | No | No | No | No | No | No | N/A | Yes | Yes |
+Cells reflect each provider's `Supports()` implementation. For chat-based features, availability can also vary by model — see the model-specific tables below.
+
+| Provider | Chat | Streaming | Tool Calling | Reasoning | Built-in Tools | Response Chain | Structured Output | Embeddings | Reranking | Images |
+|----------|------|-----------|--------------|-----------|----------------|----------------|--------------------|------------|-----------|--------|
+| OpenAI | Yes | Yes | Yes | Yes* | Yes* | Yes* | Yes | Yes | No | Yes |
+| Anthropic | Yes | Yes | Yes | Yes | No | No | No† | No | No | No |
+| Gemini | Yes | Yes | Yes | Yes | No | No | Yes | No | No | Yes |
+| xAI (Grok) | Yes | Yes | Yes | Yes | No | No | No† | No | No | No |
+| Perplexity | Yes | Yes | Yes | Yes | No | No | No† | No | No | No |
+| Z.ai (GLM) | Yes | Yes | Yes | Yes | No | No | No† | No | No | No |
+| Ollama | Yes | Yes | Yes | Yes | No | No | No† | Yes | No | No |
+| HuggingFace | Yes | Yes | Yes | No | No | No | No† | No | No | No |
+| Azure AI Foundry | Yes | Yes | Yes | Yes | No | No | Yes | Yes | No | No |
+| VoyageAI | No | No | No | No | No | No | N/A | Yes | Yes | No |
+
+Perplexity additionally supports web-search grounding (`core.SearchOptions`, response citations) via `core.FeatureWebSearch`.
 
 *Feature availability varies by model. See model-specific tables below.
 
@@ -413,6 +418,33 @@ results, err := provider.Rerank(ctx, &core.RerankRequest{
     Query:     "machine learning",
     Documents: []string{"doc1", "doc2", "doc3"},
 })
+```
+
+### Azure AI Foundry
+
+**API Endpoint**: `https://{resource}.services.ai.azure.com/models` (Model Inference API) or `https://{resource}.openai.azure.com` (Azure OpenAI Service, via `WithOpenAIEndpoint()`)
+
+**Authentication**: API key or Microsoft Entra ID (Azure AD) credential. Via environment: `AZURE_AI_ENDPOINT`, `AZURE_AI_API_KEY`, and optional `AZURE_AI_DEPLOYMENT_ID` (required with `WithOpenAIEndpoint()`).
+
+**Models**: Multi-family catalog — OpenAI (GPT), Meta Llama, Mistral, Cohere, and more — including embeddings models. Use `provider.Models()` or `azurefoundry.GetModelInfo(id)` to inspect the static catalog.
+
+**Notes**:
+- Unlike other Iris providers, `azurefoundry.New` takes `(endpoint, apiKey, ...)` — the resource endpoint is mandatory.
+- Entra ID auth (managed identity, workload identity, etc.) is available via `NewWithCredential(endpoint, credential)`, where `credential` implements `azurefoundry.TokenCredential`.
+- The provider registry entry requires the endpoint to come from `AZURE_AI_ENDPOINT`; prefer `New`/`NewFromEnv` for full configuration.
+
+**Usage Example**:
+```go
+provider, err := azurefoundry.NewFromEnv()
+// or: provider := azurefoundry.New("https://my-resource.services.ai.azure.com", apiKey)
+if err != nil {
+    log.Fatal(err)
+}
+client := core.NewClient(provider)
+
+resp, err := client.Chat("gpt-5.6"). // any deployed model
+    User("Hello").
+    GetResponse(ctx)
 ```
 
 ## Choosing a Provider

--- a/docs/changes/2026-08-17_v0.18.0_provider-docs-coverage.md
+++ b/docs/changes/2026-08-17_v0.18.0_provider-docs-coverage.md
@@ -1,0 +1,117 @@
+---
+date: 2026-08-17
+version: v0.18.0
+feature: Provider Coverage Documentation and Registry Completeness (Issue #57)
+product: iris
+change_type: docs
+affected_components: [providers/perplexity/register.go, README.md, docs/PROVIDERS.md, tests/docs_test.go]
+related_frds: []
+---
+
+## Summary
+
+This change closes issue #57 by making the documented provider set match reality. Perplexity now self-registers with the provider registry (it was the only provider without a `register.go`), README's provider lists cover all 10 providers, `docs/PROVIDERS.md` gains an Azure AI Foundry section and an Images column with corrected cells, the `providers.List()` example shows the required subpackage imports, and a new docs test parses the feature matrix and verifies every cell against each provider's actual `Supports()` implementation so the matrix cannot silently drift again.
+
+## Motivation
+
+The docs systematically understated the provider set (10 exist; README listed 7 and omitted Hugging Face, Azure AI Foundry, and Voyage AI), the `providers.List()` example printed a wrong list while hiding the empty-without-imports trap, and the PROVIDERS.md feature matrix had wrong cells (Ollama/OpenAI embeddings marked "No" despite implementing `EmbeddingProvider`, Anthropic reasoning "No" despite declaring it) and omitted AzureFoundry and image generation entirely.
+
+## What Changed
+
+### New Additions
+
+- `providers/perplexity/register.go` — registers the `perplexity` factory via `init()`, matching the pattern of the other nine providers. `providers.List()` (with all subpackages imported) now returns `[anthropic azurefoundry gemini huggingface ollama openai perplexity voyageai xai zai]`.
+- `tests/docs_test.go` → `TestProvidersDocMatrixAccuracy` — parses the PROVIDERS.md feature matrix and asserts each cell:
+  - `Yes` ⇒ `provider.Supports(feature)` is true (provider-level claim)
+  - `Yes*` ⇒ `Supports(feature)` is true **or** at least one model in the provider's catalog has the capability via `ModelInfo.HasCapability` (model-dependent claim, e.g. OpenAI reasoning on GPT-5.x Responses API models)
+  - `No` ⇒ `Supports(feature)` is false
+  - `N/A` and other prose cells are not machine-checked
+
+### Modifications
+
+- `README.md`:
+  - "Why Iris" provider list: 7 → 10 providers
+  - Project Structure tree: adds `huggingface/`, `azurefoundry/`, `voyageai/`, and `contrib/` with one-line descriptions
+  - Supported Providers table: all 10 rows, corrected feature lists (OpenAI embeddings/images, Anthropic reasoning, Gemini images, Perplexity web search + citations, Ollama embeddings, Azure Foundry Entra ID, Voyage AI embeddings/reranking)
+  - "Importing the SDK" block: adds the three missing provider imports
+  - Provider Registry `providers.List()` example: blank-imports all ten subpackages with a comment explaining the registry is empty without them, and shows the correct sorted output
+- `docs/PROVIDERS.md`:
+  - Feature matrix: adds **Azure AI Foundry** row and **Images** column; corrected cells against `Supports()` — OpenAI Embeddings/Images Yes, Anthropic Reasoning Yes, Ollama Embeddings Yes, Gemini Images Yes, HuggingFace Tool Calling Yes; added a note that Perplexity supports web-search grounding via `FeatureWebSearch`
+  - New **Azure AI Foundry** detail section: endpoint formats (Model Inference API vs Azure OpenAI Service via `WithOpenAIEndpoint()`), auth (API key and Entra ID via `NewWithCredential`), env vars (`AZURE_AI_ENDPOINT`, `AZURE_AI_API_KEY`, `AZURE_AI_DEPLOYMENT_ID`), and a `NewFromEnv` usage example
+- `tests/docs_test.go` → `TestProvidersDocExists`: required sections now include `### Azure AI Foundry`
+
+### Removals
+
+None.
+
+## Technical Specification
+
+### Registry
+
+```go
+// providers/perplexity/register.go
+func init() {
+    providers.Register("perplexity", func(apiKey string) core.Provider {
+        return New(apiKey)
+    })
+}
+```
+
+### Docs Matrix Contract (enforced by TestProvidersDocMatrixAccuracy)
+
+| Cell | Assertion |
+|---|---|
+| `Yes` | `Supports(feature) == true` |
+| `Yes*` | `Supports(feature) == true` OR any `Models()` entry `HasCapability(feature)` |
+| `No` | `Supports(feature) == false` |
+| `N/A` | unchecked (provider-specific prose) |
+
+The test instantiates each provider through the registry (`providers.Create`) with a dummy key — `Supports()` does not depend on credentials — so the check also fails if a provider forgets to register.
+
+## Usage Examples
+
+### Example: correctly listing providers
+
+```go
+import (
+    "github.com/petal-labs/iris/providers"
+
+    _ "github.com/petal-labs/iris/providers/anthropic"
+    _ "github.com/petal-labs/iris/providers/azurefoundry"
+    _ "github.com/petal-labs/iris/providers/gemini"
+    _ "github.com/petal-labs/iris/providers/huggingface"
+    _ "github.com/petal-labs/iris/providers/ollama"
+    _ "github.com/petal-labs/iris/providers/openai"
+    _ "github.com/petal-labs/iris/providers/perplexity"
+    _ "github.com/petal-labs/iris/providers/voyageai"
+    _ "github.com/petal-labs/iris/providers/xai"
+    _ "github.com/petal-labs/iris/providers/zai"
+)
+
+fmt.Println(providers.List())
+// [anthropic azurefoundry gemini huggingface ollama openai perplexity voyageai xai zai]
+```
+
+Without the blank imports, `providers.List()` returns an empty slice — the registry is populated by provider packages' `init()` functions.
+
+## Integration Notes
+
+- The perplexity registration is behavior-affecting only for registry consumers (`providers.Create("perplexity", key)` now works); the CLI factory already constructed perplexity directly and is unaffected.
+- `TestProvidersDocMatrixAccuracy` runs in the normal (non-integration) test suite, so any future `Supports()` change that drifts from the matrix fails CI — contributors must update PROVIDERS.md (or deliberately use `Yes*`/`N/A` semantics) alongside capability changes.
+
+## Breaking Changes & Migration
+
+None.
+
+## Deferred / Out of Scope
+
+- Declaring `FeatureReasoning`/`FeatureBuiltInTools`/`FeatureResponseChain` at provider level on OpenAI (`Supports()` returns false today; the matrix documents them as `Yes*` via catalog capabilities) — tracked by issue #67.
+- CLI factory support for perplexity/voyageai/azurefoundry — issue #66.
+- Gemini embeddings (matrix correctly says No; the API is unimplemented) — issue #67.
+
+## Testing Notes
+
+- `TestProvidersDocMatrixAccuracy` (new) — found and verifies all matrix corrections; intentionally tolerates `Yes*` via model-catalog evidence and `N/A` prose.
+- `TestProvidersDocExists` — extended with the Azure AI Foundry section.
+- Matrix parsing gotchas handled: newline exclusion in cell regexes (greedy `[^|]` swallows the whole table otherwise) and leading-pipe trimming in the header split (off-by-one otherwise).
+- Full suite green: `go build ./...`, `go vet ./...`, `gofmt` clean, `go test ./...` (23 packages ok).

--- a/providers/perplexity/register.go
+++ b/providers/perplexity/register.go
@@ -1,0 +1,12 @@
+package perplexity
+
+import (
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers"
+)
+
+func init() {
+	providers.Register("perplexity", func(apiKey string) core.Provider {
+		return New(apiKey)
+	})
+}

--- a/tests/docs_test.go
+++ b/tests/docs_test.go
@@ -3,8 +3,22 @@ package tests
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers"
+	_ "github.com/petal-labs/iris/providers/anthropic"
+	_ "github.com/petal-labs/iris/providers/azurefoundry"
+	_ "github.com/petal-labs/iris/providers/gemini"
+	_ "github.com/petal-labs/iris/providers/huggingface"
+	_ "github.com/petal-labs/iris/providers/ollama"
+	_ "github.com/petal-labs/iris/providers/openai"
+	_ "github.com/petal-labs/iris/providers/perplexity"
+	_ "github.com/petal-labs/iris/providers/voyageai"
+	_ "github.com/petal-labs/iris/providers/xai"
+	_ "github.com/petal-labs/iris/providers/zai"
 )
 
 // TestProvidersDocExists verifies PROVIDERS.md exists and contains required sections.
@@ -24,6 +38,7 @@ func TestProvidersDocExists(t *testing.T) {
 		"### Ollama",
 		"### HuggingFace",
 		"### VoyageAI",
+		"### Azure AI Foundry",
 		"## Choosing a Provider",
 		"## Rate Limits and Pricing",
 	}
@@ -50,6 +65,174 @@ func TestProvidersDocExists(t *testing.T) {
 			t.Errorf("PROVIDERS.md missing usage example for %s provider", p)
 		}
 	}
+}
+
+// matrixColumns maps the PROVIDERS.md feature-matrix columns to the core
+// Feature constants each represents.
+var matrixColumns = []struct {
+	column  string
+	feature core.Feature
+}{
+	{"Chat", core.FeatureChat},
+	{"Streaming", core.FeatureChatStreaming},
+	{"Tool Calling", core.FeatureToolCalling},
+	{"Reasoning", core.FeatureReasoning},
+	{"Built-in Tools", core.FeatureBuiltInTools},
+	{"Response Chain", core.FeatureResponseChain},
+	{"Structured Output", core.FeatureStructuredOutput},
+	{"Embeddings", core.FeatureEmbeddings},
+	{"Reranking", core.FeatureReranking},
+	{"Images", core.FeatureImageGeneration},
+}
+
+// docMatrixProviderID maps the PROVIDERS.md display names to registry IDs.
+var docMatrixProviderID = map[string]string{
+	"OpenAI":           "openai",
+	"Anthropic":        "anthropic",
+	"Gemini":           "gemini",
+	"xAI (Grok)":       "xai",
+	"Perplexity":       "perplexity",
+	"Z.ai (GLM)":       "zai",
+	"Ollama":           "ollama",
+	"HuggingFace":      "huggingface",
+	"Azure AI Foundry": "azurefoundry",
+	"VoyageAI":         "voyageai",
+}
+
+// TestProvidersDocMatrixAccuracy verifies the PROVIDERS.md feature matrix
+// matches each provider's actual Supports() implementation, so the docs
+// cannot silently drift from the code.
+func TestProvidersDocMatrixAccuracy(t *testing.T) {
+	content := readDocFile(t, "PROVIDERS.md")
+
+	// Parse matrix rows: | <Provider> | Yes | No | ... |
+	// Note: [^|\n] — without excluding newlines the greedy inner group
+	// swallows the whole table into a single match.
+	rowRe := regexp.MustCompile(`(?m)^\| ([^|\n]+) \|((?:[^|\n]+\|)+)$`)
+	cells := map[string][]string{}
+	for _, match := range rowRe.FindAllStringSubmatch(content, -1) {
+		name := strings.TrimSpace(match[1])
+		if _, ok := docMatrixProviderID[name]; !ok {
+			continue // header or separator row
+		}
+		var row []string
+		for _, cell := range strings.Split(strings.TrimSuffix(match[2], "|"), "|") {
+			row = append(row, strings.TrimSpace(cell))
+		}
+		cells[name] = row
+	}
+
+	if len(cells) != len(docMatrixProviderID) {
+		t.Errorf("matrix has %d provider rows, want %d (missing providers: %v)",
+			len(cells), len(docMatrixProviderID), missingMatrixRows(cells))
+	}
+
+	header := matrixHeader(content)
+	if len(header) == 0 {
+		t.Fatal("could not parse feature matrix header row")
+	}
+
+	for displayName, id := range docMatrixProviderID {
+		row, ok := cells[displayName]
+		if !ok {
+			t.Errorf("matrix missing row for %q", displayName)
+			continue
+		}
+
+		// Instantiate the provider through the registry with a dummy key;
+		// Supports() does not depend on the key.
+		provider, err := providers.Create(id, "docs-test-key")
+		if err != nil {
+			t.Errorf("provider %q is not registered: %v", id, err)
+			continue
+		}
+
+		for _, col := range matrixColumns {
+			idx := headerIndex(header, col.column)
+			if idx < 0 {
+				t.Errorf("matrix has no %q column", col.column)
+				continue
+			}
+			// Header index 0 is the "Provider" name column; row cells are
+			// everything after it, so shift by one.
+			cellIdx := idx - 1
+			if cellIdx < 0 || cellIdx >= len(row) {
+				t.Errorf("matrix row for %q has no %q cell", displayName, col.column)
+				continue
+			}
+
+			supported := provider.Supports(col.feature)
+			cell := row[cellIdx]
+			switch strings.TrimSuffix(cell, "†") { // gated-sentinel footnote marker
+			case "Yes":
+				// Bare Yes asserts a provider-level capability.
+				if !supported {
+					t.Errorf("matrix cell %s/%s = %q, but Supports(%s) = false (use \"Yes*\" if model-dependent)",
+						displayName, col.column, cell, col.feature)
+				}
+			case "Yes*":
+				// Starred Yes asserts the capability exists for at least one
+				// model in the provider's catalog, even if not declared at
+				// provider level.
+				if !supported && !anyModelHasCapability(provider, col.feature) {
+					t.Errorf("matrix cell %s/%s = %q, but Supports(%s) = false and no catalog model has the capability",
+						displayName, col.column, cell, col.feature)
+				}
+			case "No":
+				if supported {
+					t.Errorf("matrix cell %s/%s = %q, want \"Yes\" (Supports(%s) = true)",
+						displayName, col.column, cell, col.feature)
+				}
+			default:
+				// "N/A" and anything else is provider-specific prose; not
+				// machine-checked.
+			}
+		}
+	}
+}
+
+// anyModelHasCapability reports whether any model in the provider's catalog
+// declares the feature.
+func anyModelHasCapability(p core.Provider, feature core.Feature) bool {
+	for _, m := range p.Models() {
+		if m.HasCapability(feature) {
+			return true
+		}
+	}
+	return false
+}
+
+func missingMatrixRows(cells map[string][]string) []string {
+	var missing []string
+	for name := range docMatrixProviderID {
+		if _, ok := cells[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+func matrixHeader(content string) []string {
+	re := regexp.MustCompile(`(?m)^\| Provider \|([^|\n]+\|)+$`)
+	match := re.FindString(content)
+	if match == "" {
+		return nil
+	}
+	trimmed := strings.TrimSuffix(strings.TrimPrefix(match, "|"), "|")
+	var header []string
+	for _, cell := range strings.Split(trimmed, "|") {
+		header = append(header, strings.TrimSpace(cell))
+	}
+	return header
+}
+
+func headerIndex(header []string, column string) int {
+	for i, h := range header {
+		if h == column {
+			return i
+		}
+	}
+	return -1
 }
 
 // TestArchitectureDocExists verifies ARCHITECTURE.md exists and contains required sections.


### PR DESCRIPTION
Closes #57.

## Summary

Docs systematically understated the provider set (10 exist; README listed 7). This PR completes the registry (perplexity was the only provider without `register.go`), documents all 10 providers everywhere, fixes the wrong cells in the PROVIDERS.md matrix, and adds a test that verifies the matrix against each provider's actual `Supports()` so it can't drift again.

## Changes

**Code**
- `providers/perplexity/register.go` — registers the perplexity factory via `init()`, matching the other nine providers. `providers.List()` (with subpackages imported) now returns `[anthropic azurefoundry gemini huggingface ollama openai perplexity voyageai xai zai]`

**README**
- "Why Iris", Project Structure, Supported Providers table, and the import block now cover all 10 providers (+ `contrib/`)
- `providers.List()` example blank-imports the subpackages, documents the empty-without-imports trap, and shows the correct sorted output

**docs/PROVIDERS.md**
- Matrix: new **Azure AI Foundry** row and **Images** column; corrected cells against `Supports()` (OpenAI embeddings/images = Yes, Anthropic reasoning = Yes, Ollama embeddings = Yes, Gemini images = Yes); note on Perplexity `FeatureWebSearch`
- New **Azure AI Foundry** detail section (endpoints, Entra ID auth, env vars, usage example)

**Drift guard**
- `TestProvidersDocMatrixAccuracy` parses the matrix and asserts each cell: `Yes` ⇔ `Supports()` true; `Yes*` ⇔ `Supports()` true **or** any catalog model `HasCapability` (e.g. OpenAI reasoning on GPT-5.x); `No` ⇔ `Supports()` false. Runs in the normal test suite, so capability changes that don't update the docs fail CI

## Acceptance criteria (from #57)

- [x] Perplexity registers in the registry
- [x] README tables/structure list all 10 providers
- [x] PROVIDERS.md matrix matches `Supports()`, includes AzureFoundry and an image column
- [x] `providers.List()` snippet shows required subpackage imports

## Testing

- New matrix-accuracy test found and verified every corrected cell (it initially caught the OpenAI `Yes*` cells, which now pass via model-catalog evidence)
- Full `go test ./...` green (23 packages), build/vet/gofmt clean

## Out of scope

- OpenAI provider-level `FeatureReasoning`/`FeatureBuiltInTools`/`FeatureResponseChain` declarations (matrix documents them as `Yes*`; tracked in #67)
- CLI factory support for perplexity/voyageai/azurefoundry (#66)