### PR TITLE
feat(tools)!: unify Tool interface with compiler-enforced schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,8 @@ client := core.NewClient(provider,
 
 ### Using Tools
 
+Tools implement the `tools.Tool` interface — `Name()`, `Description()`, and `Schema()` come from `core.Tool`; `Call()` makes the tool executable. Any `tools.Tool` can be passed straight to `Tools(...)`:
+
 ```go
 // Define a tool
 weatherTool := mytools.NewWeatherTool()
@@ -482,6 +484,8 @@ if len(resp.ToolCalls) > 0 {
     }
 }
 ```
+
+A minimal tool without execution logic only needs the three `core.Tool` methods (return `core.ToolSchema{}` for a no-parameter tool). The schema is part of the interface, so the compiler guarantees every tool you register carries its parameters schema to the provider.
 
 ### Tool Middleware and Validation
 

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -499,6 +499,7 @@ type mockTool struct {
 
 func (t *mockTool) Name() string        { return t.name }
 func (t *mockTool) Description() string { return "mock tool" }
+func (t *mockTool) Schema() ToolSchema  { return ToolSchema{} }
 
 func TestImageGeneratorInterface(t *testing.T) {
 	// Verify the interface is defined

--- a/core/types.go
+++ b/core/types.go
@@ -247,11 +247,35 @@ func (b *TypedToolResultBuilder[T]) Build() []ToolResult {
 	return out
 }
 
-// Tool is a placeholder interface for tool definitions.
-// Full implementation is in the tools package (Task 07).
+// Tool is the canonical contract for tool definitions passed to
+// ChatBuilder.Tools. Name and Description are used by every provider;
+// Schema supplies the JSON Schema describing the tool's parameters so the
+// model can generate valid arguments. A tool that takes no parameters may
+// return an empty ToolSchema.
+//
+// The tools package extends this interface with Call for executable tools:
+//
+//	type Tool interface {
+//	    core.Tool
+//	    Call(ctx context.Context, args json.RawMessage) (any, error)
+//	}
+//
+// Any type implementing tools.Tool (or core.Tool plus Schema) can be passed
+// to ChatBuilder.Tools.
 type Tool interface {
 	Name() string
 	Description() string
+	Schema() ToolSchema
+}
+
+// ToolSchema describes a tool's parameters as a JSON Schema.
+// tools.ToolSchema is an alias of this type, so implementations may return
+// either interchangeably.
+type ToolSchema struct {
+	// JSONSchema is a valid JSON Schema object describing the tool's
+	// parameters. Example:
+	//   {"type": "object", "properties": {"location": {"type": "string"}}}
+	JSONSchema json.RawMessage `json:"json_schema"`
 }
 
 // ToolResources contains configuration for built-in tools.

--- a/docs/changes/2026-08-17_v0.18.0_unified-tool-interface.md
+++ b/docs/changes/2026-08-17_v0.18.0_unified-tool-interface.md
@@ -1,0 +1,136 @@
+---
+date: 2026-08-17
+version: v0.18.0
+feature: Unified Tool Interface with Compiler-Enforced Schemas (Issue #58)
+product: iris
+change_type: breaking
+affected_components: [core/types.go, tools/tool.go, tools/doc.go, tools/tool_test.go, core/client_test.go, providers/openai/mapping.go, providers/openai/mapping_responses.go, providers/openai/mapping_test.go, providers/anthropic/mapping.go, providers/anthropic/mapping_test.go, providers/gemini/mapping.go, providers/gemini/mapping_test.go, providers/xai/mapping.go, providers/xai/mapping_test.go, providers/zai/mapping.go, providers/zai/mapping_test.go, providers/perplexity/mapping.go, providers/perplexity/mapping_test.go, providers/ollama/mapping.go, providers/ollama/provider_test.go, providers/huggingface/mapping.go, providers/huggingface/mapping_test.go, providers/azurefoundry/mapping.go, providers/azurefoundry/mapping_test.go, README.md]
+related_frds: []
+---
+
+## Summary
+
+This change closes issue #58 by unifying the tool contract. `core.Tool` — previously a "placeholder interface" with only `Name()` and `Description()` — now requires `Schema() ToolSchema`, with `ToolSchema` owned by `core` and aliased by the `tools` package. Every provider's private `schemaProvider` duck-typing (9 unexported interface copies) is deleted; providers call `t.Schema()` directly. A tool whose `Schema()` has the wrong signature is now a **compile error** instead of silently transmitting `{}` as the parameters schema.
+
+## Motivation
+
+The real tool contract lived in `tools.Tool`, but `ChatRequest.Tools` carries `core.Tool`, so every provider privately duck-typed each tool against an unexported `schemaProvider interface { Schema() tools.ToolSchema }` and silently sent `{}` when the assertion failed (openai/mapping.go, plus the same pattern in 8 other providers). A user-defined tool whose `Schema()` returned a different type compiled cleanly and lost its schema at the wire with no error or warning — an implicit cross-package contract invisible in `core`'s public API. (The duck-typing could not simply move into `core` because `tools` imports `core` — an import cycle — which is why `ToolSchema` moved into `core` instead.)
+
+## What Changed
+
+### New Additions
+
+- `core.ToolSchema` (`core/types.go`):
+  ```go
+  type ToolSchema struct {
+      JSONSchema json.RawMessage `json:"json_schema"`
+  }
+  ```
+- `tools/tool_test.go` → `TestToolSchemaReachesProviderThroughClient` — end-to-end: a `tools.Tool` passed to `ChatBuilder.Tools()` arrives at the provider's `Chat` with its schema intact.
+
+### Modifications
+
+- `core.Tool` (was a 2-method "placeholder"): now requires `Schema() ToolSchema`; doc comment describes the canonical contract and the `tools.Tool` extension.
+- `tools.ToolSchema` is now an alias: `type ToolSchema = core.ToolSchema` — all existing `tools.ToolSchema` user code compiles unchanged.
+- `tools.Tool` embeds `core.Tool` (Name, Description, Schema) plus `Call`; `var _ core.Tool = (Tool)(nil)` asserts satisfaction.
+- All 9 providers (`openai` ×2 call sites, `anthropic`, `gemini`, `xai`, `zai`, `perplexity`, `ollama`, `huggingface`, `azurefoundry`): deleted the unexported `schemaProvider` interface and the `if sp, ok := t.(schemaProvider); ok` block; tools map via `t.Schema().JSONSchema` directly. An **empty** schema (no parameters) still maps to `{}` on the wire — that is the legitimate representation of a no-argument tool, not a failure path. `openai/mapping_responses.go` also drops its `var _ schemaProvider = (tools.Tool)(nil)` assertion and the `tools` import.
+- `tools/doc.go`: documents the canonical interface and the alias relationship.
+- README "Using Tools": documents the interface shape and the compiler guarantee.
+- Test mocks in `core/client_test.go` and 8 provider test files: added `Schema()` methods.
+
+### Removals
+
+- The 9 unexported `schemaProvider` interfaces (one per provider package) and openai's duplicate assertion in `mapping_responses.go`.
+
+## Technical Specification
+
+### Go Package API
+
+```go
+// core
+type Tool interface {
+    Name() string
+    Description() string
+    Schema() ToolSchema // was absent; the schema is now part of the contract
+}
+
+// tools
+type Tool interface {
+    core.Tool
+    Call(ctx context.Context, args json.RawMessage) (any, error)
+}
+type ToolSchema = core.ToolSchema // alias, not a distinct type
+```
+
+### Provider Mapping Semantics
+
+| Tool state | Wire schema |
+|---|---|
+| `Schema().JSONSchema` non-empty | transmitted verbatim |
+| `Schema().JSONSchema` empty | `{}` (no-parameter tool) |
+| wrong `Schema()` signature | compile error (previously: silent `{}`) |
+
+## Usage Examples
+
+### Example: minimal tool (no parameters)
+
+```go
+type PingTool struct{}
+
+func (p *PingTool) Name() string                 { return "ping" }
+func (p *PingTool) Description() string          { return "Reply with pong" }
+func (p *PingTool) Schema() core.ToolSchema      { return core.ToolSchema{} } // no params
+
+resp, _ := client.Chat("gpt-5.6").User("ping it").Tools(&PingTool{}).GetResponse(ctx)
+```
+
+### Example: executable tool with schema (unchanged from before)
+
+```go
+type WeatherTool struct{}
+
+func (w *WeatherTool) Name() string        { return "get_weather" }
+func (w *WeatherTool) Description() string { return "Get current weather" }
+func (w *WeatherTool) Schema() tools.ToolSchema {
+    return tools.ToolSchema{JSONSchema: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}`)}
+}
+func (w *WeatherTool) Call(ctx context.Context, args json.RawMessage) (any, error) { /* ... */ }
+```
+
+### Error case: incompatible schema signature (now at compile time)
+
+```go
+func (t *MyTool) Schema() *MySchemaType { ... } // wrong return type
+// cannot use t (variable of type *MyTool) as core.Tool value:
+// *MyTool does not implement core.Tool (wrong type for method Schema)
+```
+
+## Integration Notes
+
+- All providers now consume the schema through the public interface; adding a new provider no longer requires re-implementing the duck-type-and-default pattern.
+- `ChatBuilder.Tools(ts ...Tool)` continues to accept any `tools.Tool` structurally (tools.Tool satisfies core.Tool).
+- The `testing` package's `MockProvider` is unaffected (it does not touch tools).
+
+## Breaking Changes & Migration
+
+**Breaking (SDK)**: any type implementing `core.Tool` with only `Name()` and `Description()` must add:
+
+```go
+func (t *T) Schema() core.ToolSchema { return core.ToolSchema{} } // or a real schema
+```
+
+Affected in-repo code: test mocks (all updated). User impact is limited to custom minimal tool types; full `tools.Tool` implementations already had `Schema()` and compile unchanged thanks to the `ToolSchema` alias.
+
+## Deferred / Out of Scope
+
+- A warning when a tool's schema is empty but the tool declares parameters elsewhere — empty schemas are legitimate no-arg tools, so no warning is emitted.
+- Moving `Call` into `core.Tool` — execution stays in `tools.Tool`; the request-carrier interface intentionally excludes it.
+- The `providers/provider.go` re-export layer does not re-export `Tool`/`ToolSchema`; that inconsistency is tracked under provider-consistency (issue #71).
+
+## Testing Notes
+
+- `TestToolSchemaReachesProviderThroughClient` (new, tools package): end-to-end schema delivery through `core.NewClient` + `ChatBuilder.Tools`.
+- `TestMapToolsEmptySchemaDefaultsToEmptyObject` (renamed from `TestMapToolsWithoutSchema`): empty schema → `{}` on the wire.
+- Existing per-provider `TestMapToolsWithSchema` tests unchanged and green (schemas flow identically).
+- Compile-time enforcement demonstrated by the initial `go vet` failures: 9 test mocks lacking `Schema()` were rejected by the compiler — exactly the failure mode that used to be silent.
+- Full suite green: `go build ./...` (root + examples module), `go vet ./...`, `gofmt` clean, `go test ./...` (23 packages ok).

--- a/providers/anthropic/mapping.go
+++ b/providers/anthropic/mapping.go
@@ -5,18 +5,11 @@ import (
 	"strings"
 
 	"github.com/petal-labs/iris/core"
-	"github.com/petal-labs/iris/tools"
 )
 
 // defaultMaxTokens is the default max_tokens value when not specified.
 // Anthropic requires max_tokens, so we provide a reasonable default.
 const defaultMaxTokens = 1024
-
-// schemaProvider is an interface for tools that provide a JSON schema.
-// This allows us to check if a core.Tool also implements the full tools.Tool interface.
-type schemaProvider interface {
-	Schema() tools.ToolSchema
-}
 
 // buildRequest creates an Anthropic API request from an Iris ChatRequest.
 func buildRequest(req *core.ChatRequest, stream bool) *anthropicRequest {
@@ -142,7 +135,8 @@ func marshalToolResultContent(content any) string {
 }
 
 // mapTools converts Iris tools to Anthropic tool format.
-// Tools that implement schemaProvider will have their schema included.
+// A tool with an empty schema (no parameters) is transmitted with an empty
+// object schema.
 func mapTools(irisTools []core.Tool) []anthropicTool {
 	if len(irisTools) == 0 {
 		return nil
@@ -150,15 +144,10 @@ func mapTools(irisTools []core.Tool) []anthropicTool {
 
 	result := make([]anthropicTool, len(irisTools))
 	for i, t := range irisTools {
-		var inputSchema json.RawMessage
+		inputSchema := t.Schema().JSONSchema
 
-		// Check if the tool provides a schema
-		if sp, ok := t.(schemaProvider); ok {
-			inputSchema = sp.Schema().JSONSchema
-		}
-
-		// Default to empty object if no schema
-		if inputSchema == nil {
+		// Default to empty object for no-parameter tools
+		if len(inputSchema) == 0 {
 			inputSchema = json.RawMessage(`{}`)
 		}
 

--- a/providers/anthropic/mapping_test.go
+++ b/providers/anthropic/mapping_test.go
@@ -170,8 +170,9 @@ type mockTool struct {
 	description string
 }
 
-func (t *mockTool) Name() string        { return t.name }
-func (t *mockTool) Description() string { return t.description }
+func (t *mockTool) Name() string            { return t.name }
+func (t *mockTool) Description() string     { return t.description }
+func (t *mockTool) Schema() core.ToolSchema { return core.ToolSchema{} }
 
 // mockToolWithSchema implements core.Tool and schemaProvider
 type mockToolWithSchema struct {

--- a/providers/azurefoundry/mapping.go
+++ b/providers/azurefoundry/mapping.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 
 	"github.com/petal-labs/iris/core"
-	"github.com/petal-labs/iris/tools"
 )
 
 // ----------------------------------------------------------------------------
@@ -188,11 +187,6 @@ func (f *azureContentFilters) IsFiltered() bool {
 // Mapping Functions
 // ----------------------------------------------------------------------------
 
-// schemaProvider is an interface for tools that provide a JSON schema.
-type schemaProvider interface {
-	Schema() tools.ToolSchema
-}
-
 // mapMessages converts Iris messages to Azure message format.
 func mapMessages(msgs []core.Message) []azureMessage {
 	result := make([]azureMessage, 0, len(msgs))
@@ -271,15 +265,10 @@ func mapTools(irisTools []core.Tool) []azureTool {
 
 	result := make([]azureTool, len(irisTools))
 	for i, t := range irisTools {
-		var params json.RawMessage
+		params := t.Schema().JSONSchema
 
-		// Check if the tool provides a schema
-		if sp, ok := t.(schemaProvider); ok {
-			params = sp.Schema().JSONSchema
-		}
-
-		// Default to empty object if no schema
-		if params == nil {
+		// Default to empty object for no-parameter tools
+		if len(params) == 0 {
 			params = json.RawMessage(`{}`)
 		}
 

--- a/providers/azurefoundry/mapping_test.go
+++ b/providers/azurefoundry/mapping_test.go
@@ -212,8 +212,9 @@ type mockTool struct {
 	description string
 }
 
-func (m *mockTool) Name() string        { return m.name }
-func (m *mockTool) Description() string { return m.description }
+func (m *mockTool) Name() string            { return m.name }
+func (m *mockTool) Description() string     { return m.description }
+func (m *mockTool) Schema() core.ToolSchema { return core.ToolSchema{} }
 
 func TestMapToolsBasic(t *testing.T) {
 	tools := []core.Tool{

--- a/providers/gemini/mapping.go
+++ b/providers/gemini/mapping.go
@@ -6,13 +6,7 @@ import (
 	"strings"
 
 	"github.com/petal-labs/iris/core"
-	"github.com/petal-labs/iris/tools"
 )
-
-// schemaProvider is an interface for tools that provide a JSON schema.
-type schemaProvider interface {
-	Schema() tools.ToolSchema
-}
 
 // buildRequest creates a Gemini API request from an Iris ChatRequest.
 func buildRequest(req *core.ChatRequest) *geminiRequest {
@@ -300,15 +294,10 @@ func mapTools(irisTools []core.Tool) []geminiTool {
 
 	decls := make([]geminiFunctionDecl, len(irisTools))
 	for i, t := range irisTools {
-		var params json.RawMessage
+		params := t.Schema().JSONSchema
 
-		// Check if the tool provides a schema
-		if sp, ok := t.(schemaProvider); ok {
-			params = sp.Schema().JSONSchema
-		}
-
-		// Default to empty object if no schema
-		if params == nil {
+		// Default to empty object for no-parameter tools
+		if len(params) == 0 {
 			params = json.RawMessage(`{}`)
 		}
 

--- a/providers/huggingface/mapping.go
+++ b/providers/huggingface/mapping.go
@@ -4,13 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/petal-labs/iris/core"
-	"github.com/petal-labs/iris/tools"
 )
-
-// schemaProvider is an interface for tools that provide a JSON schema.
-type schemaProvider interface {
-	Schema() tools.ToolSchema
-}
 
 // mapMessages converts Iris messages to HF message format.
 func mapMessages(msgs []core.Message) []hfMessage {
@@ -32,15 +26,10 @@ func mapTools(irisTools []core.Tool) []hfTool {
 
 	result := make([]hfTool, len(irisTools))
 	for i, t := range irisTools {
-		var params json.RawMessage
+		params := t.Schema().JSONSchema
 
-		// Check if the tool provides a schema
-		if sp, ok := t.(schemaProvider); ok {
-			params = sp.Schema().JSONSchema
-		}
-
-		// Default to empty object if no schema
-		if params == nil {
+		// Default to empty object for no-parameter tools
+		if len(params) == 0 {
 			params = json.RawMessage(`{}`)
 		}
 

--- a/providers/huggingface/mapping_test.go
+++ b/providers/huggingface/mapping_test.go
@@ -361,8 +361,9 @@ type mockTool struct {
 	description string
 }
 
-func (t *mockTool) Name() string        { return t.name }
-func (t *mockTool) Description() string { return t.description }
+func (t *mockTool) Name() string            { return t.name }
+func (t *mockTool) Description() string     { return t.description }
+func (t *mockTool) Schema() core.ToolSchema { return core.ToolSchema{} }
 
 // mockToolWithSchema is a tool that provides a schema.
 type mockToolWithSchema struct {

--- a/providers/ollama/mapping.go
+++ b/providers/ollama/mapping.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/petal-labs/iris/core"
-	"github.com/petal-labs/iris/tools"
 )
 
 // mapRequest converts a core.ChatRequest to an ollamaRequest.
@@ -104,12 +103,9 @@ func marshalToolResultContent(content any) string {
 	}
 }
 
-// schemaProvider is an interface for tools that provide a JSON schema.
-type schemaProvider interface {
-	Schema() tools.ToolSchema
-}
-
 // mapTools converts core tools to Ollama tools.
+// A tool with an empty schema (no parameters) is transmitted with an empty
+// object schema.
 func mapTools(coreTools []core.Tool) []ollamaTool {
 	if len(coreTools) == 0 {
 		return nil
@@ -120,13 +116,10 @@ func mapTools(coreTools []core.Tool) []ollamaTool {
 	for _, t := range coreTools {
 		var params map[string]interface{}
 
-		// Check if the tool provides a schema
-		if sp, ok := t.(schemaProvider); ok {
-			schema := sp.Schema()
-			if len(schema.JSONSchema) > 0 {
-				if err := json.Unmarshal(schema.JSONSchema, &params); err != nil {
-					params = map[string]interface{}{}
-				}
+		schema := t.Schema()
+		if len(schema.JSONSchema) > 0 {
+			if err := json.Unmarshal(schema.JSONSchema, &params); err != nil {
+				params = map[string]interface{}{}
 			}
 		}
 

--- a/providers/ollama/provider_test.go
+++ b/providers/ollama/provider_test.go
@@ -775,5 +775,6 @@ type mockTool struct {
 	description string
 }
 
-func (t *mockTool) Name() string        { return t.name }
-func (t *mockTool) Description() string { return t.description }
+func (t *mockTool) Name() string            { return t.name }
+func (t *mockTool) Description() string     { return t.description }
+func (t *mockTool) Schema() core.ToolSchema { return core.ToolSchema{} }

--- a/providers/openai/mapping.go
+++ b/providers/openai/mapping.go
@@ -4,14 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/petal-labs/iris/core"
-	"github.com/petal-labs/iris/tools"
 )
-
-// schemaProvider is an interface for tools that provide a JSON schema.
-// This allows us to check if a core.Tool also implements the full tools.Tool interface.
-type schemaProvider interface {
-	Schema() tools.ToolSchema
-}
 
 // mapMessages converts Iris messages to OpenAI message format.
 func mapMessages(msgs []core.Message) []openAIMessage {
@@ -84,7 +77,8 @@ func marshalToolResultContent(content any) string {
 }
 
 // mapTools converts Iris tools to OpenAI tool format.
-// Tools that implement schemaProvider will have their schema included.
+// A tool with an empty schema (no parameters) is transmitted with an empty
+// object schema.
 func mapTools(irisTools []core.Tool) []openAITool {
 	if len(irisTools) == 0 {
 		return nil
@@ -92,15 +86,10 @@ func mapTools(irisTools []core.Tool) []openAITool {
 
 	result := make([]openAITool, len(irisTools))
 	for i, t := range irisTools {
-		var params json.RawMessage
+		params := t.Schema().JSONSchema
 
-		// Check if the tool provides a schema
-		if sp, ok := t.(schemaProvider); ok {
-			params = sp.Schema().JSONSchema
-		}
-
-		// Default to empty object if no schema
-		if params == nil {
+		// Default to empty object for no-parameter tools
+		if len(params) == 0 {
 			params = json.RawMessage(`{}`)
 		}
 

--- a/providers/openai/mapping_responses.go
+++ b/providers/openai/mapping_responses.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 
 	"github.com/petal-labs/iris/core"
-	"github.com/petal-labs/iris/tools"
 )
 
 // buildResponsesRequest creates a Responses API request from an Iris ChatRequest.
@@ -193,15 +192,10 @@ func mapResponsesTools(irisTools []core.Tool, builtInTools []core.BuiltInTool) [
 
 	// Add custom function tools
 	for _, t := range irisTools {
-		var params json.RawMessage
+		params := t.Schema().JSONSchema
 
-		// Check if the tool provides a schema
-		if sp, ok := t.(schemaProvider); ok {
-			params = sp.Schema().JSONSchema
-		}
-
-		// Default to empty object if no schema
-		if params == nil {
+		// Default to empty object for no-parameter tools
+		if len(params) == 0 {
 			params = json.RawMessage(`{}`)
 		}
 
@@ -215,10 +209,6 @@ func mapResponsesTools(irisTools []core.Tool, builtInTools []core.BuiltInTool) [
 
 	return result
 }
-
-// schemaProvider interface is already defined in mapping.go
-// We use tools.ToolSchema for the schema type.
-var _ schemaProvider = (tools.Tool)(nil)
 
 // mapResponsesResponse converts a Responses API response to an Iris ChatResponse.
 func mapResponsesResponse(resp *responsesResponse) (*core.ChatResponse, error) {

--- a/providers/openai/mapping_test.go
+++ b/providers/openai/mapping_test.go
@@ -105,14 +105,15 @@ func (m *mockFullTool) Description() string                                     
 func (m *mockFullTool) Schema() tools.ToolSchema                                    { return m.schema }
 func (m *mockFullTool) Call(ctx context.Context, args json.RawMessage) (any, error) { return nil, nil }
 
-// mockBasicTool implements only core.Tool (no Schema)
+// mockBasicTool implements core.Tool with an empty schema (no parameters).
 type mockBasicTool struct {
 	name        string
 	description string
 }
 
-func (m *mockBasicTool) Name() string        { return m.name }
-func (m *mockBasicTool) Description() string { return m.description }
+func (m *mockBasicTool) Name() string            { return m.name }
+func (m *mockBasicTool) Description() string     { return m.description }
+func (m *mockBasicTool) Schema() core.ToolSchema { return core.ToolSchema{} }
 
 func TestMapToolsWithSchema(t *testing.T) {
 	schema := json.RawMessage(`{"type":"object","properties":{"location":{"type":"string"}}}`)
@@ -145,7 +146,9 @@ func TestMapToolsWithSchema(t *testing.T) {
 	}
 }
 
-func TestMapToolsWithoutSchema(t *testing.T) {
+func TestMapToolsEmptySchemaDefaultsToEmptyObject(t *testing.T) {
+	// A tool that declares no parameters (empty ToolSchema) is transmitted
+	// with an empty object schema rather than a missing one.
 	tool := &mockBasicTool{
 		name:        "simple_tool",
 		description: "A simple tool",

--- a/providers/perplexity/mapping.go
+++ b/providers/perplexity/mapping.go
@@ -4,14 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/petal-labs/iris/core"
-	"github.com/petal-labs/iris/tools"
 )
-
-// schemaProvider is an interface for tools that provide a JSON schema.
-// This allows us to check if a core.Tool also implements the full tools.Tool interface.
-type schemaProvider interface {
-	Schema() tools.ToolSchema
-}
 
 // mapMessages converts Iris messages to Perplexity message format.
 func mapMessages(msgs []core.Message) []perplexityMessage {
@@ -26,7 +19,8 @@ func mapMessages(msgs []core.Message) []perplexityMessage {
 }
 
 // mapTools converts Iris tools to Perplexity tool format.
-// Tools that implement schemaProvider will have their schema included.
+// A tool with an empty schema (no parameters) is transmitted with an empty
+// object schema.
 func mapTools(irisTools []core.Tool) []perplexityTool {
 	if len(irisTools) == 0 {
 		return nil
@@ -34,15 +28,10 @@ func mapTools(irisTools []core.Tool) []perplexityTool {
 
 	result := make([]perplexityTool, len(irisTools))
 	for i, t := range irisTools {
-		var params json.RawMessage
+		params := t.Schema().JSONSchema
 
-		// Check if the tool provides a schema
-		if sp, ok := t.(schemaProvider); ok {
-			params = sp.Schema().JSONSchema
-		}
-
-		// Default to empty object if no schema
-		if params == nil {
+		// Default to empty object for no-parameter tools
+		if len(params) == 0 {
 			params = json.RawMessage(`{}`)
 		}
 

--- a/providers/perplexity/mapping_test.go
+++ b/providers/perplexity/mapping_test.go
@@ -410,8 +410,9 @@ type mockTool struct {
 	description string
 }
 
-func (t *mockTool) Name() string        { return t.name }
-func (t *mockTool) Description() string { return t.description }
+func (t *mockTool) Name() string            { return t.name }
+func (t *mockTool) Description() string     { return t.description }
+func (t *mockTool) Schema() core.ToolSchema { return core.ToolSchema{} }
 
 func TestMapResponseCitations(t *testing.T) {
 	resp := &perplexityResponse{

--- a/providers/xai/mapping.go
+++ b/providers/xai/mapping.go
@@ -4,14 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/petal-labs/iris/core"
-	"github.com/petal-labs/iris/tools"
 )
-
-// schemaProvider is an interface for tools that provide a JSON schema.
-// This allows us to check if a core.Tool also implements the full tools.Tool interface.
-type schemaProvider interface {
-	Schema() tools.ToolSchema
-}
 
 // mapMessages converts Iris messages to xAI message format.
 func mapMessages(msgs []core.Message) []xaiMessage {
@@ -26,7 +19,8 @@ func mapMessages(msgs []core.Message) []xaiMessage {
 }
 
 // mapTools converts Iris tools to xAI tool format.
-// Tools that implement schemaProvider will have their schema included.
+// A tool with an empty schema (no parameters) is transmitted with an empty
+// object schema.
 func mapTools(irisTools []core.Tool) []xaiTool {
 	if len(irisTools) == 0 {
 		return nil
@@ -34,15 +28,10 @@ func mapTools(irisTools []core.Tool) []xaiTool {
 
 	result := make([]xaiTool, len(irisTools))
 	for i, t := range irisTools {
-		var params json.RawMessage
+		params := t.Schema().JSONSchema
 
-		// Check if the tool provides a schema
-		if sp, ok := t.(schemaProvider); ok {
-			params = sp.Schema().JSONSchema
-		}
-
-		// Default to empty object if no schema
-		if params == nil {
+		// Default to empty object for no-parameter tools
+		if len(params) == 0 {
 			params = json.RawMessage(`{}`)
 		}
 

--- a/providers/xai/mapping_test.go
+++ b/providers/xai/mapping_test.go
@@ -167,8 +167,9 @@ type mockTool struct {
 	description string
 }
 
-func (m *mockTool) Name() string        { return m.name }
-func (m *mockTool) Description() string { return m.description }
+func (m *mockTool) Name() string            { return m.name }
+func (m *mockTool) Description() string     { return m.description }
+func (m *mockTool) Schema() core.ToolSchema { return core.ToolSchema{} }
 
 func TestMapToolsBasic(t *testing.T) {
 	tools := []core.Tool{

--- a/providers/zai/mapping.go
+++ b/providers/zai/mapping.go
@@ -4,14 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/petal-labs/iris/core"
-	"github.com/petal-labs/iris/tools"
 )
-
-// schemaProvider is an interface for tools that provide a JSON schema.
-// This allows us to check if a core.Tool also implements the full tools.Tool interface.
-type schemaProvider interface {
-	Schema() tools.ToolSchema
-}
 
 // mapMessages converts Iris messages to Z.ai message format.
 func mapMessages(msgs []core.Message) []zaiMessage {
@@ -26,7 +19,8 @@ func mapMessages(msgs []core.Message) []zaiMessage {
 }
 
 // mapTools converts Iris tools to Z.ai tool format.
-// Tools that implement schemaProvider will have their schema included.
+// A tool with an empty schema (no parameters) is transmitted with an empty
+// object schema.
 func mapTools(irisTools []core.Tool) []zaiTool {
 	if len(irisTools) == 0 {
 		return nil
@@ -34,15 +28,10 @@ func mapTools(irisTools []core.Tool) []zaiTool {
 
 	result := make([]zaiTool, len(irisTools))
 	for i, t := range irisTools {
-		var params json.RawMessage
+		params := t.Schema().JSONSchema
 
-		// Check if the tool provides a schema
-		if sp, ok := t.(schemaProvider); ok {
-			params = sp.Schema().JSONSchema
-		}
-
-		// Default to empty object if no schema
-		if params == nil {
+		// Default to empty object for no-parameter tools
+		if len(params) == 0 {
 			params = json.RawMessage(`{}`)
 		}
 

--- a/providers/zai/mapping_test.go
+++ b/providers/zai/mapping_test.go
@@ -179,8 +179,9 @@ type mockTool struct {
 	description string
 }
 
-func (m *mockTool) Name() string        { return m.name }
-func (m *mockTool) Description() string { return m.description }
+func (m *mockTool) Name() string            { return m.name }
+func (m *mockTool) Description() string     { return m.description }
+func (m *mockTool) Schema() core.ToolSchema { return core.ToolSchema{} }
 
 func TestMapToolsBasic(t *testing.T) {
 	tools := []core.Tool{

--- a/tools/doc.go
+++ b/tools/doc.go
@@ -1,2 +1,19 @@
 // Package tools provides tool interfaces, registry, and argument parsing for AI tool calling.
+//
+// Tool is the executable tool contract: it embeds core.Tool (Name,
+// Description, and Schema) and adds Call. Because it embeds core.Tool, any
+// Tool implementation can be passed directly to ChatBuilder.Tools or stored
+// in ChatRequest.Tools, and every provider transmits its schema:
+//
+//	type Tool interface {
+//	    core.Tool
+//	    Call(ctx context.Context, args json.RawMessage) (any, error)
+//	}
+//
+// ToolSchema is an alias of core.ToolSchema; the schema contract is owned by
+// core so providers can consume it without importing this package.
+//
+// The package also provides a tool Registry, middleware (logging, timeout,
+// rate limiting, cache, validation, retry, circuit breaking, metrics), and
+// the ParseArgs generic helper for decoding tool-call arguments.
 package tools

--- a/tools/tool.go
+++ b/tools/tool.go
@@ -3,23 +3,18 @@ package tools
 import (
 	"context"
 	"encoding/json"
+
+	"github.com/petal-labs/iris/core"
 )
 
-// Tool defines the interface for AI-callable tools.
+// Tool defines the interface for executable AI-callable tools.
 // Tools provide a schema for argument validation and a Call method for execution.
 //
-// Any type implementing Tool also satisfies core.Tool (which requires only
-// Name and Description), allowing tools to be used with ChatRequest.Tools.
+// Tool embeds core.Tool, so any type implementing Tool can be passed
+// directly to ChatBuilder.Tools (or ChatRequest.Tools) and providers will
+// transmit its schema.
 type Tool interface {
-	// Name returns the unique identifier for this tool.
-	Name() string
-
-	// Description returns a human-readable description of what this tool does.
-	// This is provided to the AI model to help it decide when to use the tool.
-	Description() string
-
-	// Schema returns the JSON Schema that describes the tool's parameters.
-	Schema() ToolSchema
+	core.Tool
 
 	// Call executes the tool with the given arguments.
 	// The args parameter contains the raw JSON arguments from the model.
@@ -28,9 +23,9 @@ type Tool interface {
 }
 
 // ToolSchema describes the parameters a tool accepts.
-// JSONSchema must be a valid JSON Schema object.
-type ToolSchema struct {
-	// JSONSchema is a valid JSON Schema object describing the tool's parameters.
-	// Example: {"type": "object", "properties": {"location": {"type": "string"}}}
-	JSONSchema json.RawMessage `json:"json_schema"`
-}
+// It is an alias of core.ToolSchema; the schema contract is owned by core
+// so providers can consume it without importing this package.
+type ToolSchema = core.ToolSchema
+
+// Ensure the executable interface satisfies the request-carrier interface.
+var _ core.Tool = (Tool)(nil)

--- a/tools/tool_test.go
+++ b/tools/tool_test.go
@@ -90,3 +90,58 @@ func TestToolSchemaJSONSerialization(t *testing.T) {
 		t.Errorf("Round-trip failed: got %q, want %q", string(parsed.JSONSchema), string(schema.JSONSchema))
 	}
 }
+
+// capturingProvider captures the ChatRequest the client built, so tests can
+// verify tools passed via ChatBuilder.Tools arrive intact.
+type capturingProvider struct {
+	lastReq *core.ChatRequest
+}
+
+func (p *capturingProvider) ID() string                         { return "capturing" }
+func (p *capturingProvider) Models() []core.ModelInfo           { return nil }
+func (p *capturingProvider) Supports(feature core.Feature) bool { return true }
+func (p *capturingProvider) Chat(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	p.lastReq = req
+	return &core.ChatResponse{ID: "resp-1", Model: req.Model, Output: "ok"}, nil
+}
+func (p *capturingProvider) StreamChat(ctx context.Context, req *core.ChatRequest) (*core.ChatStream, error) {
+	p.lastReq = req
+	ch := make(chan core.ChatChunk, 1)
+	errCh := make(chan error, 1)
+	finalCh := make(chan *core.ChatResponse, 1)
+	go func() {
+		ch <- core.ChatChunk{Delta: "ok"}
+		close(ch)
+		finalCh <- &core.ChatResponse{ID: "resp-1", Model: req.Model, Output: "ok"}
+		close(finalCh)
+		close(errCh)
+	}()
+	return &core.ChatStream{Ch: ch, Err: errCh, Final: finalCh}, nil
+}
+
+func TestToolSchemaReachesProviderThroughClient(t *testing.T) {
+	schema := tools.ToolSchema{JSONSchema: json.RawMessage(`{"type":"object","properties":{"city":{"type":"string"}}}`)}
+	tool := &mockTool{
+		name:        "get_weather",
+		description: "Get weather",
+		schema:      schema,
+		callFn:      func(ctx context.Context, args json.RawMessage) (any, error) { return "sunny", nil },
+	}
+
+	provider := &capturingProvider{}
+	client := core.NewClient(provider)
+
+	_, err := client.Chat("gpt-4").User("Weather in Tokyo?").Tools(tool).GetResponse(context.Background())
+	if err != nil {
+		t.Fatalf("GetResponse() error = %v", err)
+	}
+
+	if provider.lastReq == nil || len(provider.lastReq.Tools) != 1 {
+		t.Fatalf("request did not carry the tool (tools: %v)", provider.lastReq)
+	}
+
+	got := provider.lastReq.Tools[0].Schema().JSONSchema
+	if string(got) != string(schema.JSONSchema) {
+		t.Errorf("schema at provider = %s, want %s", got, schema.JSONSchema)
+	}
+}


### PR DESCRIPTION
Closes #58.

## Summary

`core.Tool` was a placeholder interface (Name + Description only); the real contract lived in `tools.Tool`, and all 9 providers duck-typed tools against unexported `schemaProvider` interfaces — **silently sending `{}` as the parameters schema** whenever the assertion failed. This PR makes the schema part of the contract so the compiler enforces it.

## Changes

- **`core.ToolSchema`** (new, in core) — `tools.ToolSchema` becomes an alias (`type ToolSchema = core.ToolSchema`), so all existing `tools.ToolSchema` code compiles unchanged
- **`core.Tool`** now requires `Schema() ToolSchema` — an incompatible `Schema()` signature is a **compile error** instead of silent schema loss
- **`tools.Tool`** embeds `core.Tool` + `Call()`, with `var _ core.Tool = (Tool)(nil)` asserting satisfaction
- **All 9 providers**: deleted the unexported `schemaProvider` interfaces (10 call sites incl. openai's Responses path); providers call `t.Schema()` directly
- Empty schema (legitimate no-parameter tool) still maps to `{}` on the wire
- Docs: canonical interface documented in `core/types.go`, `tools/doc.go`, README "Using Tools"
- New end-to-end test: `tools.Tool` → `ChatBuilder.Tools()` → provider receives schema intact

## Why ToolSchema moved into core

`tools` imports `core` (parser uses `core.ToolCall`), so `core.Tool` referencing `tools.ToolSchema` would be an import cycle. Owning the schema type in core lets providers consume it without importing tools at all.

## Acceptance criteria (from #58)

- [x] A tool with an incompatible `Schema()` signature is a compile error (demonstrated: 9 in-repo test mocks were rejected by the compiler before being fixed)
- [x] The silent `{}` fallback is gone — the assertion that could fail no longer exists; empty schemas (no-arg tools) intentionally produce `{}`
- [x] Single canonical `Tool` interface documented across `core` and `tools`

## Breaking change

Types implementing `core.Tool` with only `Name()`/`Description()` must add:

```go
func (t *T) Schema() core.ToolSchema { return core.ToolSchema{} } // or a real schema
```

Full `tools.Tool` implementations already had `Schema()` and are unaffected.

## Testing

- New: `TestToolSchemaReachesProviderThroughClient` (end-to-end schema delivery)
- Renamed/updated: `TestMapToolsEmptySchemaDefaultsToEmptyObject`
- All per-provider `TestMapToolsWithSchema` tests unchanged and green
- Full `go test ./...` green (23 packages), build/vet/gofmt clean, examples module builds