### PR TITLE
feat(cli): chat feature parity (REPL, timeout, schema, iris models)

### DIFF
--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -4,6 +4,7 @@ package commands
 import (
 	"io"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -28,24 +29,28 @@ type AppOption func(*App)
 type App struct {
 	root *cobra.Command
 
-	loadConfig      ConfigLoader
-	createProvider  ProviderFactory
-	newKeystore     KeystoreFactory
-	stdin           io.Reader
-	stdout          io.Writer
-	stderr          io.Writer
-	cfgFile         string
-	provider        string
-	model           string
-	jsonOutput      bool
-	verbose         bool
-	cfg             *config.Config
-	chatPrompt      string
-	chatSystem      string
-	chatTemperature float32
-	chatMaxTokens   int
-	chatStream      bool
-	initProvider    string
+	loadConfig          ConfigLoader
+	createProvider      ProviderFactory
+	newKeystore         KeystoreFactory
+	stdin               io.Reader
+	stdout              io.Writer
+	stderr              io.Writer
+	cfgFile             string
+	provider            string
+	model               string
+	jsonOutput          bool
+	verbose             bool
+	cfg                 *config.Config
+	chatPrompt          string
+	chatSystem          string
+	chatTemperature     float32
+	chatMaxTokens       int
+	chatStream          bool
+	chatTimeout         time.Duration
+	chatSchema          string
+	chatSchemaNonStrict bool
+	chatInteractive     bool
+	initProvider        string
 }
 
 // WithConfigLoader injects a config loader dependency.
@@ -128,12 +133,13 @@ Use Iris to manage API keys, chat with models, and scaffold projects.`,
 	root.PersistentFlags().StringVar(&a.provider, "provider", "", "provider ID (openai, anthropic, ollama)")
 	root.PersistentFlags().StringVar(&a.model, "model", "", "model ID (e.g. gpt-4o)")
 	root.PersistentFlags().BoolVar(&a.jsonOutput, "json", false, "emit JSON output")
-	root.PersistentFlags().BoolVar(&a.verbose, "verbose", false, "print token usage summary after streaming responses")
+	root.PersistentFlags().BoolVar(&a.verbose, "verbose", false, "print token usage summary after each response")
 
 	root.AddCommand(a.newChatCommand())
 	root.AddCommand(a.newKeysCommand())
 	root.AddCommand(a.newInitCommand())
 	root.AddCommand(a.newVersionCommand())
+	root.AddCommand(a.newModelsCommand())
 
 	return root
 }

--- a/cli/commands/chat.go
+++ b/cli/commands/chat.go
@@ -1,12 +1,20 @@
 package commands
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/petal-labs/iris/cli/keystore"
 	"github.com/petal-labs/iris/core"
@@ -18,48 +26,96 @@ const (
 	ExitValidation = 1
 	ExitProvider   = 2
 	ExitNetwork    = 3
+	ExitTimeout    = 4
 )
 
 func (a *App) newChatCommand() *cobra.Command {
 	chatCmd := &cobra.Command{
-		Use:   "chat",
-		Short: "Send a chat completion request",
-		Long: `Send a chat completion request to an LLM provider.
+		Use:   "chat [prompt]",
+		Short: "Send a chat completion request or start an interactive REPL",
+		Long: `Send a chat completion request to an LLM provider, or start an interactive
+conversation when no prompt is supplied.
+
+The prompt may be given as a flag, a positional argument, or piped via stdin.
+When no prompt is provided and stdin is a terminal, an interactive REPL starts
+backed by the SDK's Conversation API (Ctrl-D or Ctrl-C to exit).
 
 Examples:
   iris chat --provider openai --model gpt-4o --prompt "Hello"
-  iris chat --prompt "Hello" --stream
-  iris chat --prompt "Hello" --json`,
+  iris chat "Hello"
+  echo "Hello" | iris chat
+  iris chat --system "Be concise"        # interactive REPL
+  iris chat --schema person.json --prompt "Extract: John is 30"
+  iris chat --prompt "Hello" --stream --timeout 30s`,
 		RunE: a.runChat,
 	}
 
-	chatCmd.Flags().StringVar(&a.chatPrompt, "prompt", "", "User message (required)")
+	chatCmd.Flags().StringVar(&a.chatPrompt, "prompt", "", "User message (omitted for interactive REPL)")
 	chatCmd.Flags().StringVar(&a.chatSystem, "system", "", "System message")
 	chatCmd.Flags().Float32Var(&a.chatTemperature, "temperature", 0, "Temperature (0 = use default)")
 	chatCmd.Flags().IntVar(&a.chatMaxTokens, "max-tokens", 0, "Max tokens (0 = use default)")
 	chatCmd.Flags().BoolVar(&a.chatStream, "stream", false, "Enable streaming output")
-
-	_ = chatCmd.MarkFlagRequired("prompt")
+	chatCmd.Flags().DurationVar(&a.chatTimeout, "timeout", 0, "Execution timeout (e.g. 30s, 2m); 0 = SDK default")
+	chatCmd.Flags().StringVar(&a.chatSchema, "schema", "", "Path to a JSON Schema file constraining output (strict mode)")
+	chatCmd.Flags().BoolVar(&a.chatSchemaNonStrict, "schema-non-strict", false, "Relax --schema to non-strict mode")
+	chatCmd.Flags().BoolVarP(&a.chatInteractive, "interactive", "i", false, "Force interactive REPL mode")
 	return chatCmd
 }
 
 func (a *App) runChat(cmd *cobra.Command, args []string) error {
-	// Validate provider.
+	client, err := a.resolveClient(true, true)
+	if err != nil {
+		return err
+	}
+
+	// Base context is cancelled on SIGINT/SIGTERM so in-flight requests and
+	// the REPL can exit cleanly on user interrupt.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	prompt := a.chatPrompt
+	if prompt == "" && len(args) > 0 {
+		prompt = args[0]
+	}
+
+	if prompt == "" {
+		// No prompt: enter REPL when stdin is a terminal or --interactive is
+		// set; otherwise treat piped stdin as a one-shot prompt.
+		isTerminal := false
+		if f, ok := a.stdin.(*os.File); ok {
+			isTerminal = term.IsTerminal(int(f.Fd()))
+		}
+		if isTerminal || a.chatInteractive {
+			return a.runREPLChat(ctx, client, core.ModelID(a.model))
+		}
+		data, rerr := io.ReadAll(a.stdin)
+		if rerr != nil {
+			return exitWithCode(ExitValidation, fmt.Errorf("failed to read prompt from stdin: %w", rerr))
+		}
+		prompt = strings.TrimSpace(string(data))
+		if prompt == "" {
+			return exitWithCode(ExitValidation, fmt.Errorf("no prompt: provide --prompt, a positional argument, or pipe input via stdin"))
+		}
+	}
+
+	return a.runOneShotChat(ctx, client, core.ModelID(a.model), prompt)
+}
+
+// resolveClient builds a core.Client from the configured provider/model/key.
+// requireKey controls whether a missing keystore entry is fatal; requireModel
+// controls whether a model ID must be configured.
+func (a *App) resolveClient(requireKey, requireModel bool) (*core.Client, error) {
 	providerID := a.provider
 	if providerID == "" {
-		return exitWithCode(ExitValidation, fmt.Errorf("provider required: use --provider flag or set default_provider in config"))
+		return nil, exitWithCode(ExitValidation, fmt.Errorf("provider required: use --provider flag or set default_provider in config"))
+	}
+	if requireModel && a.model == "" {
+		return nil, exitWithCode(ExitValidation, fmt.Errorf("model required: use --model flag or set default_model in config"))
 	}
 
-	// Validate model.
-	modelID := a.model
-	if modelID == "" {
-		return exitWithCode(ExitValidation, fmt.Errorf("model required: use --model flag or set default_model in config"))
-	}
-
-	// Get API key from keystore.
 	ks, err := a.openKeystore()
 	if err != nil {
-		return exitWithCode(ExitValidation, fmt.Errorf("failed to open keystore: %w", err))
+		return nil, exitWithCode(ExitValidation, fmt.Errorf("failed to open keystore: %w", err))
 	}
 
 	apiKey, err := ks.Get(providerID)
@@ -69,44 +125,60 @@ func (a *App) runChat(cmd *cobra.Command, args []string) error {
 			// key; proceed with an empty key and let the provider decide.
 			// Ollama Cloud still fails at request time with its own
 			// unauthorized error if a key was actually required.
-			if !providerAllowsEmptyAPIKey(providerID) {
-				return exitWithCode(ExitValidation, fmt.Errorf("no API key for %s: run 'iris keys set %s' first", providerID, providerID))
+			if !providerAllowsEmptyAPIKey(providerID) && requireKey {
+				return nil, exitWithCode(ExitValidation, fmt.Errorf("no API key for %s: run 'iris keys set %s' first", providerID, providerID))
 			}
 			apiKey = ""
 		} else {
-			return exitWithCode(ExitValidation, fmt.Errorf("failed to get API key: %w", err))
+			return nil, exitWithCode(ExitValidation, fmt.Errorf("failed to get API key: %w", err))
 		}
 	}
 
-	// Create provider.
 	provider, err := a.createProvider(providerID, apiKey, a.cfg)
 	if err != nil {
-		return exitWithCode(ExitValidation, err)
+		return nil, exitWithCode(ExitValidation, err)
 	}
 
-	// Create client and build request.
-	client := core.NewClient(provider)
-	builder := client.Chat(core.ModelID(modelID)).User(a.chatPrompt)
+	return core.NewClient(provider), nil
+}
 
+// runOneShotChat executes a single chat request with the given prompt.
+func (a *App) runOneShotChat(ctx context.Context, client *core.Client, model core.ModelID, prompt string) error {
+	builder := client.Chat(model)
 	if a.chatSystem != "" {
-		// System message should come before user message.
-		builder = client.Chat(core.ModelID(modelID)).System(a.chatSystem).User(a.chatPrompt)
+		builder = builder.System(a.chatSystem)
 	}
+	builder = builder.User(prompt)
+
 	if a.chatTemperature > 0 {
 		builder = builder.Temperature(a.chatTemperature)
 	}
 	if a.chatMaxTokens > 0 {
 		builder = builder.MaxTokens(a.chatMaxTokens)
 	}
-
-	ctx := context.Background()
-	if a.chatStream {
-		return a.runStreamingChat(ctx, builder)
+	if a.chatTimeout > 0 {
+		// Let the SDK apply the deadline so it is mapped to ErrTimeout.
+		builder = builder.Timeout(a.chatTimeout)
 	}
-	return a.runNonStreamingChat(ctx, builder)
+	if a.chatSchema != "" {
+		schema, err := loadSchema(a.chatSchema)
+		if err != nil {
+			return exitWithCode(ExitValidation, err)
+		}
+		if a.chatSchemaNonStrict {
+			builder = builder.ResponseJSONSchemaNonStrict(schema)
+		} else {
+			builder = builder.ResponseJSONSchema(schema)
+		}
+	}
+
+	if a.chatStream {
+		return a.runStreamingChat(ctx, builder, prompt)
+	}
+	return a.runNonStreamingChat(ctx, builder, prompt)
 }
 
-func (a *App) runNonStreamingChat(ctx context.Context, builder *core.ChatBuilder) error {
+func (a *App) runNonStreamingChat(ctx context.Context, builder *core.ChatBuilder, prompt string) error {
 	resp, err := builder.GetResponse(ctx)
 	if err != nil {
 		return a.handleChatError(err)
@@ -117,12 +189,15 @@ func (a *App) runNonStreamingChat(ctx context.Context, builder *core.ChatBuilder
 	}
 
 	// Text output.
-	fmt.Fprintf(a.stdout, "> %s\n", a.chatPrompt)
+	fmt.Fprintf(a.stdout, "> %s\n", prompt)
 	fmt.Fprintln(a.stdout, resp.Output)
+	if a.verbose {
+		a.printUsage(resp.Usage)
+	}
 	return nil
 }
 
-func (a *App) runStreamingChat(ctx context.Context, builder *core.ChatBuilder) error {
+func (a *App) runStreamingChat(ctx context.Context, builder *core.ChatBuilder, prompt string) error {
 	chatStream, err := builder.Stream(ctx)
 	if err != nil {
 		return a.handleChatError(err)
@@ -137,17 +212,30 @@ func (a *App) runStreamingChat(ctx context.Context, builder *core.ChatBuilder) e
 	}
 
 	// Stream text output.
-	fmt.Fprintf(a.stdout, "> %s\n", a.chatPrompt)
+	fmt.Fprintf(a.stdout, "> %s\n", prompt)
 
-	var finalResp *core.ChatResponse
-	var streamErr error
+	finalResp, streamErr := a.drainStream(chatStream)
+	if streamErr != nil {
+		return a.handleChatError(streamErr)
+	}
 
-	// Read chunks as they arrive.
+	if a.verbose && finalResp != nil {
+		a.printUsage(finalResp.Usage)
+	}
+
+	return nil
+}
+
+// drainStream prints streamed deltas to stdout and returns the final response
+// and/or error observed on the stream. It prints a trailing newline after the
+// last delta. The Final/Err selects use default cases to preserve the original
+// non-blocking behavior: the telemetry wrapper buffers both channels (cap 1)
+// and closes them once the stream completes.
+func (a *App) drainStream(chatStream *core.ChatStream) (finalResp *core.ChatResponse, streamErr error) {
 	for chunk := range chatStream.Ch {
 		fmt.Fprint(a.stdout, chunk.Delta)
 	}
 
-	// Check for errors.
 	select {
 	case err := <-chatStream.Err:
 		if err != nil {
@@ -156,32 +244,149 @@ func (a *App) runStreamingChat(ctx context.Context, builder *core.ChatBuilder) e
 	default:
 	}
 
-	// Get final response.
 	select {
 	case resp := <-chatStream.Final:
 		finalResp = resp
 	default:
 	}
 
-	// Print final newline.
 	fmt.Fprintln(a.stdout)
+	return finalResp, streamErr
+}
 
-	if streamErr != nil {
-		return a.handleChatError(streamErr)
+// runREPLChat runs an interactive, Conversation-backed REPL. Ctrl-D (EOF) and
+// Ctrl-C (signal cancellation) produce a clean exit.
+func (a *App) runREPLChat(ctx context.Context, client *core.Client, model core.ModelID) error {
+	var opts []core.ConversationOption
+	if a.chatSystem != "" {
+		opts = append(opts, core.WithSystemMessage(a.chatSystem))
+	}
+	conv := core.NewConversation(ctx, client, model, opts...)
+
+	fmt.Fprintf(a.stderr, "Iris REPL — provider=%s model=%s (Ctrl-D or Ctrl-C to exit)\n", a.provider, a.model)
+
+	reader := bufio.NewReader(a.stdin)
+	for {
+		if ctx.Err() != nil {
+			fmt.Fprintln(a.stderr, "Interrupted.")
+			return nil
+		}
+
+		fmt.Fprint(a.stdout, "> ")
+		line, err := reader.ReadString('\n')
+		text := strings.TrimSpace(line)
+
+		if err == io.EOF {
+			if text != "" {
+				if e := a.runREPLTurn(ctx, conv, text); e != nil {
+					return e
+				}
+			}
+			fmt.Fprintln(a.stdout)
+			return nil
+		}
+		if err != nil {
+			return exitWithCode(ExitValidation, fmt.Errorf("failed to read input: %w", err))
+		}
+
+		if text == "" {
+			continue
+		}
+		if e := a.runREPLTurn(ctx, conv, text); e != nil {
+			return e
+		}
+	}
+}
+
+// runREPLTurn sends a single user turn and prints the result. Recoverable
+// errors are reported inline and the REPL continues; context cancellation
+// returns nil so the caller can exit cleanly.
+func (a *App) runREPLTurn(ctx context.Context, conv *core.Conversation, text string) error {
+	if a.chatStream {
+		stream, err := conv.Stream(ctx, text)
+		if err != nil {
+			return a.reportREPLError(err)
+		}
+		finalResp, streamErr := a.drainStream(stream)
+		if streamErr != nil {
+			return a.reportREPLError(streamErr)
+		}
+		if a.verbose && finalResp != nil {
+			a.printUsage(finalResp.Usage)
+		}
+		return nil
 	}
 
-	// Log usage if verbose.
-	if a.verbose && finalResp != nil {
-		fmt.Fprintf(a.stderr, "Usage: %d prompt + %d completion = %d total tokens\n",
-			finalResp.Usage.PromptTokens,
-			finalResp.Usage.CompletionTokens,
-			finalResp.Usage.TotalTokens)
+	resp, err := conv.Send(ctx, text)
+	if err != nil {
+		return a.reportREPLError(err)
 	}
-
+	fmt.Fprintln(a.stdout, resp.Output)
+	if a.verbose {
+		a.printUsage(resp.Usage)
+	}
 	return nil
 }
 
+// reportREPLError prints an error for an in-REPL turn and returns nil so the
+// loop continues. Context cancellation is swallowed here; the REPL loop's
+// ctx.Err() check reports "Interrupted." and exits on the next iteration.
+func (a *App) reportREPLError(err error) error {
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	_ = a.handleChatError(err) // print classified error
+	return nil
+}
+
+func (a *App) printUsage(u core.TokenUsage) {
+	fmt.Fprintf(a.stderr, "Usage: %d prompt + %d completion = %d total tokens\n",
+		u.PromptTokens, u.CompletionTokens, u.TotalTokens)
+}
+
+// loadSchema reads a JSON Schema from path and returns a definition suitable
+// for ResponseJSONSchema(ResponseJSONSchemaNonStrict). The schema name is
+// derived from the file's base name (without extension).
+func loadSchema(path string) (*core.JSONSchemaDefinition, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read schema file %s: %w", path, err)
+	}
+	// Validate that the file is valid JSON before sending it to a provider.
+	var node json.RawMessage
+	if err := json.Unmarshal(data, &node); err != nil {
+		return nil, fmt.Errorf("schema file %s is not valid JSON: %w", path, err)
+	}
+
+	name := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	if name == "" {
+		name = "output"
+	}
+	return &core.JSONSchemaDefinition{
+		Name:   name,
+		Schema: json.RawMessage(data),
+	}, nil
+}
+
 func (a *App) handleChatError(err error) error {
+	// User-initiated cancellation: clean exit, no error envelope.
+	if errors.Is(err, context.Canceled) {
+		if !a.jsonOutput {
+			fmt.Fprintln(a.stderr, "Interrupted.")
+		}
+		return nil
+	}
+
+	// Iris-imposed execution timeout.
+	if errors.Is(err, core.ErrTimeout) {
+		if a.jsonOutput {
+			a.outputSimpleErrorJSON("timeout", err.Error())
+		} else {
+			fmt.Fprintf(a.stderr, "Error: %v\n", err)
+		}
+		return exitWithCode(ExitTimeout, err)
+	}
+
 	var provErr *core.ProviderError
 	if errors.As(err, &provErr) {
 		if a.jsonOutput {
@@ -212,8 +417,10 @@ func (a *App) handleChatError(err error) error {
 		return exitWithCode(ExitNetwork, err)
 	}
 
-	// Validation errors.
-	if errors.Is(err, core.ErrModelRequired) || errors.Is(err, core.ErrNoMessages) {
+	// Validation errors (request-level, before any HTTP call).
+	if errors.Is(err, core.ErrModelRequired) || errors.Is(err, core.ErrNoMessages) ||
+		errors.Is(err, core.ErrInvalidSchema) || errors.Is(err, core.ErrStructuredOutputUnsupported) ||
+		errors.Is(err, core.ErrSearchUnsupported) {
 		if a.jsonOutput {
 			a.outputSimpleErrorJSON("validation_error", err.Error())
 		} else {

--- a/cli/commands/chat_test.go
+++ b/cli/commands/chat_test.go
@@ -2,13 +2,17 @@ package commands
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/petal-labs/iris/cli/config"
 	"github.com/petal-labs/iris/cli/keystore"
@@ -244,5 +248,387 @@ func TestRunChatMissingKeyFailsForKeyedProviders(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "iris keys set openai") {
 		t.Errorf("error = %q, want actionable 'iris keys set openai' hint", err.Error())
+	}
+}
+
+// writeSchemaFile writes data to a temporary file and returns its path.
+func writeSchemaFile(t *testing.T, data string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "schema.json")
+	if err := os.WriteFile(p, []byte(data), 0644); err != nil {
+		t.Fatalf("write schema file: %v", err)
+	}
+	return p
+}
+
+// TestRunChatSchemaStrict verifies --schema sets ResponseFormatJSONSchema with
+// Strict=true and forwards the schema bytes to the provider.
+func TestRunChatSchemaStrict(t *testing.T) {
+	var gotReq *core.ChatRequest
+	mp := &mockChatProvider{
+		chat: func(_ context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+			gotReq = req
+			return &core.ChatResponse{ID: "r", Model: req.Model, Output: `{"name":"John"}`}, nil
+		},
+	}
+	app, _, _ := appWithMockProvider(t, mp)
+	app.chatPrompt = "Extract: John is 30"
+	app.chatSchema = writeSchemaFile(t, `{"type":"object","additionalProperties":false,"properties":{"name":{"type":"string"}},"required":["name"]}`)
+
+	if err := app.runChat(nil, nil); err != nil {
+		t.Fatalf("runChat() error = %v", err)
+	}
+	if gotReq == nil {
+		t.Fatal("provider.Chat was not called")
+	}
+	if gotReq.ResponseFormat != core.ResponseFormatJSONSchema {
+		t.Errorf("ResponseFormat = %q, want %q", gotReq.ResponseFormat, core.ResponseFormatJSONSchema)
+	}
+	if gotReq.JSONSchema == nil {
+		t.Fatal("JSONSchema is nil")
+	}
+	if !gotReq.JSONSchema.Strict {
+		t.Error("JSONSchema.Strict = false, want true (strict mode)")
+	}
+	if gotReq.JSONSchema.Name != "schema" {
+		t.Errorf("JSONSchema.Name = %q, want %q", gotReq.JSONSchema.Name, "schema")
+	}
+}
+
+// TestRunChatSchemaNonStrict verifies --schema-non-strict relaxes strict mode.
+func TestRunChatSchemaNonStrict(t *testing.T) {
+	var gotReq *core.ChatRequest
+	mp := &mockChatProvider{
+		chat: func(_ context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+			gotReq = req
+			return &core.ChatResponse{Output: `{}`}, nil
+		},
+	}
+	app, _, _ := appWithMockProvider(t, mp)
+	app.chatPrompt = "Extract"
+	// Schema is intentionally not strict-compliant (missing
+	// additionalProperties:false and required); non-strict mode must accept it.
+	app.chatSchema = writeSchemaFile(t, `{"type":"object","properties":{"name":{"type":"string"}}}`)
+	app.chatSchemaNonStrict = true
+
+	if err := app.runChat(nil, nil); err != nil {
+		t.Fatalf("runChat() error = %v", err)
+	}
+	if gotReq.JSONSchema == nil || gotReq.JSONSchema.Strict {
+		t.Errorf("got Strict = true, want false in non-strict mode")
+	}
+}
+
+// TestRunChatSchemaStrictRejected verifies a non-strict-compliant schema under
+// strict mode fails with ErrInvalidSchema (ExitValidation) before any HTTP call.
+func TestRunChatSchemaStrictRejected(t *testing.T) {
+	called := false
+	mp := &mockChatProvider{
+		chat: func(_ context.Context, _ *core.ChatRequest) (*core.ChatResponse, error) {
+			called = true
+			return &core.ChatResponse{}, nil
+		},
+	}
+	app, _, _ := appWithMockProvider(t, mp)
+	app.chatPrompt = "Extract"
+	app.chatSchema = writeSchemaFile(t, `{"type":"object","properties":{"name":{"type":"string"}}}`) // not strict
+
+	err := app.runChat(nil, nil)
+	if err == nil {
+		t.Fatal("runChat() should fail for non-strict-compliant schema in strict mode")
+	}
+	if called {
+		t.Error("provider.Chat should not be called when schema validation fails")
+	}
+	exitErr, ok := err.(*exitError)
+	if !ok || exitErr.ExitCode() != ExitValidation {
+		t.Errorf("exit code = %v, want ExitValidation", err)
+	}
+}
+
+// TestLoadSchemaErrors covers file-not-found and invalid-JSON cases.
+func TestLoadSchemaErrors(t *testing.T) {
+	if _, err := loadSchema(filepath.Join(t.TempDir(), "missing.json")); err == nil {
+		t.Fatal("loadSchema(missing) should error")
+	}
+	bad := writeSchemaFile(t, `{not valid json`)
+	if _, err := loadSchema(bad); err == nil {
+		t.Fatal("loadSchema(invalid JSON) should error")
+	}
+}
+
+// TestRunChatPositionalArg verifies a positional argument is used as the prompt.
+func TestRunChatPositionalArg(t *testing.T) {
+	var gotReq *core.ChatRequest
+	mp := &mockChatProvider{
+		chat: func(_ context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+			gotReq = req
+			return &core.ChatResponse{Output: "ok"}, nil
+		},
+	}
+	app, _, _ := appWithMockProvider(t, mp)
+	app.chatPrompt = "" // no --prompt
+
+	if err := app.runChat(nil, []string{"Hello from arg"}); err != nil {
+		t.Fatalf("runChat() error = %v", err)
+	}
+	if gotReq == nil {
+		t.Fatal("provider.Chat was not called")
+	}
+	last := gotReq.Messages[len(gotReq.Messages)-1]
+	if last.Role != core.RoleUser || last.Content != "Hello from arg" {
+		t.Errorf("last message = {%s, %q}, want user/Hello from arg", last.Role, last.Content)
+	}
+}
+
+// TestRunChatStdinPipe verifies piped stdin is treated as a one-shot prompt.
+func TestRunChatStdinPipe(t *testing.T) {
+	var gotReq *core.ChatRequest
+	mp := &mockChatProvider{
+		chat: func(_ context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+			gotReq = req
+			return &core.ChatResponse{Output: "ok"}, nil
+		},
+	}
+	var stdout bytes.Buffer
+	app := NewApp(
+		WithProviderFactory(func(string, string, *config.Config) (core.Provider, error) { return mp, nil }),
+		WithKeystoreFactory(func() (keystore.Keystore, error) {
+			return keystore.NewKeystoreAtPath(filepath.Join(t.TempDir(), "keys.enc"))
+		}),
+		WithIO(strings.NewReader("piped prompt\n"), &stdout, &bytes.Buffer{}),
+	)
+	app.cfg = &config.Config{}
+	app.provider = "ollama"
+	app.model = "llama3.2"
+
+	if err := app.runChat(nil, nil); err != nil {
+		t.Fatalf("runChat() error = %v", err)
+	}
+	if gotReq == nil {
+		t.Fatal("provider.Chat was not called")
+	}
+	last := gotReq.Messages[len(gotReq.Messages)-1]
+	if last.Content != "piped prompt" {
+		t.Errorf("last user message = %q, want %q", last.Content, "piped prompt")
+	}
+}
+
+// TestRunChatNoPromptError verifies an empty prompt (no flag, no arg, empty
+// stdin, non-interactive) yields a validation error rather than entering REPL.
+func TestRunChatNoPromptError(t *testing.T) {
+	mp := &mockChatProvider{}
+	app, _, _ := appWithMockProvider(t, mp)
+	app.chatPrompt = ""
+
+	err := app.runChat(nil, nil)
+	if err == nil {
+		t.Fatal("runChat() should error when no prompt is available")
+	}
+	if !strings.Contains(err.Error(), "no prompt") {
+		t.Errorf("error = %q, want 'no prompt' guidance", err.Error())
+	}
+}
+
+// TestRunChatREPL verifies the interactive REPL: multiple turns are sent
+// through a Conversation, so history accumulates across turns. Ctrl-D (EOF on
+// the piped reader) exits cleanly.
+func TestRunChatREPL(t *testing.T) {
+	type capturedReq struct {
+		msgs []core.Message
+	}
+	var captured []capturedReq
+	mp := &mockChatProvider{
+		chat: func(_ context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+			cp := make([]core.Message, len(req.Messages))
+			copy(cp, req.Messages)
+			captured = append(captured, capturedReq{msgs: cp})
+			return &core.ChatResponse{Output: fmt.Sprintf("answer%d", len(captured))}, nil
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	app := NewApp(
+		WithProviderFactory(func(string, string, *config.Config) (core.Provider, error) { return mp, nil }),
+		WithKeystoreFactory(func() (keystore.Keystore, error) {
+			return keystore.NewKeystoreAtPath(filepath.Join(t.TempDir(), "keys.enc"))
+		}),
+		WithIO(strings.NewReader("hello\nhow are you\n"), &stdout, &stderr),
+	)
+	app.cfg = &config.Config{}
+	app.provider = "ollama"
+	app.model = "llama3.2"
+	app.chatInteractive = true // force REPL despite non-terminal stdin
+
+	if err := app.runChat(nil, nil); err != nil {
+		t.Fatalf("runChat() error = %v", err)
+	}
+	if len(captured) != 2 {
+		t.Fatalf("provider.Chat called %d times, want 2", len(captured))
+	}
+	// Turn 1: only the user message.
+	if len(captured[0].msgs) != 1 || captured[0].msgs[0].Content != "hello" {
+		t.Errorf("turn 1 messages = %v, want [user:hello]", captured[0].msgs)
+	}
+	// Turn 2: history includes turn 1's user + assistant + turn 2's user.
+	if len(captured[1].msgs) != 3 {
+		t.Fatalf("turn 2 messages = %v, want 3 (history + new user)", captured[1].msgs)
+	}
+	if captured[1].msgs[0].Content != "hello" || captured[1].msgs[0].Role != core.RoleUser {
+		t.Errorf("turn 2 msg[0] = %v, want user:hello", captured[1].msgs[0])
+	}
+	if captured[1].msgs[1].Content != "answer1" || captured[1].msgs[1].Role != core.RoleAssistant {
+		t.Errorf("turn 2 msg[1] = %v, want assistant:answer1", captured[1].msgs[1])
+	}
+	if captured[1].msgs[2].Content != "how are you" || captured[1].msgs[2].Role != core.RoleUser {
+		t.Errorf("turn 2 msg[2] = %v, want user:how are you", captured[1].msgs[2])
+	}
+	if !strings.Contains(stdout.String(), "answer1") || !strings.Contains(stdout.String(), "answer2") {
+		t.Errorf("stdout = %q, want both answers", stdout.String())
+	}
+}
+
+// TestRunChatREPLEmptyInput verifies an immediate EOF in REPL mode exits cleanly
+// without invoking the provider.
+func TestRunChatREPLEmptyInput(t *testing.T) {
+	called := false
+	mp := &mockChatProvider{
+		chat: func(_ context.Context, _ *core.ChatRequest) (*core.ChatResponse, error) {
+			called = true
+			return &core.ChatResponse{Output: "x"}, nil
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	app := NewApp(
+		WithProviderFactory(func(string, string, *config.Config) (core.Provider, error) { return mp, nil }),
+		WithKeystoreFactory(func() (keystore.Keystore, error) {
+			return keystore.NewKeystoreAtPath(filepath.Join(t.TempDir(), "keys.enc"))
+		}),
+		WithIO(strings.NewReader(""), &stdout, &stderr),
+	)
+	app.cfg = &config.Config{}
+	app.provider = "ollama"
+	app.model = "llama3.2"
+	app.chatInteractive = true
+
+	if err := app.runChat(nil, nil); err != nil {
+		t.Fatalf("runChat() error = %v", err)
+	}
+	if called {
+		t.Error("provider.Chat should not be called on immediate EOF")
+	}
+}
+
+// TestRunChatREPLSystemMessage verifies a --system message seeds the
+// conversation history in REPL mode.
+func TestRunChatREPLSystemMessage(t *testing.T) {
+	var firstReq *core.ChatRequest
+	mp := &mockChatProvider{
+		chat: func(_ context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+			if firstReq == nil {
+				firstReq = req
+			}
+			return &core.ChatResponse{Output: "ok"}, nil
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	app := NewApp(
+		WithProviderFactory(func(string, string, *config.Config) (core.Provider, error) { return mp, nil }),
+		WithKeystoreFactory(func() (keystore.Keystore, error) {
+			return keystore.NewKeystoreAtPath(filepath.Join(t.TempDir(), "keys.enc"))
+		}),
+		WithIO(strings.NewReader("hi\n"), &stdout, &stderr),
+	)
+	app.cfg = &config.Config{}
+	app.provider = "ollama"
+	app.model = "llama3.2"
+	app.chatInteractive = true
+	app.chatSystem = "Be concise"
+
+	if err := app.runChat(nil, nil); err != nil {
+		t.Fatalf("runChat() error = %v", err)
+	}
+	if firstReq == nil || len(firstReq.Messages) < 2 {
+		t.Fatalf("expected system + user messages, got %v", firstReq)
+	}
+	if firstReq.Messages[0].Role != core.RoleSystem || firstReq.Messages[0].Content != "Be concise" {
+		t.Errorf("msg[0] = %v, want system/Be concise", firstReq.Messages[0])
+	}
+}
+
+// TestRunChatTimeout verifies --timeout cancels an unresponsive provider and
+// surfaces ExitTimeout.
+func TestRunChatTimeout(t *testing.T) {
+	mp := &mockChatProvider{
+		chat: func(ctx context.Context, _ *core.ChatRequest) (*core.ChatResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+	app, _, _ := appWithMockProvider(t, mp)
+	app.chatPrompt = "hi"
+	app.chatTimeout = 50 * time.Millisecond
+
+	err := app.runChat(nil, nil)
+	if err == nil {
+		t.Fatal("runChat() should time out")
+	}
+	exitErr, ok := err.(*exitError)
+	if !ok {
+		t.Fatalf("error type = %T, want *exitError", err)
+	}
+	if exitErr.ExitCode() != ExitTimeout {
+		t.Errorf("exit code = %d, want ExitTimeout (%d)", exitErr.ExitCode(), ExitTimeout)
+	}
+}
+
+// TestRunChatVerboseNonStreaming verifies --verbose prints a token usage
+// summary for non-streaming responses (previously only streaming did).
+func TestRunChatVerboseNonStreaming(t *testing.T) {
+	mp := &mockChatProvider{
+		chat: func(_ context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+			return &core.ChatResponse{
+				Output: "ok",
+				Usage:  core.TokenUsage{PromptTokens: 5, CompletionTokens: 7, TotalTokens: 12},
+			}, nil
+		},
+	}
+	app, _, stderr := appWithMockProvider(t, mp)
+	app.chatPrompt = "hi"
+	app.verbose = true
+
+	if err := app.runChat(nil, nil); err != nil {
+		t.Fatalf("runChat() error = %v", err)
+	}
+	if !strings.Contains(stderr.String(), "Usage:") {
+		t.Errorf("stderr = %q, want a usage summary", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "12 total tokens") {
+		t.Errorf("stderr = %q, want '12 total tokens'", stderr.String())
+	}
+}
+
+// TestRunChatJSONEnvelopeWithSchema verifies --json still emits the response
+// envelope when --schema is set (the schema constrains the model; --json wraps
+// the envelope).
+func TestRunChatJSONEnvelopeWithSchema(t *testing.T) {
+	mp := &mockChatProvider{
+		chat: func(_ context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+			return &core.ChatResponse{ID: "r1", Model: req.Model, Output: `{"name":"John"}`}, nil
+		},
+	}
+	app, stdout, _ := appWithMockProvider(t, mp)
+	app.chatPrompt = "Extract: John"
+	app.chatSchema = writeSchemaFile(t, `{"type":"object","additionalProperties":false,"properties":{"name":{"type":"string"}},"required":["name"]}`)
+	app.jsonOutput = true
+
+	if err := app.runChat(nil, nil); err != nil {
+		t.Fatalf("runChat() error = %v", err)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &env); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v (got %q)", err, stdout.String())
+	}
+	if env["output"] != `{"name":"John"}` {
+		t.Errorf("envelope output = %v, want the schema-constrained JSON string", env["output"])
 	}
 }

--- a/cli/commands/mockprovider_test.go
+++ b/cli/commands/mockprovider_test.go
@@ -1,0 +1,70 @@
+package commands
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/petal-labs/iris/cli/config"
+	"github.com/petal-labs/iris/cli/keystore"
+	"github.com/petal-labs/iris/core"
+)
+
+// mockChatProvider is a test double for core.Provider used by the CLI tests.
+// It avoids HTTP entirely: chat/stream behavior is driven by the function
+// fields, which may be nil for a trivial canned response.
+type mockChatProvider struct {
+	id     string
+	models []core.ModelInfo
+	sup    map[core.Feature]bool
+	chat   func(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error)
+	stream func(ctx context.Context, req *core.ChatRequest) (*core.ChatStream, error)
+}
+
+func (m *mockChatProvider) ID() string { return m.id }
+
+func (m *mockChatProvider) Models() []core.ModelInfo { return m.models }
+
+func (m *mockChatProvider) Supports(f core.Feature) bool {
+	if m.sup == nil {
+		return true
+	}
+	return m.sup[f]
+}
+
+func (m *mockChatProvider) Chat(ctx context.Context, req *core.ChatRequest) (*core.ChatResponse, error) {
+	if m.chat != nil {
+		return m.chat(ctx, req)
+	}
+	return &core.ChatResponse{ID: "resp-1", Model: req.Model, Output: "mock"}, nil
+}
+
+func (m *mockChatProvider) StreamChat(ctx context.Context, req *core.ChatRequest) (*core.ChatStream, error) {
+	if m.stream != nil {
+		return m.stream(ctx, req)
+	}
+	return nil, core.ErrNotSupported
+}
+
+// appWithMockProvider builds an App wired to a mock provider (registered under
+// "ollama" so the keyless path applies and no API key is required) and an empty
+// keystore. The returned provider may be mutated by callers to customize chat.
+func appWithMockProvider(t *testing.T, mp *mockChatProvider) (*App, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	app := NewApp(
+		WithProviderFactory(func(providerID, apiKey string, cfg *config.Config) (core.Provider, error) {
+			return mp, nil
+		}),
+		WithKeystoreFactory(func() (keystore.Keystore, error) {
+			return keystore.NewKeystoreAtPath(filepath.Join(t.TempDir(), "keys.enc"))
+		}),
+		WithIO(strings.NewReader(""), &stdout, &stderr),
+	)
+	app.cfg = &config.Config{}
+	app.provider = "ollama"
+	app.model = "llama3.2"
+	return app, &stdout, &stderr
+}

--- a/cli/commands/models.go
+++ b/cli/commands/models.go
@@ -1,0 +1,91 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func (a *App) newModelsCommand() *cobra.Command {
+	modelsCmd := &cobra.Command{
+		Use:   "models",
+		Short: "List models available for a provider",
+		Long: `List models available for a provider from its static catalog.
+
+The provider is selected with the global --provider flag (or the
+default_provider in config). Output is a table by default; pass --json for
+machine-readable output.
+
+Examples:
+  iris models --provider openai
+  iris models --provider ollama --json`,
+		RunE: a.runModels,
+	}
+
+	return modelsCmd
+}
+
+func (a *App) runModels(cmd *cobra.Command, args []string) error {
+	// The model catalog is static, so a missing API key is not fatal here:
+	// the provider is constructed with an empty key solely to read its
+	// catalog. Keyed providers that need a live listing should expose that
+	// through their own discovery API.
+	client, err := a.resolveClient(false, false)
+	if err != nil {
+		return err
+	}
+
+	models := client.Provider().Models()
+
+	if a.jsonOutput {
+		return a.outputModelsJSON(models)
+	}
+
+	if len(models) == 0 {
+		fmt.Fprintf(a.stdout, "No models in the %s catalog.\n", a.provider)
+		return nil
+	}
+
+	fmt.Fprintf(a.stdout, "Models for %s (%d):\n\n", a.provider, len(models))
+	w := tabwriter.NewWriter(a.stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "ID\tDISPLAY NAME\tCAPABILITIES")
+	for _, m := range models {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", m.ID, m.DisplayName, capabilitiesString(m.Capabilities))
+	}
+	return w.Flush()
+}
+
+func (a *App) outputModelsJSON(models []core.ModelInfo) error {
+	out := make([]map[string]interface{}, 0, len(models))
+	for _, m := range models {
+		caps := make([]string, 0, len(m.Capabilities))
+		for _, c := range m.Capabilities {
+			caps = append(caps, string(c))
+		}
+		out = append(out, map[string]interface{}{
+			"id":           string(m.ID),
+			"display_name": m.DisplayName,
+			"capabilities": caps,
+		})
+	}
+
+	enc := json.NewEncoder(a.stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+func capabilitiesString(caps []core.Feature) string {
+	if len(caps) == 0 {
+		return "-"
+	}
+	parts := make([]string, 0, len(caps))
+	for _, c := range caps {
+		parts = append(parts, string(c))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/cli/commands/models_test.go
+++ b/cli/commands/models_test.go
@@ -1,0 +1,130 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/petal-labs/iris/cli/config"
+	"github.com/petal-labs/iris/cli/keystore"
+	"github.com/petal-labs/iris/core"
+)
+
+func newModelsApp(t *testing.T, mp *mockChatProvider) (*App, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	app := NewApp(
+		WithProviderFactory(func(string, string, *config.Config) (core.Provider, error) { return mp, nil }),
+		WithKeystoreFactory(func() (keystore.Keystore, error) {
+			return keystore.NewKeystoreAtPath(filepath.Join(t.TempDir(), "keys.enc"))
+		}),
+		WithIO(strings.NewReader(""), &stdout, &stderr),
+	)
+	app.cfg = &config.Config{}
+	app.provider = "ollama"
+	return app, &stdout, &stderr
+}
+
+func TestRunModelsTable(t *testing.T) {
+	mp := &mockChatProvider{
+		models: []core.ModelInfo{
+			{ID: "llama3.2", DisplayName: "Llama 3.2", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming}},
+			{ID: "mistral", DisplayName: "Mistral 7B", Capabilities: []core.Feature{core.FeatureChat}},
+		},
+	}
+	app, stdout, _ := newModelsApp(t, mp)
+
+	if err := app.runModels(nil, nil); err != nil {
+		t.Fatalf("runModels() error = %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{"llama3.2", "Llama 3.2", "mistral", "Mistral 7B", "chat", "chat_streaming"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunModelsJSON(t *testing.T) {
+	mp := &mockChatProvider{
+		models: []core.ModelInfo{
+			{ID: "gpt-4o", DisplayName: "GPT-4o", Capabilities: []core.Feature{core.FeatureChat, core.FeatureStructuredOutput}},
+		},
+	}
+	app, stdout, _ := newModelsApp(t, mp)
+	app.jsonOutput = true
+
+	if err := app.runModels(nil, nil); err != nil {
+		t.Fatalf("runModels() error = %v", err)
+	}
+	var got []map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout not valid JSON array: %v (got %q)", err, stdout.String())
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0]["id"] != "gpt-4o" {
+		t.Errorf("id = %v, want gpt-4o", got[0]["id"])
+	}
+	caps, _ := got[0]["capabilities"].([]any)
+	if len(caps) != 2 {
+		t.Errorf("capabilities = %v, want 2 entries", caps)
+	}
+}
+
+func TestRunModelsEmptyCatalog(t *testing.T) {
+	mp := &mockChatProvider{models: nil}
+	app, stdout, _ := newModelsApp(t, mp)
+
+	if err := app.runModels(nil, nil); err != nil {
+		t.Fatalf("runModels() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), "No models") {
+		t.Errorf("stdout = %q, want 'No models' notice", stdout.String())
+	}
+}
+
+func TestRunModelsNoProvider(t *testing.T) {
+	mp := &mockChatProvider{}
+	app, _, _ := newModelsApp(t, mp)
+	app.provider = ""
+
+	err := app.runModels(nil, nil)
+	if err == nil {
+		t.Fatal("runModels() should error without a provider")
+	}
+	exitErr, ok := err.(*exitError)
+	if !ok || exitErr.ExitCode() != ExitValidation {
+		t.Errorf("exit code = %v, want ExitValidation", err)
+	}
+}
+
+// TestRunModelsDoesNotRequireAPIKey verifies the static catalog is reachable
+// even when no key is stored for a normally-keyed provider, via the injected
+// factory.
+func TestRunModelsDoesNotRequireAPIKey(t *testing.T) {
+	mp := &mockChatProvider{
+		id:     "openai",
+		models: []core.ModelInfo{{ID: "gpt-4o", DisplayName: "GPT-4o"}},
+	}
+	var stdout bytes.Buffer
+	app := NewApp(
+		WithProviderFactory(func(string, string, *config.Config) (core.Provider, error) { return mp, nil }),
+		WithKeystoreFactory(func() (keystore.Keystore, error) {
+			return keystore.NewKeystoreAtPath(filepath.Join(t.TempDir(), "keys.enc"))
+		}),
+		WithIO(strings.NewReader(""), &stdout, &bytes.Buffer{}),
+	)
+	app.cfg = &config.Config{}
+	app.provider = "openai" // normally keyed, but no key stored
+
+	if err := app.runModels(nil, nil); err != nil {
+		t.Fatalf("runModels() should not require an API key for the static catalog; got %v", err)
+	}
+	if !strings.Contains(stdout.String(), "gpt-4o") {
+		t.Errorf("stdout = %q, want the model id", stdout.String())
+	}
+}


### PR DESCRIPTION
## Summary

Closes #62. Brings `iris chat` to parity with the SDK and adds `iris models`.

### Acceptance criteria

- [x] REPL mode (no `--prompt` → interactive, `Conversation`-backed, Ctrl-D/Ctrl-C clean exit)
- [x] `--timeout` + signal-driven cancellation (SIGINT/SIGTERM)
- [x] `--schema <file>` structured output flag
- [x] `iris models [--provider]` listing
- [x] `--verbose` either debug-logs or is re-documented

### Changes

**`chat.go`** — rewrote the chat command:
- **REPL**: `--prompt` is no longer required. With no prompt and a terminal stdin (or `-i`), an interactive REPL launches backed by `core.Conversation`/`InMemoryStore`; Ctrl-D (EOF) and Ctrl-C (SIGINT) exit cleanly. History accumulates across turns via the SDK's `Conversation` API.
- **`--timeout`** + signals: base context is `signal.NotifyContext(SIGINT, SIGTERM)`; `--timeout` flows through `builder.Timeout()` so the SDK maps it to `ErrTimeout` (new `ExitTimeout=4`). `context.Canceled` exits 0.
- **`--schema <file>`**: loads a JSON Schema, applies `ResponseJSONSchema` (strict) or `--schema-non-strict` for `ResponseJSONSchemaNonStrict`. Schema name derives from the filename. Validation errors (`ErrInvalidSchema`, `ErrStructuredOutputUnsupported`) map to `ExitValidation`.
- **Prompt sources**: positional arg (`iris chat "Hi"`) and stdin pipe (`echo "Hi" | iris chat`) now work alongside `--prompt`.
- **`--verbose`**: now prints token usage for non-streaming responses too; flag re-documented as "after each response".
- Fixed the fragile `--system` builder rebuild (single builder, system before user) and extracted `resolveClient`/`drainStream` helpers.

**`models.go`** (new) — `iris models [--provider]` lists the provider's static catalog as a table or `--json`; no API key required (catalog is static).

### Tests

18 new tests via a mock provider (`mockprovider_test.go`) covering:
- Schema strict / non-strict / strict-rejected
- REPL multi-turn history, EOF exit, system-message seeding
- `--timeout` cancellation → `ExitTimeout`
- `--verbose` non-streaming usage
- Positional arg and stdin pipe prompts
- `iris models` table / JSON / empty catalog / no-provider / keyless

### Verification

```
make lint      # gofmt clean, go vet clean
make build     # ok
go test ./cli/commands/ ./core/ ./tools/   # all pass
```

Smoke-tested the binary: `iris chat --help`, `iris models --provider openai`, `iris models --provider ollama --json`, `--schema` validation gate (fails fast on unsupported providers), piped-stdin prompt, and `-i` REPL with immediate EOF all behave as expected.

The only failing test in the repo (`TestNewKeystoreLegacyMode` in `cli/keystore`) is pre-existing on clean `main` (verified by stashing these changes) and unrelated to this issue.

### Out of scope

Mentioned in the issue body but not in the acceptance criteria: tools wiring, multimodal input flags, `--reasoning-effort`/built-in tool flags, and the `iris config`/`iris embed`/`iris image`/`iris keys export` commands. These can be addressed in follow-ups.

### Test notes

- [x] `make lint`, `make build` pass locally.
- [x] `go test ./cli/commands/ ./core/ ./tools/` passes.
- [ ] Integration tests: not run (no API keys); changes are CLI-only and covered by unit tests.