### PR TITLE
fix(providers): transmit multimodal image parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Conversation.AddToolResults(ctx, results)` for recording tool execution results before the next conversational turn (#60)
+- Provider content-part capability declarations and `WithWarningHandler` warnings before unsupported multimodal parts are omitted (#61)
 
 ### Changed
 
@@ -18,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Conversation replay now preserves complete messages, including assistant tool calls, tool results, and multimodal parts; unary and streaming tool-call responses are retained in history (#60)
+- Anthropic image blocks, OpenAI Chat Completions image parts, and Azure AI Foundry vision messages are now transmitted instead of silently dropping `Message.Parts`; Gemini now accepts the pointer parts produced by `UserMultimodal` (#61)
 
 ## [0.17.0] - 2026-08-02
 

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ resp, err := core.DrainStream(ctx, stream)
 
 ### Warning Hooks
 
-Route non-fatal SDK warnings (for example, mismatched tool result IDs) into your application logger:
+Route non-fatal SDK warnings (for example, mismatched tool result IDs or unsupported multimodal parts) into your application logger:
 
 ```go
 client := core.NewClient(provider,
@@ -463,6 +463,21 @@ client := core.NewClient(provider,
     }),
 )
 ```
+
+### Multimodal Messages
+
+Send text and images together with `UserMultimodal` or the `UserWithImageURL` convenience method:
+
+```go
+resp, err := client.Chat(model).
+    UserMultimodal().
+        Text("What's in this image?").
+        ImageURLWithDetail("https://example.com/image.jpg", core.ImageDetailHigh).
+        Done().
+    GetResponse(ctx)
+```
+
+Image URLs and base64 data URLs are mapped for Anthropic, OpenAI Chat Completions and Responses, Azure AI Foundry, and Gemini. File IDs and document parts remain endpoint-specific. When requests execute through `core.Client`, configure `WithWarningHandler` to observe any part that the selected provider, model endpoint, or message role cannot transmit; the client invokes that handler before an unsupported part is omitted.
 
 ### Using Tools
 

--- a/core/client.go
+++ b/core/client.go
@@ -634,6 +634,7 @@ func (b *ChatBuilder) GetResponse(ctx context.Context) (*ChatResponse, error) {
 	if err := b.validate(); err != nil {
 		return nil, err
 	}
+	b.warnUnsupportedContentParts()
 
 	// Apply the effective execution timeout (see effectiveTimeout for precedence).
 	// timedOut records that any resulting DeadlineExceeded is Iris-owned and
@@ -737,6 +738,7 @@ func (b *ChatBuilder) Stream(ctx context.Context) (*ChatStream, error) {
 	if err := b.validate(); err != nil {
 		return nil, err
 	}
+	b.warnUnsupportedContentParts()
 
 	// Apply the effective execution timeout (see effectiveTimeout for precedence).
 	// cancel is intentionally NOT deferred here: on success it is handed to
@@ -1057,4 +1059,34 @@ func wrapStreamWithTelemetry(
 
 func (c *Client) warnf(format string, args ...any) {
 	c.warningHandler(fmt.Sprintf(format, args...))
+}
+
+func (b *ChatBuilder) warnUnsupportedContentParts() {
+	supporter, declaresSupport := b.client.provider.(ContentPartSupporter)
+	for messageIndex, message := range b.req.Messages {
+		for partIndex, part := range message.Parts {
+			if declaresSupport && supporter.SupportsContentPart(b.req.Model, message.Role, part) {
+				continue
+			}
+			b.client.warnf(
+				"provider %s model %s does not declare support for content part %s at message %d part %d; part will be omitted",
+				b.client.provider.ID(), b.req.Model, contentPartType(part), messageIndex, partIndex,
+			)
+		}
+	}
+}
+
+func contentPartType(part ContentPart) string {
+	switch part.(type) {
+	case InputText, *InputText:
+		return "input_text"
+	case InputImage, *InputImage:
+		return "input_image"
+	case InputFile, *InputFile:
+		return "input_file"
+	case nil:
+		return "<nil>"
+	default:
+		return fmt.Sprintf("%T", part)
+	}
 }

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -20,6 +20,19 @@ type mockProvider struct {
 	mu          sync.Mutex
 }
 
+type contentPartAwareMockProvider struct {
+	*mockProvider
+	support func(model ModelID, role Role, part ContentPart) bool
+}
+
+type customContentPart struct{}
+
+func (customContentPart) ContentType() string { return "custom" }
+
+func (p *contentPartAwareMockProvider) SupportsContentPart(model ModelID, role Role, part ContentPart) bool {
+	return p.support(model, role, part)
+}
+
 func (m *mockProvider) ID() string {
 	return m.id
 }
@@ -1237,6 +1250,132 @@ func TestToolResultsWarningHandler(t *testing.T) {
 	}
 	if !strings.Contains(warnings[1], "call_2") {
 		t.Errorf("warnings[1] = %q, want mention of call_2", warnings[1])
+	}
+}
+
+func TestUnsupportedContentPartsWarnForChatAndStream(t *testing.T) {
+	for _, execute := range []struct {
+		name string
+		run  func(*ChatBuilder) error
+	}{
+		{
+			name: "chat",
+			run: func(builder *ChatBuilder) error {
+				_, err := builder.GetResponse(context.Background())
+				return err
+			},
+		},
+		{
+			name: "stream",
+			run: func(builder *ChatBuilder) error {
+				stream, err := builder.Stream(context.Background())
+				if err != nil {
+					return err
+				}
+				_, err = DrainStream(context.Background(), stream)
+				return err
+			},
+		},
+	} {
+		t.Run(execute.name, func(t *testing.T) {
+			provider := &mockProvider{id: "text-only"}
+			var warnings []string
+			client := NewClient(provider, WithWarningHandler(func(message string) {
+				warnings = append(warnings, message)
+			}))
+
+			err := execute.run(client.Chat("mock-model").
+				UserMultimodal().
+				ImageURL("https://example.com/cat.jpg").
+				Done())
+			if err != nil {
+				t.Fatalf("execute() error = %v", err)
+			}
+			if len(warnings) != 1 {
+				t.Fatalf("len(warnings) = %d, want 1", len(warnings))
+			}
+			for _, want := range []string{"text-only", "mock-model", "input_image", "omitted"} {
+				if !strings.Contains(warnings[0], want) {
+					t.Errorf("warning = %q, want it to contain %q", warnings[0], want)
+				}
+			}
+		})
+	}
+}
+
+func TestSupportedContentPartsDoNotWarn(t *testing.T) {
+	provider := &contentPartAwareMockProvider{
+		mockProvider: &mockProvider{id: "vision"},
+		support: func(model ModelID, role Role, part ContentPart) bool {
+			return model == "mock-model" && role == RoleUser && part.ContentType() == "input_image"
+		},
+	}
+	var warnings []string
+	client := NewClient(provider, WithWarningHandler(func(message string) {
+		warnings = append(warnings, message)
+	}))
+
+	_, err := client.Chat("mock-model").
+		UserMultimodal().
+		ImageURL("https://example.com/cat.jpg").
+		Done().
+		GetResponse(context.Background())
+	if err != nil {
+		t.Fatalf("GetResponse() error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", warnings)
+	}
+}
+
+func TestContentPartSupporterWarnsOnlyForUnsupportedParts(t *testing.T) {
+	provider := &contentPartAwareMockProvider{
+		mockProvider: &mockProvider{id: "partial-vision"},
+		support: func(_ ModelID, role Role, part ContentPart) bool {
+			return role == RoleUser && part.ContentType() == "input_text"
+		},
+	}
+	var warnings []string
+	client := NewClient(provider, WithWarningHandler(func(message string) {
+		warnings = append(warnings, message)
+	}))
+
+	_, err := client.Chat("mock-model").
+		UserMultimodal().
+		Text("Describe this image").
+		ImageURL("https://example.com/cat.jpg").
+		Done().
+		GetResponse(context.Background())
+	if err != nil {
+		t.Fatalf("GetResponse() error = %v", err)
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "input_image") {
+		t.Fatalf("warnings = %v, want one input_image warning", warnings)
+	}
+}
+
+func TestContentPartType(t *testing.T) {
+	tests := []struct {
+		name string
+		part ContentPart
+		want string
+	}{
+		{name: "text value", part: InputText{}, want: "input_text"},
+		{name: "text pointer", part: &InputText{}, want: "input_text"},
+		{name: "image value", part: InputImage{}, want: "input_image"},
+		{name: "image pointer", part: &InputImage{}, want: "input_image"},
+		{name: "file value", part: InputFile{}, want: "input_file"},
+		{name: "file pointer", part: &InputFile{}, want: "input_file"},
+		{name: "nil", part: nil, want: "<nil>"},
+		{name: "custom", part: customContentPart{}, want: "core.customContentPart"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := contentPartType(tt.part); got != tt.want {
+				t.Errorf("contentPartType() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/core/content.go
+++ b/core/content.go
@@ -2,11 +2,18 @@
 package core
 
 // ContentPart represents a part of multimodal content in a message.
-// Types implementing this interface can be used in multimodal messages
-// with the OpenAI Responses API.
+// Types implementing this interface can be used in multimodal messages.
 type ContentPart interface {
 	// ContentType returns the type identifier for this content part.
 	ContentType() string
+}
+
+// ContentPartSupporter is an optional provider capability interface for
+// declaring which message parts a provider can transmit for a model. The
+// client warns through WarningHandler before dispatching any part for which
+// support is not declared.
+type ContentPartSupporter interface {
+	SupportsContentPart(model ModelID, role Role, part ContentPart) bool
 }
 
 // ImageDetail specifies the level of detail for image processing.

--- a/core/doc.go
+++ b/core/doc.go
@@ -160,8 +160,9 @@
 //
 // # Warnings
 //
-// Non-fatal SDK warnings (for example, mismatched tool result IDs) can be routed
-// through [WithWarningHandler]. The default warning handler is a no-op.
+// Non-fatal SDK warnings (for example, mismatched tool result IDs or message
+// parts unsupported by the selected provider) can be routed through
+// [WithWarningHandler]. The default warning handler is a no-op.
 //
 // # Multimodal Messages
 //
@@ -179,6 +180,11 @@
 //	resp, err := client.Chat(model).
 //	    UserWithImageURL("Describe this:", "https://example.com/image.jpg").
 //	    GetResponse(ctx)
+//
+// Image URLs and data URLs are supported by Anthropic, OpenAI, Azure AI
+// Foundry, and Gemini. File IDs and document inputs are endpoint-specific.
+// Providers declare support through [ContentPartSupporter]; undeclared parts
+// invoke the client's [WarningHandler] before they are omitted.
 //
 // # Thread Safety
 //

--- a/core/types.go
+++ b/core/types.go
@@ -126,7 +126,7 @@ const (
 type Message struct {
 	Role        Role          `json:"role"`
 	Content     string        `json:"content,omitempty"`
-	Parts       []ContentPart `json:"-"`                      // Multimodal content parts (Responses API only)
+	Parts       []ContentPart `json:"-"`                      // Provider-mapped multimodal content parts
 	ToolCalls   []ToolCall    `json:"tool_calls,omitempty"`   // For assistant messages requesting tools
 	ToolResults []ToolResult  `json:"tool_results,omitempty"` // For tool result messages (RoleTool)
 }

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -73,6 +73,8 @@ Perplexity additionally supports web-search grounding (`core.SearchOptions`, res
 
 **Structured Output**: `ResponseJSONSchema` works on both the Chat Completions API and the Responses API (GPT-5.x), mapped to each API's native `response_format`/`text.format` shape respectively. Requesting it against a Chat Completions-only model that lacks `core.FeatureStructuredOutput` (e.g. gpt-3.5-turbo) fails with `core.ErrStructuredOutputUnsupported`.
 
+**Multimodal Input**: Image URLs and base64 data URLs are mapped on both Chat Completions and Responses routes. Responses-routed models also accept image file IDs and document inputs.
+
 **Usage Example**:
 ```go
 provider := openai.New(os.Getenv("OPENAI_API_KEY"))
@@ -112,6 +114,7 @@ resp, err := client.Chat(openai.ModelGPT4o).
 - Strong instruction following
 - Built-in safety guardrails
 - Thinking/reasoning modes
+- Vision input via hosted image URLs or base64 data URLs
 
 **Usage Example**:
 ```go
@@ -432,6 +435,7 @@ results, err := provider.Rerank(ctx, &core.RerankRequest{
 - Unlike other Iris providers, `azurefoundry.New` takes `(endpoint, apiKey, ...)` — the resource endpoint is mandatory.
 - Entra ID auth (managed identity, workload identity, etc.) is available via `NewWithCredential(endpoint, credential)`, where `credential` implements `azurefoundry.TokenCredential`.
 - The provider registry entry requires the endpoint to come from `AZURE_AI_ENDPOINT`; prefer `New`/`NewFromEnv` for full configuration.
+- Vision-capable deployments accept image URLs and base64 data URLs through `UserMultimodal`; support still depends on the deployed model.
 
 **Usage Example**:
 ```go
@@ -458,8 +462,10 @@ resp, err := client.Chat("gpt-5.6"). // any deployed model
 | Cost-sensitive applications | HuggingFace (routing), Ollama (local) |
 | Embeddings and RAG | VoyageAI |
 | Code generation | OpenAI (Codex models), Anthropic |
-| Multimodal (vision) | OpenAI (GPT-4o), Gemini, Z.ai (GLM-V) |
+| Multimodal (vision) | OpenAI (GPT-4o), Anthropic (Claude), Gemini, Azure AI Foundry vision deployments |
 | Image generation | OpenAI (DALL-E, GPT-Image), Gemini (Nano Banana) |
+
+Iris currently maps `Message.Parts` for OpenAI, Anthropic, Gemini, and Azure AI Foundry. Other providers invoke `core.WithWarningHandler` before omitting undeclared content parts, even when an upstream model advertises vision support.
 
 ## Rate Limits and Pricing
 

--- a/providers/anthropic/mapping.go
+++ b/providers/anthropic/mapping.go
@@ -100,14 +100,13 @@ func mapMessages(msgs []core.Message) (system string, messages []anthropicMessag
 			}
 
 		case core.RoleUser:
+			content := mapUserContent(msg)
+			if len(content) == 0 {
+				continue
+			}
 			messages = append(messages, anthropicMessage{
-				Role: "user",
-				Content: []anthropicContentBlock{
-					{
-						Type: "text",
-						Text: msg.Content,
-					},
-				},
+				Role:    "user",
+				Content: content,
 			})
 		}
 	}
@@ -118,6 +117,80 @@ func mapMessages(msgs []core.Message) (system string, messages []anthropicMessag
 	}
 
 	return system, messages
+}
+
+func mapUserContent(msg core.Message) []anthropicContentBlock {
+	if len(msg.Parts) == 0 {
+		return []anthropicContentBlock{{Type: "text", Text: msg.Content}}
+	}
+
+	content := make([]anthropicContentBlock, 0, len(msg.Parts))
+	for _, part := range msg.Parts {
+		if block, ok := mapContentPart(part); ok {
+			content = append(content, block)
+		}
+	}
+	return content
+}
+
+func mapContentPart(part core.ContentPart) (anthropicContentBlock, bool) {
+	switch value := part.(type) {
+	case core.InputText:
+		return anthropicContentBlock{Type: "text", Text: value.Text}, true
+	case *core.InputText:
+		if value != nil {
+			return anthropicContentBlock{Type: "text", Text: value.Text}, true
+		}
+	case core.InputImage:
+		return mapInputImage(value)
+	case *core.InputImage:
+		if value != nil {
+			return mapInputImage(*value)
+		}
+	}
+	return anthropicContentBlock{}, false
+}
+
+func mapInputImage(image core.InputImage) (anthropicContentBlock, bool) {
+	if image.ImageURL == "" || image.FileID != "" {
+		return anthropicContentBlock{}, false
+	}
+	if strings.HasPrefix(image.ImageURL, "data:") {
+		mediaType, data, ok := parseImageDataURL(image.ImageURL)
+		if !ok {
+			return anthropicContentBlock{}, false
+		}
+		return anthropicContentBlock{
+			Type: "image",
+			Source: &anthropicImageSource{
+				Type:      "base64",
+				MediaType: mediaType,
+				Data:      data,
+			},
+		}, true
+	}
+	return anthropicContentBlock{
+		Type: "image",
+		Source: &anthropicImageSource{
+			Type: "url",
+			URL:  image.ImageURL,
+		},
+	}, true
+}
+
+func parseImageDataURL(value string) (mediaType, data string, ok bool) {
+	if !strings.HasPrefix(value, "data:") {
+		return "", "", false
+	}
+	metadata, data, found := strings.Cut(strings.TrimPrefix(value, "data:"), ",")
+	if !found || data == "" {
+		return "", "", false
+	}
+	mediaType, encoding, found := strings.Cut(metadata, ";")
+	if !found || encoding != "base64" || !strings.HasPrefix(mediaType, "image/") {
+		return "", "", false
+	}
+	return mediaType, data, true
 }
 
 // marshalToolResultContent converts tool result content to a string.

--- a/providers/anthropic/mapping_test.go
+++ b/providers/anthropic/mapping_test.go
@@ -93,6 +93,69 @@ func TestMapMessages(t *testing.T) {
 	}
 }
 
+func TestMapMessagesMultimodalImages(t *testing.T) {
+	tests := []struct {
+		name     string
+		imageURL string
+		wantJSON string
+	}{
+		{
+			name:     "remote URL",
+			imageURL: "https://example.com/cat.jpg",
+			wantJSON: `[{"role":"user","content":[{"type":"text","text":"Describe this image"},{"type":"image","source":{"type":"url","url":"https://example.com/cat.jpg"}}]}]`,
+		},
+		{
+			name:     "base64 data URL",
+			imageURL: "data:image/png;base64,aGVsbG8=",
+			wantJSON: `[{"role":"user","content":[{"type":"text","text":"Describe this image"},{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aGVsbG8="}}]}]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, messages := mapMessages([]core.Message{{
+				Role: core.RoleUser,
+				Parts: []core.ContentPart{
+					&core.InputText{Text: "Describe this image"},
+					&core.InputImage{ImageURL: tt.imageURL},
+				},
+			}})
+
+			got, err := json.Marshal(messages)
+			if err != nil {
+				t.Fatalf("json.Marshal() error = %v", err)
+			}
+			if string(got) != tt.wantJSON {
+				t.Errorf("wire JSON = %s, want %s", got, tt.wantJSON)
+			}
+		})
+	}
+}
+
+func TestMapContentPartRejectsUnsupportedImageSources(t *testing.T) {
+	for _, image := range []core.InputImage{
+		{FileID: "file-123"},
+		{ImageURL: "data:image/png;base64"},
+		{ImageURL: "https://example.com/cat.jpg", FileID: "file-123"},
+	} {
+		if _, ok := mapContentPart(&image); ok {
+			t.Errorf("mapContentPart(%+v) supported an invalid Anthropic image source", image)
+		}
+	}
+}
+
+func TestParseImageDataURLRejectsInvalidMetadata(t *testing.T) {
+	for _, value := range []string{
+		"data:text/plain;base64,aGVsbG8=",
+		"data:image/png,aGVsbG8=",
+		"data:image/png;base64,",
+	} {
+		if _, _, ok := parseImageDataURL(value); ok {
+			t.Errorf("parseImageDataURL(%q) succeeded, want invalid", value)
+		}
+	}
+}
+
 func TestBuildRequest(t *testing.T) {
 	temp := float32(0.7)
 	maxTokens := 500

--- a/providers/anthropic/provider.go
+++ b/providers/anthropic/provider.go
@@ -82,6 +82,15 @@ func (p *Anthropic) Supports(feature core.Feature) bool {
 	}
 }
 
+// SupportsContentPart reports whether Anthropic can transmit a message part.
+func (p *Anthropic) SupportsContentPart(_ core.ModelID, role core.Role, part core.ContentPart) bool {
+	if role != core.RoleUser {
+		return false
+	}
+	_, ok := mapContentPart(part)
+	return ok
+}
+
 // buildHeaders constructs the HTTP headers for an API request.
 func (p *Anthropic) buildHeaders() http.Header {
 	headers := make(http.Header)
@@ -119,3 +128,5 @@ func (p *Anthropic) StreamChat(ctx context.Context, req *core.ChatRequest) (*cor
 
 // Compile-time check that Anthropic implements Provider.
 var _ core.Provider = (*Anthropic)(nil)
+
+var _ core.ContentPartSupporter = (*Anthropic)(nil)

--- a/providers/anthropic/provider_test.go
+++ b/providers/anthropic/provider_test.go
@@ -232,6 +232,29 @@ func TestModelCapabilities(t *testing.T) {
 
 func TestProviderImplementsInterface(t *testing.T) {
 	var _ core.Provider = (*Anthropic)(nil)
+	var _ core.ContentPartSupporter = (*Anthropic)(nil)
+}
+
+func TestSupportsContentPart(t *testing.T) {
+	provider := New("test-key")
+	tests := []struct {
+		name string
+		role core.Role
+		part core.ContentPart
+		want bool
+	}{
+		{name: "text", role: core.RoleUser, part: core.InputText{Text: "describe"}, want: true},
+		{name: "image URL", role: core.RoleUser, part: core.InputImage{ImageURL: "https://example.com/cat.jpg"}, want: true},
+		{name: "file ID", role: core.RoleUser, part: &core.InputImage{FileID: "file-123"}, want: false},
+		{name: "assistant image", role: core.RoleAssistant, part: &core.InputImage{ImageURL: "https://example.com/cat.jpg"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := provider.SupportsContentPart(ModelClaudeSonnet46, tt.role, tt.part); got != tt.want {
+				t.Errorf("SupportsContentPart() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }
 
 func TestNewWithDefaultFilesAPIBeta(t *testing.T) {

--- a/providers/anthropic/types_anthropic.go
+++ b/providers/anthropic/types_anthropic.go
@@ -22,8 +22,9 @@ type anthropicMessage struct {
 
 // anthropicContentBlock represents a content block in a message.
 type anthropicContentBlock struct {
-	Type string `json:"type"`
-	Text string `json:"text,omitempty"`
+	Type   string                `json:"type"`
+	Text   string                `json:"text,omitempty"`
+	Source *anthropicImageSource `json:"source,omitempty"`
 	// For tool_use blocks (assistant requesting tool)
 	ID    string          `json:"id,omitempty"`
 	Name  string          `json:"name,omitempty"`
@@ -32,6 +33,13 @@ type anthropicContentBlock struct {
 	ToolUseID string `json:"tool_use_id,omitempty"`
 	Content   string `json:"content,omitempty"`
 	IsError   bool   `json:"is_error,omitempty"`
+}
+
+type anthropicImageSource struct {
+	Type      string `json:"type"`
+	MediaType string `json:"media_type,omitempty"`
+	Data      string `json:"data,omitempty"`
+	URL       string `json:"url,omitempty"`
 }
 
 // anthropicTool represents a tool definition in the Anthropic format.

--- a/providers/azurefoundry/mapping.go
+++ b/providers/azurefoundry/mapping.go
@@ -38,6 +38,17 @@ type azureMessage struct {
 	ToolCallID string          `json:"tool_call_id,omitempty"` // For tool result messages
 }
 
+type azureContentPart struct {
+	Type     string         `json:"type"`
+	Text     string         `json:"text,omitempty"`
+	ImageURL *azureImageURL `json:"image_url,omitempty"`
+}
+
+type azureImageURL struct {
+	URL    string `json:"url"`
+	Detail string `json:"detail,omitempty"`
+}
+
 // azureTool represents a tool definition in the Azure format.
 type azureTool struct {
 	Type     string        `json:"type"` // "function"
@@ -217,14 +228,59 @@ func mapMessages(msgs []core.Message) []azureMessage {
 
 		default:
 			// System, User messages
+			content := any(msg.Content)
+			if msg.Role == core.RoleUser && len(msg.Parts) > 0 {
+				content = mapContentParts(msg.Parts)
+			}
 			result = append(result, azureMessage{
 				Role:    string(msg.Role),
-				Content: msg.Content,
+				Content: content,
 			})
 		}
 	}
 
 	return result
+}
+
+func mapContentParts(parts []core.ContentPart) []azureContentPart {
+	result := make([]azureContentPart, 0, len(parts))
+	for _, part := range parts {
+		if mapped, ok := mapContentPart(part); ok {
+			result = append(result, mapped)
+		}
+	}
+	return result
+}
+
+func mapContentPart(part core.ContentPart) (azureContentPart, bool) {
+	switch value := part.(type) {
+	case core.InputText:
+		return azureContentPart{Type: "text", Text: value.Text}, true
+	case *core.InputText:
+		if value != nil {
+			return azureContentPart{Type: "text", Text: value.Text}, true
+		}
+	case core.InputImage:
+		return mapInputImage(value)
+	case *core.InputImage:
+		if value != nil {
+			return mapInputImage(*value)
+		}
+	}
+	return azureContentPart{}, false
+}
+
+func mapInputImage(image core.InputImage) (azureContentPart, bool) {
+	if image.ImageURL == "" || image.FileID != "" {
+		return azureContentPart{}, false
+	}
+	return azureContentPart{
+		Type: "image_url",
+		ImageURL: &azureImageURL{
+			URL:    image.ImageURL,
+			Detail: string(image.Detail),
+		},
+	}, true
 }
 
 // mapToolCallsToAzure converts Iris ToolCalls to Azure format.

--- a/providers/azurefoundry/mapping_test.go
+++ b/providers/azurefoundry/mapping_test.go
@@ -44,6 +44,40 @@ func TestMapMessagesEmpty(t *testing.T) {
 	}
 }
 
+func TestMapMessagesMultimodalImage(t *testing.T) {
+	messages := mapMessages([]core.Message{{
+		Role: core.RoleUser,
+		Parts: []core.ContentPart{
+			&core.InputText{Text: "Describe this image"},
+			&core.InputImage{
+				ImageURL: "data:image/jpeg;base64,aGVsbG8=",
+				Detail:   core.ImageDetailLow,
+			},
+		},
+	}})
+
+	got, err := json.Marshal(messages)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	want := `[{"role":"user","content":[{"type":"text","text":"Describe this image"},{"type":"image_url","image_url":{"url":"data:image/jpeg;base64,aGVsbG8=","detail":"low"}}]}]`
+	if string(got) != want {
+		t.Errorf("wire JSON = %s, want %s", got, want)
+	}
+}
+
+func TestMapContentPartRejectsImageFileID(t *testing.T) {
+	if _, ok := mapContentPart(&core.InputImage{FileID: "file-123"}); ok {
+		t.Fatal("Azure Foundry should not map an image file ID")
+	}
+	if _, ok := mapContentPart(&core.InputImage{
+		ImageURL: "https://example.com/cat.jpg",
+		FileID:   "file-123",
+	}); ok {
+		t.Fatal("Azure Foundry should reject an image with multiple sources")
+	}
+}
+
 func TestMapMessagesWithToolCalls(t *testing.T) {
 	msgs := []core.Message{
 		{

--- a/providers/azurefoundry/provider.go
+++ b/providers/azurefoundry/provider.go
@@ -166,6 +166,15 @@ func (p *AzureFoundry) Supports(feature core.Feature) bool {
 	}
 }
 
+// SupportsContentPart reports whether Azure Foundry can transmit a message part.
+func (p *AzureFoundry) SupportsContentPart(_ core.ModelID, role core.Role, part core.ContentPart) bool {
+	if role != core.RoleUser {
+		return false
+	}
+	_, ok := mapContentPart(part)
+	return ok
+}
+
 // buildHeaders constructs the HTTP headers for an API request.
 func (p *AzureFoundry) buildHeaders(ctx context.Context) (http.Header, error) {
 	headers := make(http.Header)
@@ -230,3 +239,5 @@ func normalizeEndpoint(endpoint string) string {
 
 // Compile-time check that AzureFoundry implements Provider.
 var _ core.Provider = (*AzureFoundry)(nil)
+
+var _ core.ContentPartSupporter = (*AzureFoundry)(nil)

--- a/providers/azurefoundry/provider_test.go
+++ b/providers/azurefoundry/provider_test.go
@@ -338,6 +338,28 @@ func TestBuildHeadersWithCustomHeaders(t *testing.T) {
 	}
 }
 
+func TestSupportsContentPart(t *testing.T) {
+	provider := New("https://example.services.ai.azure.com", "test-key")
+	tests := []struct {
+		name string
+		role core.Role
+		part core.ContentPart
+		want bool
+	}{
+		{name: "text", role: core.RoleUser, part: core.InputText{Text: "describe"}, want: true},
+		{name: "image URL", role: core.RoleUser, part: core.InputImage{ImageURL: "https://example.com/cat.jpg"}, want: true},
+		{name: "file ID", role: core.RoleUser, part: &core.InputImage{FileID: "file-123"}, want: false},
+		{name: "assistant image", role: core.RoleAssistant, part: &core.InputImage{ImageURL: "https://example.com/cat.jpg"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := provider.SupportsContentPart("vision-model", tt.role, tt.part); got != tt.want {
+				t.Errorf("SupportsContentPart() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // mockCredential implements TokenCredential for testing.
 type mockCredential struct {
 	token string

--- a/providers/gemini/mapping.go
+++ b/providers/gemini/mapping.go
@@ -105,16 +105,35 @@ func mapMessageParts(msg core.Message) []geminiPart {
 
 	parts := make([]geminiPart, 0, len(msg.Parts))
 	for _, part := range msg.Parts {
-		switch p := part.(type) {
-		case core.InputText:
-			parts = append(parts, geminiPart{Text: p.Text})
-		case core.InputImage:
-			parts = append(parts, mapInputImage(p))
-		case core.InputFile:
-			parts = append(parts, mapInputFile(p))
+		if mapped, ok := mapContentPart(part); ok {
+			parts = append(parts, mapped)
 		}
 	}
 	return parts
+}
+
+func mapContentPart(part core.ContentPart) (geminiPart, bool) {
+	switch value := part.(type) {
+	case core.InputText:
+		return geminiPart{Text: value.Text}, true
+	case *core.InputText:
+		if value != nil {
+			return geminiPart{Text: value.Text}, true
+		}
+	case core.InputImage:
+		return mapInputImage(value), true
+	case *core.InputImage:
+		if value != nil {
+			return mapInputImage(*value), true
+		}
+	case core.InputFile:
+		return mapInputFile(value), true
+	case *core.InputFile:
+		if value != nil {
+			return mapInputFile(*value), true
+		}
+	}
+	return geminiPart{}, false
 }
 
 // mapInputImage converts an InputImage to a Gemini part.

--- a/providers/gemini/mapping_test.go
+++ b/providers/gemini/mapping_test.go
@@ -253,6 +253,27 @@ func TestMapMessages_WithMultimodalParts(t *testing.T) {
 	}
 }
 
+func TestMapMessages_WithPointerMultimodalParts(t *testing.T) {
+	msgs := []core.Message{{
+		Role: core.RoleUser,
+		Parts: []core.ContentPart{
+			&core.InputText{Text: "What's in this image?"},
+			&core.InputImage{ImageURL: "data:image/png;base64,aGVsbG8="},
+		},
+	}}
+
+	_, contents := mapMessages(msgs)
+	if len(contents) != 1 || len(contents[0].Parts) != 2 {
+		t.Fatalf("mapped contents = %#v, want one message with two parts", contents)
+	}
+	if contents[0].Parts[0].Text != "What's in this image?" {
+		t.Errorf("text = %q, want prompt text", contents[0].Parts[0].Text)
+	}
+	if contents[0].Parts[1].InlineData == nil {
+		t.Fatal("image InlineData is nil")
+	}
+}
+
 func TestMapMessages_WithFileReference(t *testing.T) {
 	msgs := []core.Message{
 		{

--- a/providers/gemini/provider.go
+++ b/providers/gemini/provider.go
@@ -86,6 +86,15 @@ func (p *Gemini) Supports(feature core.Feature) bool {
 	}
 }
 
+// SupportsContentPart reports whether Gemini can transmit a message part.
+func (p *Gemini) SupportsContentPart(_ core.ModelID, role core.Role, part core.ContentPart) bool {
+	if role != core.RoleUser && role != core.RoleAssistant {
+		return false
+	}
+	_, ok := mapContentPart(part)
+	return ok
+}
+
 // buildHeaders constructs the HTTP headers for an API request.
 func (p *Gemini) buildHeaders() http.Header {
 	headers := make(http.Header)
@@ -122,6 +131,8 @@ func (p *Gemini) StreamChat(ctx context.Context, req *core.ChatRequest) (*core.C
 
 // Compile-time check that Gemini implements Provider.
 var _ core.Provider = (*Gemini)(nil)
+
+var _ core.ContentPartSupporter = (*Gemini)(nil)
 
 // Compile-time check that Gemini implements ImageGenerator.
 var _ core.ImageGenerator = (*Gemini)(nil)

--- a/providers/gemini/provider_test.go
+++ b/providers/gemini/provider_test.go
@@ -304,3 +304,25 @@ func TestIsGemini3Model(t *testing.T) {
 		})
 	}
 }
+
+func TestSupportsContentPart(t *testing.T) {
+	provider := New("test-key")
+	tests := []struct {
+		name string
+		role core.Role
+		part core.ContentPart
+		want bool
+	}{
+		{name: "user text", role: core.RoleUser, part: core.InputText{Text: "describe"}, want: true},
+		{name: "assistant image", role: core.RoleAssistant, part: core.InputImage{ImageURL: "https://example.com/cat.jpg"}, want: true},
+		{name: "user file", role: core.RoleUser, part: &core.InputFile{FileID: "files/123"}, want: true},
+		{name: "system image", role: core.RoleSystem, part: &core.InputImage{ImageURL: "https://example.com/cat.jpg"}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := provider.SupportsContentPart(ModelGemini36Flash, tt.role, tt.part); got != tt.want {
+				t.Errorf("SupportsContentPart() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/openai/mapping.go
+++ b/providers/openai/mapping.go
@@ -36,14 +36,59 @@ func mapMessages(msgs []core.Message) []openAIMessage {
 
 		default:
 			// System, User messages
+			content := any(msg.Content)
+			if msg.Role == core.RoleUser && len(msg.Parts) > 0 {
+				content = mapChatContentParts(msg.Parts)
+			}
 			result = append(result, openAIMessage{
 				Role:    string(msg.Role),
-				Content: msg.Content,
+				Content: content,
 			})
 		}
 	}
 
 	return result
+}
+
+func mapChatContentParts(parts []core.ContentPart) []openAIContentPart {
+	result := make([]openAIContentPart, 0, len(parts))
+	for _, part := range parts {
+		if mapped, ok := mapChatContentPart(part); ok {
+			result = append(result, mapped)
+		}
+	}
+	return result
+}
+
+func mapChatContentPart(part core.ContentPart) (openAIContentPart, bool) {
+	switch value := part.(type) {
+	case core.InputText:
+		return openAIContentPart{Type: "text", Text: value.Text}, true
+	case *core.InputText:
+		if value != nil {
+			return openAIContentPart{Type: "text", Text: value.Text}, true
+		}
+	case core.InputImage:
+		return mapChatInputImage(value)
+	case *core.InputImage:
+		if value != nil {
+			return mapChatInputImage(*value)
+		}
+	}
+	return openAIContentPart{}, false
+}
+
+func mapChatInputImage(image core.InputImage) (openAIContentPart, bool) {
+	if image.ImageURL == "" || image.FileID != "" {
+		return openAIContentPart{}, false
+	}
+	return openAIContentPart{
+		Type: "image_url",
+		ImageURL: &openAIImageURL{
+			URL:    image.ImageURL,
+			Detail: string(image.Detail),
+		},
+	}, true
 }
 
 // mapToolCallsToOpenAI converts Iris ToolCalls to OpenAI format.

--- a/providers/openai/mapping_responses.go
+++ b/providers/openai/mapping_responses.go
@@ -131,7 +131,9 @@ func buildResponsesInput(msgs []core.Message, instructions string) responsesInpu
 		if len(msg.Parts) > 0 {
 			parts := make([]responsesContentPart, 0, len(msg.Parts))
 			for _, part := range msg.Parts {
-				parts = append(parts, mapContentPart(part))
+				if mapped := mapResponsesContentPart(part); mapped.Type != "" {
+					parts = append(parts, mapped)
+				}
 			}
 			messages = append(messages, responsesInputMessage{
 				Role:    role,
@@ -148,34 +150,66 @@ func buildResponsesInput(msgs []core.Message, instructions string) responsesInpu
 	return responsesInput{Messages: messages}
 }
 
-// mapContentPart converts a core.ContentPart to a responsesContentPart.
-func mapContentPart(part core.ContentPart) responsesContentPart {
+// mapResponsesContentPart converts a core.ContentPart to a Responses API part.
+func mapResponsesContentPart(part core.ContentPart) responsesContentPart {
 	switch p := part.(type) {
+	case core.InputText:
+		return responsesContentPart{Type: "input_text", Text: p.Text}
 	case *core.InputText:
+		if p == nil {
+			return responsesContentPart{}
+		}
 		return responsesContentPart{
 			Type: "input_text",
 			Text: p.Text,
 		}
+	case core.InputImage:
+		return mapResponsesInputImage(p)
 	case *core.InputImage:
-		cp := responsesContentPart{
-			Type:     "input_image",
-			ImageURL: p.ImageURL,
-			FileID:   p.FileID,
+		if p == nil {
+			return responsesContentPart{}
 		}
-		if p.Detail != "" {
-			cp.Detail = string(p.Detail)
-		}
-		return cp
+		return mapResponsesInputImage(*p)
+	case core.InputFile:
+		return mapResponsesInputFile(p)
 	case *core.InputFile:
-		return responsesContentPart{
-			Type:     "input_file",
-			FileID:   p.FileID,
-			FileURL:  p.FileURL,
-			FileData: p.FileData,
-			Filename: p.Filename,
+		if p == nil {
+			return responsesContentPart{}
 		}
+		return mapResponsesInputFile(*p)
 	default:
 		return responsesContentPart{}
+	}
+}
+
+func mapResponsesInputImage(image core.InputImage) responsesContentPart {
+	if (image.ImageURL == "") == (image.FileID == "") {
+		return responsesContentPart{}
+	}
+	return responsesContentPart{
+		Type:     "input_image",
+		ImageURL: image.ImageURL,
+		FileID:   image.FileID,
+		Detail:   string(image.Detail),
+	}
+}
+
+func mapResponsesInputFile(file core.InputFile) responsesContentPart {
+	sourceCount := 0
+	for _, source := range []string{file.FileID, file.FileURL, file.FileData} {
+		if source != "" {
+			sourceCount++
+		}
+	}
+	if sourceCount != 1 {
+		return responsesContentPart{}
+	}
+	return responsesContentPart{
+		Type:     "input_file",
+		FileID:   file.FileID,
+		FileURL:  file.FileURL,
+		FileData: file.FileData,
+		Filename: file.Filename,
 	}
 }
 

--- a/providers/openai/mapping_responses_test.go
+++ b/providers/openai/mapping_responses_test.go
@@ -570,3 +570,45 @@ func TestBuildResponsesInputMultimodal(t *testing.T) {
 		})
 	}
 }
+
+func TestMapResponsesContentPartRejectsAmbiguousSources(t *testing.T) {
+	image := &core.InputImage{
+		ImageURL: "https://example.com/cat.jpg",
+		FileID:   "file-123",
+	}
+	if got := mapResponsesContentPart(image); got.Type != "" {
+		t.Errorf("ambiguous image mapped as %#v", got)
+	}
+
+	file := &core.InputFile{FileID: "file-123", FileURL: "https://example.com/file.pdf"}
+	if got := mapResponsesContentPart(file); got.Type != "" {
+		t.Errorf("ambiguous file mapped as %#v", got)
+	}
+}
+
+func TestMapResponsesContentPartAcceptsValueParts(t *testing.T) {
+	parts := []core.ContentPart{
+		core.InputText{Text: "describe"},
+		core.InputImage{FileID: "file-image"},
+		core.InputFile{FileData: "cGRm", Filename: "document.pdf"},
+	}
+	wantTypes := []string{"input_text", "input_image", "input_file"}
+	for index, part := range parts {
+		if got := mapResponsesContentPart(part); got.Type != wantTypes[index] {
+			t.Errorf("part %d type = %q, want %q", index, got.Type, wantTypes[index])
+		}
+	}
+
+	var nilText *core.InputText
+	var nilImage *core.InputImage
+	var nilFile *core.InputFile
+	for _, part := range []core.ContentPart{nilText, nilImage, nilFile, customPart{}} {
+		if got := mapResponsesContentPart(part); got.Type != "" {
+			t.Errorf("unsupported part %T mapped as %#v", part, got)
+		}
+	}
+}
+
+type customPart struct{}
+
+func (customPart) ContentType() string { return "custom" }

--- a/providers/openai/mapping_test.go
+++ b/providers/openai/mapping_test.go
@@ -93,6 +93,54 @@ func TestMapMessagesEmpty(t *testing.T) {
 	}
 }
 
+func TestMapMessagesMultimodalImage(t *testing.T) {
+	messages := mapMessages([]core.Message{{
+		Role: core.RoleUser,
+		Parts: []core.ContentPart{
+			&core.InputText{Text: "Describe this image"},
+			&core.InputImage{
+				ImageURL: "https://example.com/cat.jpg",
+				Detail:   core.ImageDetailHigh,
+			},
+		},
+	}})
+
+	got, err := json.Marshal(messages)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	want := `[{"role":"user","content":[{"type":"text","text":"Describe this image"},{"type":"image_url","image_url":{"url":"https://example.com/cat.jpg","detail":"high"}}]}]`
+	if string(got) != want {
+		t.Errorf("wire JSON = %s, want %s", got, want)
+	}
+}
+
+func TestChatCompletionsRejectsImageFileID(t *testing.T) {
+	if _, ok := mapChatContentPart(&core.InputImage{FileID: "file-123"}); ok {
+		t.Fatal("Chat Completions should not map an image file ID")
+	}
+	if _, ok := mapChatContentPart(&core.InputImage{
+		ImageURL: "https://example.com/cat.jpg",
+		FileID:   "file-123",
+	}); ok {
+		t.Fatal("Chat Completions should reject an image with multiple sources")
+	}
+}
+
+func TestMapChatContentPartValueAndNilParts(t *testing.T) {
+	if got, ok := mapChatContentPart(core.InputText{Text: "describe"}); !ok || got.Text != "describe" {
+		t.Errorf("text value mapped as %#v, %v", got, ok)
+	}
+
+	var nilText *core.InputText
+	var nilImage *core.InputImage
+	for _, part := range []core.ContentPart{nilText, nilImage, customPart{}} {
+		if got, ok := mapChatContentPart(part); ok {
+			t.Errorf("unsupported part %T mapped as %#v", part, got)
+		}
+	}
+}
+
 // mockFullTool implements both core.Tool and tools.Tool (with Schema)
 type mockFullTool struct {
 	name        string

--- a/providers/openai/provider.go
+++ b/providers/openai/provider.go
@@ -84,6 +84,19 @@ func (p *OpenAI) Supports(feature core.Feature) bool {
 	}
 }
 
+// SupportsContentPart reports whether the selected OpenAI endpoint can
+// transmit a message part.
+func (p *OpenAI) SupportsContentPart(model core.ModelID, role core.Role, part core.ContentPart) bool {
+	if p.shouldUseResponsesAPI(model) {
+		return mapResponsesContentPart(part).Type != ""
+	}
+	if role != core.RoleUser {
+		return false
+	}
+	_, ok := mapChatContentPart(part)
+	return ok
+}
+
 // requireAPIKey returns a descriptive *core.ProviderError wrapping
 // core.ErrUnauthorized when the configured API key is empty (or
 // whitespace-only). Callers must invoke this before building or sending any
@@ -159,6 +172,8 @@ func (p *OpenAI) shouldUseResponsesAPI(model core.ModelID) bool {
 
 // Compile-time check that OpenAI implements Provider.
 var _ core.Provider = (*OpenAI)(nil)
+
+var _ core.ContentPartSupporter = (*OpenAI)(nil)
 
 // Compile-time check that OpenAI implements ImageGenerator.
 var _ core.ImageGenerator = (*OpenAI)(nil)

--- a/providers/openai/provider_test.go
+++ b/providers/openai/provider_test.go
@@ -297,3 +297,27 @@ func TestNewFromEnvWithOptions(t *testing.T) {
 		t.Errorf("Organization header not set correctly")
 	}
 }
+
+func TestSupportsContentPart(t *testing.T) {
+	provider := New("test-key")
+	tests := []struct {
+		name  string
+		model core.ModelID
+		role  core.Role
+		part  core.ContentPart
+		want  bool
+	}{
+		{name: "completions image URL", model: ModelGPT4o, role: core.RoleUser, part: core.InputImage{ImageURL: "https://example.com/cat.jpg"}, want: true},
+		{name: "completions file ID", model: ModelGPT4o, role: core.RoleUser, part: &core.InputImage{FileID: "file-123"}, want: false},
+		{name: "completions assistant part", model: ModelGPT4o, role: core.RoleAssistant, part: &core.InputText{Text: "history"}, want: false},
+		{name: "responses image file ID", model: ModelGPT56, role: core.RoleUser, part: &core.InputImage{FileID: "file-123"}, want: true},
+		{name: "responses document data", model: ModelGPT56, role: core.RoleUser, part: &core.InputFile{FileData: "cGRm", Filename: "document.pdf"}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := provider.SupportsContentPart(tt.model, tt.role, tt.part); got != tt.want {
+				t.Errorf("SupportsContentPart() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/providers/openai/types_openai.go
+++ b/providers/openai/types_openai.go
@@ -31,9 +31,20 @@ type openAIJSONSchema struct {
 // openAIMessage represents a message in the OpenAI format.
 type openAIMessage struct {
 	Role       string           `json:"role"`
-	Content    string           `json:"content,omitempty"`
+	Content    any              `json:"content,omitempty"`
 	ToolCalls  []openAIToolCall `json:"tool_calls,omitempty"`   // For assistant messages requesting tools
 	ToolCallID string           `json:"tool_call_id,omitempty"` // For tool result messages
+}
+
+type openAIContentPart struct {
+	Type     string          `json:"type"`
+	Text     string          `json:"text,omitempty"`
+	ImageURL *openAIImageURL `json:"image_url,omitempty"`
+}
+
+type openAIImageURL struct {
+	URL    string `json:"url"`
+	Detail string `json:"detail,omitempty"`
 }
 
 // openAITool represents a tool definition in the OpenAI format.


### PR DESCRIPTION
## Summary

- transmit Anthropic image URL and base64 content blocks
- map multimodal message parts on OpenAI Chat Completions and Azure AI Foundry
- accept the pointer content parts produced by `UserMultimodal` in Gemini
- warn through `WithWarningHandler` before unsupported provider/model/role parts are omitted
- document provider-specific multimodal support and add wire-format conformance coverage

## Root cause

Several provider mappers only read `Message.Content` and ignored `Message.Parts`. Gemini handled value parts while the public builder produces pointers. Because providers did not declare part-level transport support, core could not warn before a mapper discarded an unsupported part.

## Impact

Vision requests now reach Anthropic, OpenAI Chat Completions, Azure AI Foundry, and Gemini in their native wire formats. Unsupported or ambiguous sources invoke the configured warning handler instead of disappearing silently. OpenAI Responses retains its existing file/image support and now accepts both value and pointer content parts.

## Validation

- `go test ./... -count=1`
- `go test -race ./core ./providers/anthropic ./providers/openai ./providers/azurefoundry ./providers/gemini -count=1`
- `go vet ./...`
- `golangci-lint run --new-from-rev=origin/main` (0 issues)
- focused coverage profile: 81.4%; new functions: 87.5–100%

Closes #61
