### PR TITLE
fix(core): prevent ChatBuilder input aliasing

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 )
 
@@ -147,6 +148,9 @@ func (c *Client) Chat(model ModelID) *ChatBuilder {
 
 // ChatBuilder provides a fluent API for building chat requests.
 // ChatBuilder is NOT thread-safe and should not be shared across goroutines.
+// Most configuration methods mutate the receiver and return the same builder.
+// Clone returns an independent builder; ToolResults, ToolResult, and ToolError
+// are the only configuration methods that clone automatically.
 type ChatBuilder struct {
 	client  *Client
 	req     ChatRequest
@@ -183,9 +187,11 @@ func (b *ChatBuilder) MaxTokens(n int) *ChatBuilder {
 	return b
 }
 
-// Tools sets the tools available for the request.
+// Tools sets the tools available for the request. It copies the caller's slice,
+// so later changes to the slice do not affect the request. The Tool values are
+// retained as interfaces and must not be mutated while the builder is in use.
 func (b *ChatBuilder) Tools(ts ...Tool) *ChatBuilder {
-	b.req.Tools = ts
+	b.req.Tools = slices.Clone(ts)
 	return b
 }
 
@@ -317,13 +323,7 @@ func (b *ChatBuilder) Clone() *ChatBuilder {
 		clone.req.MaxTokens = &m
 	}
 	if b.req.JSONSchema != nil {
-		schemaCopy := *b.req.JSONSchema
-		// Deep copy the schema bytes
-		if len(b.req.JSONSchema.Schema) > 0 {
-			schemaCopy.Schema = make([]byte, len(b.req.JSONSchema.Schema))
-			copy(schemaCopy.Schema, b.req.JSONSchema.Schema)
-		}
-		clone.req.JSONSchema = &schemaCopy
+		clone.req.JSONSchema = cloneJSONSchemaDefinition(b.req.JSONSchema)
 	}
 
 	// Deep copy slices
@@ -401,11 +401,13 @@ func (b *ChatBuilder) ResponseJSON() *ChatBuilder {
 // This enables structured output mode where the model produces JSON conforming to the schema.
 // The schema parameter defines the structure the output must conform to.
 //
-// This always forces schema.Strict = true. Strict mode requires the schema to
-// set "additionalProperties": false and list every property in "required" at
-// every object node; validate() rejects non-compliant schemas with
-// ErrInvalidSchema before the request is sent. Use ResponseJSONSchemaNonStrict
-// to opt out of strict mode for schemas that cannot meet those constraints.
+// This copies schema, including its raw JSON bytes, and forces Strict = true on
+// the copy without modifying the caller's value. Strict mode requires the
+// schema to set "additionalProperties": false and list every property in
+// "required" at every object node; validate() rejects non-compliant schemas
+// with ErrInvalidSchema before the request is sent. Use
+// ResponseJSONSchemaNonStrict to opt out of strict mode for schemas that cannot
+// meet those constraints.
 //
 // Example:
 //
@@ -418,27 +420,41 @@ func (b *ChatBuilder) ResponseJSON() *ChatBuilder {
 //	    ResponseJSONSchema(schema).
 //	    GetResponse(ctx)
 func (b *ChatBuilder) ResponseJSONSchema(schema *JSONSchemaDefinition) *ChatBuilder {
-	if schema != nil {
-		schema.Strict = true
+	schemaCopy := cloneJSONSchemaDefinition(schema)
+	if schemaCopy != nil {
+		schemaCopy.Strict = true
 	}
 	b.req.ResponseFormat = ResponseFormatJSONSchema
-	b.req.JSONSchema = schema
+	b.req.JSONSchema = schemaCopy
 	return b
 }
 
 // ResponseJSONSchemaNonStrict constrains the model output to match a specific
-// JSON Schema without enforcing strict mode. This forces schema.Strict = false,
-// skipping the strict-schema validation that ResponseJSONSchema applies. Use
-// this when a schema cannot satisfy strict mode's requirements (every object
-// node needs "additionalProperties": false and a "required" array covering
-// all declared properties) and the provider still accepts loose schemas.
+// JSON Schema without enforcing strict mode. This copies schema, including its
+// raw JSON bytes, and forces Strict = false on the copy without modifying the
+// caller's value. It skips the strict-schema validation that ResponseJSONSchema
+// applies. Use this when a schema cannot satisfy strict mode's requirements
+// (every object node needs "additionalProperties": false and a "required"
+// array covering all declared properties) and the provider accepts loose
+// schemas.
 func (b *ChatBuilder) ResponseJSONSchemaNonStrict(schema *JSONSchemaDefinition) *ChatBuilder {
-	if schema != nil {
-		schema.Strict = false
+	schemaCopy := cloneJSONSchemaDefinition(schema)
+	if schemaCopy != nil {
+		schemaCopy.Strict = false
 	}
 	b.req.ResponseFormat = ResponseFormatJSONSchema
-	b.req.JSONSchema = schema
+	b.req.JSONSchema = schemaCopy
 	return b
+}
+
+func cloneJSONSchemaDefinition(schema *JSONSchemaDefinition) *JSONSchemaDefinition {
+	if schema == nil {
+		return nil
+	}
+
+	clone := *schema
+	clone.Schema = slices.Clone(schema.Schema)
+	return &clone
 }
 
 // ResponseText explicitly sets the response format to text (the default).

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -492,6 +492,23 @@ func TestChatBuilderTools(t *testing.T) {
 	}
 }
 
+func TestChatBuilderToolsCopiesCallerSlice(t *testing.T) {
+	p := &mockProvider{id: "test"}
+	c := NewClient(p)
+
+	tool1 := &mockTool{name: "tool1"}
+	tool2 := &mockTool{name: "tool2"}
+	replacement := &mockTool{name: "replacement"}
+	callerTools := []Tool{tool1, tool2}
+
+	builder := c.Chat("gpt-4").Tools(callerTools...)
+	callerTools[0] = replacement
+
+	if builder.req.Tools[0] != tool1 {
+		t.Error("mutating the caller's tools slice changed the builder request")
+	}
+}
+
 // mockTool is a test implementation of Tool.
 type mockTool struct {
 	name string
@@ -1575,15 +1592,71 @@ func TestResponseJSONSchemaNonStrictOptOut(t *testing.T) {
 	}
 }
 
-func TestResponseJSONSchemaForcesStrictEvenIfCallerSetFalse(t *testing.T) {
-	schema := &JSONSchemaDefinition{
-		Name:   "x",
-		Schema: json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{},"required":[]}`),
-		Strict: false,
+func TestResponseJSONSchemaCopiesCallerSchema(t *testing.T) {
+	tests := []struct {
+		name          string
+		callerStrict  bool
+		requestStrict bool
+		apply         func(*ChatBuilder, *JSONSchemaDefinition) *ChatBuilder
+	}{
+		{
+			name:          "strict",
+			callerStrict:  false,
+			requestStrict: true,
+			apply:         (*ChatBuilder).ResponseJSONSchema,
+		},
+		{
+			name:          "non-strict",
+			callerStrict:  true,
+			requestStrict: false,
+			apply:         (*ChatBuilder).ResponseJSONSchemaNonStrict,
+		},
 	}
-	NewClient(&mockProvider{}).Chat("m").ResponseJSONSchema(schema)
-	if !schema.Strict {
-		t.Error("ResponseJSONSchema should force Strict=true even if the caller passed false")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertChatBuilderCopiesSchema(t, tt.callerStrict, tt.requestStrict, tt.apply)
+		})
+	}
+}
+
+func assertChatBuilderCopiesSchema(
+	t *testing.T,
+	callerStrict bool,
+	requestStrict bool,
+	apply func(*ChatBuilder, *JSONSchemaDefinition) *ChatBuilder,
+) {
+	t.Helper()
+	schema := &JSONSchemaDefinition{
+		Name:        "person",
+		Description: "a person",
+		Schema:      json.RawMessage(`{"type":"object","additionalProperties":false,"properties":{},"required":[]}`),
+		Strict:      callerStrict,
+	}
+
+	builder := apply(NewClient(&mockProvider{}).Chat("m"), schema)
+	if schema.Strict != callerStrict {
+		t.Errorf("caller schema Strict = %v, want unchanged value %v", schema.Strict, callerStrict)
+	}
+	if builder.req.JSONSchema == schema {
+		t.Error("builder retained the caller's schema pointer")
+	}
+
+	schema.Name = "mutated"
+	schema.Description = "mutated"
+	schema.Schema[0] = 'X'
+
+	if builder.req.JSONSchema.Name != "person" {
+		t.Errorf("request schema Name = %q, want %q", builder.req.JSONSchema.Name, "person")
+	}
+	if builder.req.JSONSchema.Description != "a person" {
+		t.Errorf("request schema Description = %q, want %q", builder.req.JSONSchema.Description, "a person")
+	}
+	if builder.req.JSONSchema.Schema[0] == 'X' {
+		t.Error("mutating caller schema bytes changed the builder request")
+	}
+	if builder.req.JSONSchema.Strict != requestStrict {
+		t.Errorf("request schema Strict = %v, want %v", builder.req.JSONSchema.Strict, requestStrict)
 	}
 }
 

--- a/core/doc.go
+++ b/core/doc.go
@@ -34,6 +34,18 @@
 //	go func() { resp1, _ := base.Clone().User("Q1").GetResponse(ctx) }()
 //	go func() { resp2, _ := base.Clone().User("Q2").GetResponse(ctx) }()
 //
+// Most ChatBuilder configuration methods mutate the receiver and return the
+// same pointer. [ChatBuilder.ToolResults], [ChatBuilder.ToolResult], and
+// [ChatBuilder.ToolError] are the exceptions: they clone the builder and leave
+// the original unchanged.
+//
+// [ChatBuilder.Tools], [ChatBuilder.ResponseJSONSchema], and
+// [ChatBuilder.ResponseJSONSchemaNonStrict] defensively copy their caller-owned
+// slice or schema, including raw schema bytes. Callers may therefore reuse or
+// modify those containers after configuring a builder. Tools themselves are
+// interface values and are not cloned; treat the underlying tool objects as
+// immutable while a builder that references them is in use.
+//
 // # Streaming
 //
 // Iris treats streaming as a first-class primitive. Use [ChatBuilder.Stream] for


### PR DESCRIPTION
## Summary

- defensively copy the caller-owned tools slice in `ChatBuilder.Tools`
- copy `JSONSchemaDefinition` values and raw schema bytes before applying strict/non-strict request settings
- document `ChatBuilder` mutation, cloning, and ownership semantics
- add regression coverage for tools-slice and schema aliasing

## Root cause

`ChatBuilder.Tools` retained the variadic slice backing array, while the schema methods stored and mutated the caller's schema pointer. The builder also mixed receiver-mutating methods with clone-returning tool-result helpers without a package-level ownership contract.

## Impact

Callers can now reuse or mutate their tools container and JSON schema after configuring a builder without changing the resulting request. The underlying tool objects remain shared interface values and are documented as immutable while in use.

## Validation

- `go test ./... -count=1`
- `go test -race ./core -count=1`
- `go vet ./...`
- `go build ./...`
- `golangci-lint run --new-from-rev=origin/main` (0 issues)
- core package coverage: 89.3%

Closes #59
