### PR TITLE
fix(core)!: propagate conversation context and tool turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Conversation.AddToolResults(ctx, results)` for recording tool execution results before the next conversational turn (#60)
+
+### Changed
+
+- **Breaking:** `NewConversation`, primary `Conversation` operations, and every `Memory` method now require `context.Context`; `SendWithContext` and `StreamWithContext` remain as deprecated aliases (#60)
+
+### Fixed
+
+- Conversation replay now preserves complete messages, including assistant tool calls, tool results, and multimodal parts; unary and streaming tool-call responses are retained in history (#60)
+
 ## [0.17.0] - 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -562,19 +562,31 @@ The `Conversation` type manages message history automatically:
 
 ```go
 // Create a conversation with a system prompt
-conv := core.NewConversation(client, "gpt-5.6",
+ctx := context.Background()
+conv := core.NewConversation(ctx, client, "gpt-5.6",
     core.WithSystemMessage("You are a helpful assistant."),
 )
 
 // Send messages - history is managed automatically
-resp1, _ := conv.Send("What is Go?")
-resp2, _ := conv.Send("What are its main features?") // Remembers context
+resp1, _ := conv.Send(ctx, "What is Go?")
+resp2, _ := conv.Send(ctx, "What are its main features?") // Remembers context
 
 // Streaming responses
-stream, _ := conv.Stream("Tell me more about concurrency")
+stream, _ := conv.Stream(ctx, "Tell me more about concurrency")
 for chunk := range stream.Ch {
     fmt.Print(chunk.Delta)
 }
+```
+
+The same context is propagated through the provider request and every `Memory`
+operation. Assistant tool calls are retained in history; after executing them,
+append their results before continuing:
+
+```go
+resp, _ := conv.Send(ctx, "What's the weather in Tokyo?")
+results := executeTools(resp.ToolCalls)
+conv.AddToolResults(ctx, results)
+resp, _ = conv.Send(ctx, "Summarize the result.")
 ```
 
 ### Batch API

--- a/core/doc.go
+++ b/core/doc.go
@@ -46,6 +46,20 @@
 // interface values and are not cloned; treat the underlying tool objects as
 // immutable while a builder that references them is in use.
 //
+// # Conversations and Memory
+//
+// [Conversation] manages multi-turn history. Its constructor and operations
+// require a context, which is passed to both the provider and every [Memory]
+// operation so cancellations, deadlines, and trace metadata reach remote
+// storage implementations:
+//
+//	conv := core.NewConversation(ctx, client, model)
+//	resp, err := conv.Send(ctx, "Hello")
+//
+// Conversation history preserves complete [Message] values, including
+// assistant tool calls and tool-result turns. After executing requested tools,
+// use [Conversation.AddToolResults] before sending the next user message.
+//
 // # Streaming
 //
 // Iris treats streaming as a first-class primitive. Use [ChatBuilder.Stream] for

--- a/core/memory.go
+++ b/core/memory.go
@@ -2,37 +2,42 @@ package core
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"sync"
 )
 
 // Memory is the interface for managing conversation history.
-// Implementations provide different storage backends (in-memory, Redis, PostgreSQL, etc.).
+// Implementations provide different storage backends (in-memory, Redis,
+// PostgreSQL, etc.). Every operation receives the caller's context so remote
+// stores can honor cancellation and deadlines and propagate trace metadata.
 type Memory interface {
 	// AddMessage appends a message to the conversation history.
-	AddMessage(msg Message)
+	AddMessage(ctx context.Context, msg Message)
 
 	// AddMessages appends multiple messages to the conversation history.
-	AddMessages(msgs []Message)
+	AddMessages(ctx context.Context, msgs []Message)
 
 	// GetHistory returns all messages in the conversation.
-	GetHistory() []Message
+	GetHistory(ctx context.Context) []Message
 
 	// GetLastN returns the last N messages in the conversation.
-	GetLastN(n int) []Message
+	GetLastN(ctx context.Context, n int) []Message
 
 	// Clear removes all messages from the conversation.
-	Clear()
+	Clear(ctx context.Context)
 
 	// Len returns the number of messages in the conversation.
-	Len() int
+	Len(ctx context.Context) int
 
 	// SetMessages replaces the entire conversation history.
-	SetMessages(msgs []Message)
+	SetMessages(ctx context.Context, msgs []Message)
 }
 
-// InMemoryStore is a thread-safe in-memory implementation of the Memory interface.
-// Suitable for single-session conversations that don't require persistence.
+// InMemoryStore is a thread-safe in-memory implementation of the Memory
+// interface. Operations complete synchronously, so their contexts are unused.
+// It is suitable for single-session conversations that don't require
+// persistence.
 type InMemoryStore struct {
 	mu       sync.RWMutex
 	messages []Message
@@ -46,14 +51,14 @@ func NewInMemoryStore() *InMemoryStore {
 }
 
 // AddMessage appends a message to the conversation history.
-func (m *InMemoryStore) AddMessage(msg Message) {
+func (m *InMemoryStore) AddMessage(_ context.Context, msg Message) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.messages = append(m.messages, msg)
 }
 
 // AddMessages appends multiple messages to the conversation history.
-func (m *InMemoryStore) AddMessages(msgs []Message) {
+func (m *InMemoryStore) AddMessages(_ context.Context, msgs []Message) {
 	if len(msgs) == 0 {
 		return
 	}
@@ -64,7 +69,7 @@ func (m *InMemoryStore) AddMessages(msgs []Message) {
 
 // GetHistory returns all messages in the conversation.
 // Returns a copy of the messages slice.
-func (m *InMemoryStore) GetHistory() []Message {
+func (m *InMemoryStore) GetHistory(_ context.Context) []Message {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -75,7 +80,7 @@ func (m *InMemoryStore) GetHistory() []Message {
 
 // GetLastN returns the last N messages in the conversation.
 // If N is greater than the number of messages, returns all messages.
-func (m *InMemoryStore) GetLastN(n int) []Message {
+func (m *InMemoryStore) GetLastN(_ context.Context, n int) []Message {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -96,21 +101,21 @@ func (m *InMemoryStore) GetLastN(n int) []Message {
 }
 
 // Clear removes all messages from the conversation.
-func (m *InMemoryStore) Clear() {
+func (m *InMemoryStore) Clear(_ context.Context) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.messages = make([]Message, 0)
 }
 
 // Len returns the number of messages in the conversation.
-func (m *InMemoryStore) Len() int {
+func (m *InMemoryStore) Len(_ context.Context) int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return len(m.messages)
 }
 
 // SetMessages replaces the entire conversation history.
-func (m *InMemoryStore) SetMessages(msgs []Message) {
+func (m *InMemoryStore) SetMessages(_ context.Context, msgs []Message) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.messages = make([]Message, len(msgs))
@@ -148,7 +153,8 @@ func WithMemoryStore(memory Memory) ConversationOption {
 }
 
 // NewConversation creates a new conversation session with the given client and model.
-func NewConversation(client *Client, model ModelID, opts ...ConversationOption) *Conversation {
+// ctx is passed to the configured Memory when initializing a system message.
+func NewConversation(ctx context.Context, client *Client, model ModelID, opts ...ConversationOption) *Conversation {
 	c := &Conversation{
 		memory: NewInMemoryStore(),
 		client: client,
@@ -161,7 +167,7 @@ func NewConversation(client *Client, model ModelID, opts ...ConversationOption) 
 
 	// Add system message if provided
 	if c.system != "" {
-		c.memory.AddMessage(Message{
+		c.memory.AddMessage(ctx, Message{
 			Role:    RoleSystem,
 			Content: c.system,
 		})
@@ -170,60 +176,65 @@ func NewConversation(client *Client, model ModelID, opts ...ConversationOption) 
 	return c
 }
 
-// Send sends a user message and returns the assistant's response.
-// Automatically manages conversation history.
-// Uses context.Background() internally.
-func (c *Conversation) Send(userMessage string) (*ChatResponse, error) {
-	return c.SendWithContext(context.Background(), userMessage)
-}
-
-// SendWithContext sends a user message with context and returns the assistant's response.
-func (c *Conversation) SendWithContext(ctx context.Context, userMessage string) (*ChatResponse, error) {
-	// Add user message to history
-	c.memory.AddMessage(Message{
-		Role:    RoleUser,
-		Content: userMessage,
-	})
-
-	// Build request with full history
-	builder := c.client.Chat(c.model)
-	for _, msg := range c.memory.GetHistory() {
-		switch msg.Role {
-		case RoleSystem:
-			builder = builder.System(msg.Content)
-		case RoleUser:
-			builder = builder.User(msg.Content)
-		case RoleAssistant:
-			builder = builder.Assistant(msg.Content)
-		}
-	}
-
-	// Get response
+// Send sends a user message with ctx and returns the assistant's response.
+// It automatically manages conversation history, preserving multimodal and
+// tool-call turns when replaying earlier messages.
+func (c *Conversation) Send(ctx context.Context, userMessage string) (*ChatResponse, error) {
+	builder := c.builderWithUserMessage(ctx, userMessage)
 	resp, err := builder.GetResponse(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Add assistant response to history
-	c.memory.AddMessage(Message{
-		Role:    RoleAssistant,
-		Content: resp.Output,
+	c.memory.AddMessage(ctx, Message{
+		Role:      RoleAssistant,
+		Content:   resp.Output,
+		ToolCalls: slices.Clone(resp.ToolCalls),
 	})
 
 	return resp, nil
 }
 
+// SendWithContext delegates to Send.
+//
+// Deprecated: use Send.
+func (c *Conversation) SendWithContext(ctx context.Context, userMessage string) (*ChatResponse, error) {
+	return c.Send(ctx, userMessage)
+}
+
+func (c *Conversation) builderWithUserMessage(ctx context.Context, userMessage string) *ChatBuilder {
+	c.memory.AddMessage(ctx, Message{Role: RoleUser, Content: userMessage})
+
+	builder := c.client.Chat(c.model)
+	builder.req.Messages = slices.Clone(c.memory.GetHistory(ctx))
+	return builder
+}
+
+// AddToolResults appends tool execution results to the conversation. Call it
+// after Send or Stream returns assistant tool calls and before sending the next
+// user message. The results slice is copied before it is stored.
+func (c *Conversation) AddToolResults(ctx context.Context, results []ToolResult) {
+	if len(results) == 0 {
+		return
+	}
+
+	c.memory.AddMessage(ctx, Message{
+		Role:        RoleTool,
+		ToolResults: slices.Clone(results),
+	})
+}
+
 // GetHistory returns the full conversation history.
-func (c *Conversation) GetHistory() []Message {
-	return c.memory.GetHistory()
+func (c *Conversation) GetHistory(ctx context.Context) []Message {
+	return c.memory.GetHistory(ctx)
 }
 
 // Clear resets the conversation history.
 // If a system message was provided, it will be re-added.
-func (c *Conversation) Clear() {
-	c.memory.Clear()
+func (c *Conversation) Clear(ctx context.Context) {
+	c.memory.Clear(ctx)
 	if c.system != "" {
-		c.memory.AddMessage(Message{
+		c.memory.AddMessage(ctx, Message{
 			Role:    RoleSystem,
 			Content: c.system,
 		})
@@ -231,99 +242,76 @@ func (c *Conversation) Clear() {
 }
 
 // MessageCount returns the number of messages in the conversation.
-func (c *Conversation) MessageCount() int {
-	return c.memory.Len()
+func (c *Conversation) MessageCount(ctx context.Context) int {
+	return c.memory.Len(ctx)
 }
 
-// Stream sends a user message and returns a streaming response.
-// Automatically manages conversation history; the assistant's response
-// is added to history when the stream completes.
-// Uses context.Background() internally.
-func (c *Conversation) Stream(userMessage string) (*ChatStream, error) {
-	return c.StreamWithContext(context.Background(), userMessage)
-}
-
-// StreamWithContext sends a user message with context and returns a streaming response.
-// The stream is wrapped to automatically add the assistant's response to history
-// when the stream completes successfully.
-func (c *Conversation) StreamWithContext(ctx context.Context, userMessage string) (*ChatStream, error) {
-	// Add user message to history
-	c.memory.AddMessage(Message{
-		Role:    RoleUser,
-		Content: userMessage,
-	})
-
-	// Build request with full history
-	builder := c.client.Chat(c.model)
-	for _, msg := range c.memory.GetHistory() {
-		switch msg.Role {
-		case RoleSystem:
-			builder = builder.System(msg.Content)
-		case RoleUser:
-			builder = builder.User(msg.Content)
-		case RoleAssistant:
-			builder = builder.Assistant(msg.Content)
-		}
-	}
-
-	// Get stream
+// Stream sends a user message with ctx and returns a streaming response.
+// The stream is wrapped to add the assistant's complete text and tool calls to
+// conversation history when it finishes successfully.
+func (c *Conversation) Stream(ctx context.Context, userMessage string) (*ChatStream, error) {
+	builder := c.builderWithUserMessage(ctx, userMessage)
 	stream, err := builder.Stream(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Wrap stream to capture final response for history
-	return c.wrapStreamForHistory(stream), nil
+	return c.wrapStreamForHistory(ctx, stream), nil
+}
+
+// StreamWithContext delegates to Stream.
+//
+// Deprecated: use Stream.
+func (c *Conversation) StreamWithContext(ctx context.Context, userMessage string) (*ChatStream, error) {
+	return c.Stream(ctx, userMessage)
 }
 
 // wrapStreamForHistory wraps a ChatStream to capture the final response
 // and add it to conversation history.
-func (c *Conversation) wrapStreamForHistory(stream *ChatStream) *ChatStream {
+func (c *Conversation) wrapStreamForHistory(ctx context.Context, stream *ChatStream) *ChatStream {
 	wrappedCh := make(chan ChatChunk, 1)
 	wrappedFinal := make(chan *ChatResponse, 1)
 
-	go func() {
-		// Accumulate content from chunks
-		var accumulated strings.Builder
-
-		// Forward all chunks while accumulating
-		for chunk := range stream.Ch {
-			accumulated.WriteString(chunk.Delta)
-			wrappedCh <- chunk
-		}
-		// Close chunk channel immediately after forwarding all chunks
-		// so consumers know chunks are done before waiting for Final
-		close(wrappedCh)
-
-		// Wait for final response
-		finalResp, ok := <-stream.Final
-		if !ok {
-			close(wrappedFinal)
-			return
-		}
-
-		// Use accumulated content if Final.Output is empty
-		output := finalResp.Output
-		if output == "" {
-			output = accumulated.String()
-		}
-
-		// Add assistant response to history
-		if output != "" {
-			c.memory.AddMessage(Message{
-				Role:    RoleAssistant,
-				Content: output,
-			})
-		}
-
-		// Forward the final response and close the channel
-		wrappedFinal <- finalResp
-		close(wrappedFinal)
-	}()
+	go c.forwardStreamToHistory(ctx, stream, wrappedCh, wrappedFinal)
 
 	return &ChatStream{
 		Ch:    wrappedCh,
 		Err:   stream.Err,
 		Final: wrappedFinal,
 	}
+}
+
+func (c *Conversation) forwardStreamToHistory(
+	ctx context.Context,
+	stream *ChatStream,
+	wrappedCh chan<- ChatChunk,
+	wrappedFinal chan<- *ChatResponse,
+) {
+	var accumulated strings.Builder
+	for chunk := range stream.Ch {
+		accumulated.WriteString(chunk.Delta)
+		wrappedCh <- chunk
+	}
+	close(wrappedCh)
+
+	finalResp, ok := <-stream.Final
+	if !ok || finalResp == nil {
+		close(wrappedFinal)
+		return
+	}
+
+	output := finalResp.Output
+	if output == "" {
+		output = accumulated.String()
+	}
+	if output != "" || len(finalResp.ToolCalls) > 0 {
+		c.memory.AddMessage(ctx, Message{
+			Role:      RoleAssistant,
+			Content:   output,
+			ToolCalls: slices.Clone(finalResp.ToolCalls),
+		})
+	}
+
+	wrappedFinal <- finalResp
+	close(wrappedFinal)
 }

--- a/core/memory_test.go
+++ b/core/memory_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 )
@@ -14,13 +15,13 @@ func TestInMemoryStoreAddMessage(t *testing.T) {
 	store := NewInMemoryStore()
 
 	msg := Message{Role: RoleUser, Content: "Hello"}
-	store.AddMessage(msg)
+	store.AddMessage(context.Background(), msg)
 
-	if store.Len() != 1 {
-		t.Errorf("Len() = %d, want 1", store.Len())
+	if store.Len(context.Background()) != 1 {
+		t.Errorf("Len() = %d, want 1", store.Len(context.Background()))
 	}
 
-	history := store.GetHistory()
+	history := store.GetHistory(context.Background())
 	if len(history) != 1 {
 		t.Fatalf("GetHistory() len = %d, want 1", len(history))
 	}
@@ -37,17 +38,17 @@ func TestInMemoryStoreAddMessages(t *testing.T) {
 		{Role: RoleAssistant, Content: "Hi there"},
 		{Role: RoleUser, Content: "How are you?"},
 	}
-	store.AddMessages(msgs)
+	store.AddMessages(context.Background(), msgs)
 
-	if store.Len() != 3 {
-		t.Errorf("Len() = %d, want 3", store.Len())
+	if store.Len(context.Background()) != 3 {
+		t.Errorf("Len() = %d, want 3", store.Len(context.Background()))
 	}
 
 	// Test empty add
-	store.AddMessages(nil)
-	store.AddMessages([]Message{})
-	if store.Len() != 3 {
-		t.Errorf("Len() after empty adds = %d, want 3", store.Len())
+	store.AddMessages(context.Background(), nil)
+	store.AddMessages(context.Background(), []Message{})
+	if store.Len(context.Background()) != 3 {
+		t.Errorf("Len() after empty adds = %d, want 3", store.Len(context.Background()))
 	}
 }
 
@@ -61,7 +62,7 @@ func TestInMemoryStoreGetLastN(t *testing.T) {
 		{Role: RoleAssistant, Content: "4"},
 		{Role: RoleUser, Content: "5"},
 	}
-	store.AddMessages(msgs)
+	store.AddMessages(context.Background(), msgs)
 
 	tests := []struct {
 		n    int
@@ -76,7 +77,7 @@ func TestInMemoryStoreGetLastN(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got := store.GetLastN(tc.n)
+		got := store.GetLastN(context.Background(), tc.n)
 		if tc.want == nil {
 			if got != nil {
 				t.Errorf("GetLastN(%d) = %v, want nil", tc.n, got)
@@ -97,33 +98,33 @@ func TestInMemoryStoreGetLastN(t *testing.T) {
 
 func TestInMemoryStoreClear(t *testing.T) {
 	store := NewInMemoryStore()
-	store.AddMessages([]Message{
+	store.AddMessages(context.Background(), []Message{
 		{Role: RoleUser, Content: "Hello"},
 		{Role: RoleAssistant, Content: "Hi"},
 	})
 
-	store.Clear()
+	store.Clear(context.Background())
 
-	if store.Len() != 0 {
-		t.Errorf("Len() after Clear = %d, want 0", store.Len())
+	if store.Len(context.Background()) != 0 {
+		t.Errorf("Len() after Clear = %d, want 0", store.Len(context.Background()))
 	}
 }
 
 func TestInMemoryStoreSetMessages(t *testing.T) {
 	store := NewInMemoryStore()
-	store.AddMessage(Message{Role: RoleUser, Content: "Original"})
+	store.AddMessage(context.Background(), Message{Role: RoleUser, Content: "Original"})
 
 	newMsgs := []Message{
 		{Role: RoleSystem, Content: "System"},
 		{Role: RoleUser, Content: "New"},
 	}
-	store.SetMessages(newMsgs)
+	store.SetMessages(context.Background(), newMsgs)
 
-	if store.Len() != 2 {
-		t.Errorf("Len() = %d, want 2", store.Len())
+	if store.Len(context.Background()) != 2 {
+		t.Errorf("Len() = %d, want 2", store.Len(context.Background()))
 	}
 
-	history := store.GetHistory()
+	history := store.GetHistory(context.Background())
 	if history[0].Role != RoleSystem {
 		t.Errorf("First message role = %q, want %q", history[0].Role, RoleSystem)
 	}
@@ -131,13 +132,13 @@ func TestInMemoryStoreSetMessages(t *testing.T) {
 
 func TestInMemoryStoreGetHistoryReturnsCopy(t *testing.T) {
 	store := NewInMemoryStore()
-	store.AddMessage(Message{Role: RoleUser, Content: "Original"})
+	store.AddMessage(context.Background(), Message{Role: RoleUser, Content: "Original"})
 
-	history := store.GetHistory()
+	history := store.GetHistory(context.Background())
 	history[0].Content = "Modified"
 
 	// Original should be unchanged
-	newHistory := store.GetHistory()
+	newHistory := store.GetHistory(context.Background())
 	if newHistory[0].Content != "Original" {
 		t.Error("GetHistory did not return a copy")
 	}
@@ -152,7 +153,7 @@ func TestInMemoryStoreConcurrency(t *testing.T) {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
-			store.AddMessage(Message{Role: RoleUser, Content: "msg"})
+			store.AddMessage(context.Background(), Message{Role: RoleUser, Content: "msg"})
 		}(i)
 	}
 
@@ -161,16 +162,16 @@ func TestInMemoryStoreConcurrency(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_ = store.GetHistory()
-			_ = store.Len()
-			_ = store.GetLastN(5)
+			_ = store.GetHistory(context.Background())
+			_ = store.Len(context.Background())
+			_ = store.GetLastN(context.Background(), 5)
 		}()
 	}
 
 	wg.Wait()
 
-	if store.Len() != 100 {
-		t.Errorf("Len() = %d, want 100 after concurrent operations", store.Len())
+	if store.Len(context.Background()) != 100 {
+		t.Errorf("Len() = %d, want 100 after concurrent operations", store.Len(context.Background()))
 	}
 }
 
@@ -181,25 +182,27 @@ func TestInMemoryStoreConcurrency(t *testing.T) {
 func TestNewConversation(t *testing.T) {
 	provider := &mockProvider{id: "test"}
 	client := NewClient(provider)
+	ctx := context.Background()
 
-	conv := NewConversation(client, "test-model")
+	conv := NewConversation(ctx, client, "test-model")
 
-	if conv.MessageCount() != 0 {
-		t.Errorf("MessageCount() = %d, want 0", conv.MessageCount())
+	if conv.MessageCount(ctx) != 0 {
+		t.Errorf("MessageCount() = %d, want 0", conv.MessageCount(ctx))
 	}
 }
 
 func TestNewConversationWithSystemMessage(t *testing.T) {
 	provider := &mockProvider{id: "test"}
 	client := NewClient(provider)
+	ctx := context.Background()
 
-	conv := NewConversation(client, "test-model", WithSystemMessage("You are helpful"))
+	conv := NewConversation(ctx, client, "test-model", WithSystemMessage("You are helpful"))
 
-	if conv.MessageCount() != 1 {
-		t.Errorf("MessageCount() = %d, want 1", conv.MessageCount())
+	if conv.MessageCount(ctx) != 1 {
+		t.Errorf("MessageCount() = %d, want 1", conv.MessageCount(ctx))
 	}
 
-	history := conv.GetHistory()
+	history := conv.GetHistory(ctx)
 	if history[0].Role != RoleSystem {
 		t.Errorf("First message role = %q, want %q", history[0].Role, RoleSystem)
 	}
@@ -211,35 +214,37 @@ func TestNewConversationWithSystemMessage(t *testing.T) {
 func TestNewConversationWithCustomMemory(t *testing.T) {
 	provider := &mockProvider{id: "test"}
 	client := NewClient(provider)
+	ctx := context.Background()
 
 	customMemory := NewInMemoryStore()
-	customMemory.AddMessage(Message{Role: RoleUser, Content: "Pre-existing"})
+	customMemory.AddMessage(ctx, Message{Role: RoleUser, Content: "Pre-existing"})
 
-	conv := NewConversation(client, "test-model", WithMemoryStore(customMemory))
+	conv := NewConversation(ctx, client, "test-model", WithMemoryStore(customMemory))
 
-	if conv.MessageCount() != 1 {
-		t.Errorf("MessageCount() = %d, want 1", conv.MessageCount())
+	if conv.MessageCount(ctx) != 1 {
+		t.Errorf("MessageCount() = %d, want 1", conv.MessageCount(ctx))
 	}
 }
 
 func TestConversationClear(t *testing.T) {
 	provider := &mockProvider{id: "test"}
 	client := NewClient(provider)
+	ctx := context.Background()
 
-	conv := NewConversation(client, "test-model", WithSystemMessage("System"))
-	conv.memory.AddMessage(Message{Role: RoleUser, Content: "Hello"})
+	conv := NewConversation(ctx, client, "test-model", WithSystemMessage("System"))
+	conv.memory.AddMessage(ctx, Message{Role: RoleUser, Content: "Hello"})
 
-	if conv.MessageCount() != 2 {
-		t.Errorf("MessageCount() before clear = %d, want 2", conv.MessageCount())
+	if conv.MessageCount(ctx) != 2 {
+		t.Errorf("MessageCount() before clear = %d, want 2", conv.MessageCount(ctx))
 	}
 
-	conv.Clear()
+	conv.Clear(ctx)
 
 	// System message should be re-added
-	if conv.MessageCount() != 1 {
-		t.Errorf("MessageCount() after clear = %d, want 1", conv.MessageCount())
+	if conv.MessageCount(ctx) != 1 {
+		t.Errorf("MessageCount() after clear = %d, want 1", conv.MessageCount(ctx))
 	}
-	history := conv.GetHistory()
+	history := conv.GetHistory(ctx)
 	if history[0].Role != RoleSystem {
 		t.Errorf("After clear, first message role = %q, want %q", history[0].Role, RoleSystem)
 	}
@@ -248,20 +253,157 @@ func TestConversationClear(t *testing.T) {
 func TestConversationClearNoSystem(t *testing.T) {
 	provider := &mockProvider{id: "test"}
 	client := NewClient(provider)
+	ctx := context.Background()
 
-	conv := NewConversation(client, "test-model")
-	conv.memory.AddMessage(Message{Role: RoleUser, Content: "Hello"})
+	conv := NewConversation(ctx, client, "test-model")
+	conv.memory.AddMessage(ctx, Message{Role: RoleUser, Content: "Hello"})
 
-	conv.Clear()
+	conv.Clear(ctx)
 
-	if conv.MessageCount() != 0 {
-		t.Errorf("MessageCount() after clear = %d, want 0", conv.MessageCount())
+	if conv.MessageCount(ctx) != 0 {
+		t.Errorf("MessageCount() after clear = %d, want 0", conv.MessageCount(ctx))
 	}
 }
 
 func TestMemoryInterfaceImplementation(t *testing.T) {
 	// Verify InMemoryStore implements Memory interface
 	var _ Memory = (*InMemoryStore)(nil)
+}
+
+type contextRecordingMemory struct {
+	*InMemoryStore
+	seen []context.Context
+}
+
+func (m *contextRecordingMemory) AddMessage(ctx context.Context, msg Message) {
+	m.seen = append(m.seen, ctx)
+	m.InMemoryStore.AddMessage(ctx, msg)
+}
+
+func (m *contextRecordingMemory) GetHistory(ctx context.Context) []Message {
+	m.seen = append(m.seen, ctx)
+	return m.InMemoryStore.GetHistory(ctx)
+}
+
+func TestConversationSendPropagatesContext(t *testing.T) {
+	type contextKey struct{}
+	ctx := context.WithValue(context.Background(), contextKey{}, "request-60")
+	memory := &contextRecordingMemory{InMemoryStore: NewInMemoryStore()}
+	provider := &mockProvider{id: "test", chatFunc: func(got context.Context, _ *ChatRequest) (*ChatResponse, error) {
+		if got.Value(contextKey{}) != "request-60" {
+			t.Error("provider did not receive the conversation context")
+		}
+		return &ChatResponse{Output: "Hello!"}, nil
+	}}
+	conv := NewConversation(ctx, NewClient(provider), "test-model",
+		WithMemoryStore(memory),
+		WithSystemMessage("You are helpful"),
+	)
+
+	if _, err := conv.Send(ctx, "Hello"); err != nil {
+		t.Fatalf("Send() error: %v", err)
+	}
+	if len(memory.seen) != 4 {
+		t.Fatalf("memory context calls = %d, want 4", len(memory.seen))
+	}
+	for _, got := range memory.seen {
+		if got.Value(contextKey{}) != "request-60" {
+			t.Error("memory did not receive the conversation context")
+		}
+	}
+}
+
+func TestConversationStreamHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	provider := &mockProvider{id: "test", streamFunc: func(got context.Context, _ *ChatRequest) (*ChatStream, error) {
+		return nil, got.Err()
+	}}
+	conv := NewConversation(context.Background(), NewClient(provider), "test-model")
+
+	_, err := conv.Stream(ctx, "Hello")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Stream() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestConversationReplaysToolTurns(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryStore()
+	store.AddMessages(ctx, []Message{
+		{Role: RoleUser, Content: "What's the weather?"},
+		{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "call-1", Name: "weather", Arguments: []byte(`{"city":"Tokyo"}`)}}},
+		{Role: RoleTool, ToolResults: []ToolResult{{CallID: "call-1", Content: "sunny"}}},
+	})
+
+	var got []Message
+	provider := &mockProvider{id: "test", chatFunc: func(_ context.Context, req *ChatRequest) (*ChatResponse, error) {
+		got = append([]Message(nil), req.Messages...)
+		return &ChatResponse{Output: "It is sunny."}, nil
+	}}
+	conv := NewConversation(ctx, NewClient(provider), "test-model", WithMemoryStore(store))
+
+	if _, err := conv.Send(ctx, "What should I wear?"); err != nil {
+		t.Fatalf("Send() error: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("replayed message count = %d, want 4", len(got))
+	}
+	if len(got[1].ToolCalls) != 1 || got[1].ToolCalls[0].ID != "call-1" {
+		t.Errorf("assistant tool calls = %#v, want call-1", got[1].ToolCalls)
+	}
+	if got[2].Role != RoleTool || len(got[2].ToolResults) != 1 {
+		t.Errorf("tool result message = %#v, want one RoleTool result", got[2])
+	}
+}
+
+func TestConversationStoresResponseToolCalls(t *testing.T) {
+	ctx := context.Background()
+	provider := &mockProvider{id: "test", chatFunc: func(_ context.Context, _ *ChatRequest) (*ChatResponse, error) {
+		return &ChatResponse{ToolCalls: []ToolCall{{ID: "call-1", Name: "weather", Arguments: []byte(`{"city":"Tokyo"}`)}}}, nil
+	}}
+	conv := NewConversation(ctx, NewClient(provider), "test-model")
+
+	if _, err := conv.Send(ctx, "What's the weather?"); err != nil {
+		t.Fatalf("Send() error: %v", err)
+	}
+	history := conv.GetHistory(ctx)
+	if len(history) != 2 {
+		t.Fatalf("history length = %d, want 2", len(history))
+	}
+	if len(history[1].ToolCalls) != 1 || history[1].ToolCalls[0].ID != "call-1" {
+		t.Errorf("stored tool calls = %#v, want call-1", history[1].ToolCalls)
+	}
+}
+
+func TestConversationAddToolResultsReplaysCompleteTurn(t *testing.T) {
+	ctx := context.Background()
+	callCount := 0
+	var replayed []Message
+	provider := &mockProvider{id: "test", chatFunc: func(_ context.Context, req *ChatRequest) (*ChatResponse, error) {
+		callCount++
+		if callCount == 1 {
+			return &ChatResponse{ToolCalls: []ToolCall{{ID: "call-1", Name: "weather"}}}, nil
+		}
+		replayed = append([]Message(nil), req.Messages...)
+		return &ChatResponse{Output: "It is sunny."}, nil
+	}}
+	conv := NewConversation(ctx, NewClient(provider), "test-model")
+
+	if _, err := conv.Send(ctx, "What's the weather?"); err != nil {
+		t.Fatalf("first Send() error: %v", err)
+	}
+	conv.AddToolResults(ctx, []ToolResult{{CallID: "call-1", Content: "sunny"}})
+	if _, err := conv.Send(ctx, "What should I wear?"); err != nil {
+		t.Fatalf("second Send() error: %v", err)
+	}
+
+	if len(replayed) != 4 {
+		t.Fatalf("replayed message count = %d, want 4", len(replayed))
+	}
+	if len(replayed[1].ToolCalls) != 1 || replayed[2].Role != RoleTool {
+		t.Errorf("replayed tool turn = %#v, want assistant call followed by tool result", replayed[1:3])
+	}
 }
 
 // -----------------------------------------------------------------------------
@@ -271,17 +413,18 @@ func TestMemoryInterfaceImplementation(t *testing.T) {
 func TestConversationStream(t *testing.T) {
 	provider := &mockProvider{id: "test"}
 	client := NewClient(provider)
+	ctx := context.Background()
 
-	conv := NewConversation(client, "test-model")
+	conv := NewConversation(ctx, client, "test-model")
 
 	// Get stream
-	stream, err := conv.Stream("Hello")
+	stream, err := conv.Stream(ctx, "Hello")
 	if err != nil {
 		t.Fatalf("Stream() error: %v", err)
 	}
 
 	// Use DrainStream for proper handling
-	resp, err := DrainStream(context.Background(), stream)
+	resp, err := DrainStream(ctx, stream)
 	if err != nil {
 		t.Fatalf("DrainStream error: %v", err)
 	}
@@ -290,7 +433,7 @@ func TestConversationStream(t *testing.T) {
 	}
 
 	// Verify history was updated
-	history := conv.GetHistory()
+	history := conv.GetHistory(ctx)
 	if len(history) != 2 {
 		t.Fatalf("History length = %d, want 2", len(history))
 	}
@@ -307,13 +450,13 @@ func TestConversationStream(t *testing.T) {
 	}
 }
 
-func TestConversationStreamWithContext(t *testing.T) {
+func TestConversationStreamWithContextAlias(t *testing.T) {
 	provider := &mockProvider{id: "test"}
 	client := NewClient(provider)
-
-	conv := NewConversation(client, "test-model", WithSystemMessage("You are helpful"))
-
 	ctx := context.Background()
+
+	conv := NewConversation(ctx, client, "test-model", WithSystemMessage("You are helpful"))
+
 	stream, err := conv.StreamWithContext(ctx, "How are you?")
 	if err != nil {
 		t.Fatalf("StreamWithContext() error: %v", err)
@@ -329,7 +472,7 @@ func TestConversationStreamWithContext(t *testing.T) {
 	}
 
 	// History should have: system, user, assistant
-	history := conv.GetHistory()
+	history := conv.GetHistory(ctx)
 	if len(history) != 3 {
 		t.Fatalf("History length = %d, want 3", len(history))
 	}
@@ -348,12 +491,11 @@ func TestConversationStreamWithContext(t *testing.T) {
 func TestConversationStreamMultipleTurns(t *testing.T) {
 	provider := &mockProvider{id: "test"}
 	client := NewClient(provider)
-
-	conv := NewConversation(client, "test-model")
 	ctx := context.Background()
+	conv := NewConversation(ctx, client, "test-model")
 
 	// First turn
-	stream1, err := conv.Stream("First")
+	stream1, err := conv.Stream(ctx, "First")
 	if err != nil {
 		t.Fatalf("Stream() first turn error: %v", err)
 	}
@@ -363,7 +505,7 @@ func TestConversationStreamMultipleTurns(t *testing.T) {
 	}
 
 	// Second turn
-	stream2, err := conv.Stream("Second")
+	stream2, err := conv.Stream(ctx, "Second")
 	if err != nil {
 		t.Fatalf("Stream() second turn error: %v", err)
 	}
@@ -373,7 +515,7 @@ func TestConversationStreamMultipleTurns(t *testing.T) {
 	}
 
 	// Should have 4 messages: user1, assistant1, user2, assistant2
-	history := conv.GetHistory()
+	history := conv.GetHistory(ctx)
 	if len(history) != 4 {
 		t.Fatalf("History length = %d, want 4", len(history))
 	}
@@ -383,5 +525,35 @@ func TestConversationStreamMultipleTurns(t *testing.T) {
 	}
 	if history[2].Content != "Second" {
 		t.Errorf("Message 2 content = %q, want %q", history[2].Content, "Second")
+	}
+}
+
+func TestConversationStreamStoresResponseToolCalls(t *testing.T) {
+	provider := &mockProvider{id: "test", streamFunc: func(_ context.Context, _ *ChatRequest) (*ChatStream, error) {
+		chunks := make(chan ChatChunk)
+		errs := make(chan error)
+		final := make(chan *ChatResponse, 1)
+		close(chunks)
+		close(errs)
+		final <- &ChatResponse{ToolCalls: []ToolCall{{ID: "call-1", Name: "weather"}}}
+		close(final)
+		return &ChatStream{Ch: chunks, Err: errs, Final: final}, nil
+	}}
+	ctx := context.Background()
+	conv := NewConversation(ctx, NewClient(provider), "test-model")
+
+	stream, err := conv.Stream(ctx, "What's the weather?")
+	if err != nil {
+		t.Fatalf("Stream() error: %v", err)
+	}
+	if _, err := DrainStream(ctx, stream); err != nil {
+		t.Fatalf("DrainStream() error: %v", err)
+	}
+	history := conv.GetHistory(ctx)
+	if len(history) != 2 {
+		t.Fatalf("history length = %d, want 2", len(history))
+	}
+	if len(history[1].ToolCalls) != 1 || history[1].ToolCalls[0].ID != "call-1" {
+		t.Errorf("stored tool calls = %#v, want call-1", history[1].ToolCalls)
 	}
 }

--- a/examples/chat/conversation-streaming/main.go
+++ b/examples/chat/conversation-streaming/main.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -28,9 +29,10 @@ func main() {
 
 	provider := openai.New(apiKey)
 	client := core.NewClient(provider)
+	ctx := context.Background()
 
 	// Create a conversation with a system prompt
-	conv := core.NewConversation(client, "gpt-5.4-mini",
+	conv := core.NewConversation(ctx, client, "gpt-5.4-mini",
 		core.WithSystemMessage("You are a helpful programming tutor. Keep responses concise. Remember our conversation context."),
 	)
 
@@ -57,7 +59,7 @@ func main() {
 		fmt.Print("Assistant: ")
 
 		// Use streaming - response is automatically added to history when complete
-		stream, err := conv.Stream(input)
+		stream, err := conv.Stream(ctx, input)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "\nError: %v\n", err)
 			continue
@@ -91,5 +93,5 @@ func main() {
 	}
 
 	// Show conversation history
-	fmt.Printf("\nConversation had %d messages total.\n", conv.MessageCount())
+	fmt.Printf("\nConversation had %d messages total.\n", conv.MessageCount(ctx))
 }


### PR DESCRIPTION
## Summary

- propagate caller context through `Conversation` and every `Memory` operation
- replay complete message parts so tool calls and tool results survive conversation history
- persist unary and streaming assistant tool calls, and add `Conversation.AddToolResults`
- update migration documentation, examples, and context/tool-turn coverage

## Root cause

Conversation operations created background contexts, the Memory interface could not receive a caller context, and history replay rebuilt only text roles. That made cancellation ineffective and silently dropped tool-call metadata and tool-result turns.

## API impact

This is a breaking pre-1.0 API change. Callers and custom Memory implementations must pass or accept `context.Context` for conversation construction, sending, streaming, and memory access. Deprecated `SendWithContext` and `StreamWithContext` aliases remain available during migration.

## Validation

- `go test ./... -count=1`
- `go test -race ./core -count=1`
- `go test ./examples/... -count=1`
- `go build ./...`
- `go build ./examples/...`
- `go vet ./...`
- `go vet ./examples/...`
- `golangci-lint run --new-from-rev=origin/main` (0 issues)
- core package coverage: 91.0%

Closes #60
