### PR TITLE
docs: reconcile OpenAI and Anthropic model tables with code

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -49,43 +49,60 @@ Perplexity additionally supports web-search grounding (`core.SearchOptions`, res
 
 **Authentication**: API key via `OPENAI_API_KEY` environment variable
 
-**API Types**:
-- Chat Completions API (GPT-4o, GPT-4, GPT-3.5 series)
-- Responses API (GPT-5.x, GPT-4.1, o-series models)
+**API Types**: the provider picks the route per model, from each model's
+`APIEndpoint`. The Route column below records which one applies.
+- Chat Completions API — GPT-4o, GPT-4, and GPT-3.5 series
+- Responses API — GPT-5.x, GPT-4.1, and o-series models; required for reasoning,
+  built-in tools, and response chaining
 
 **Models**:
 
-| Model | Display Name | Reasoning | Built-in Tools | Notes |
-|-------|--------------|-----------|----------------|-------|
-| gpt-5.4 | GPT-5.4 | Yes | Yes | Latest flagship |
-| gpt-5.4-pro | GPT-5.4 Pro | Yes | Yes | Enhanced capabilities |
-| gpt-5.4-mini | GPT-5.4 Mini | Yes | Yes | Smaller, faster |
-| gpt-5.4-nano | GPT-5.4 Nano | Yes | Yes | Lightweight |
-| gpt-5.2 | GPT-5.2 | Yes | Yes | |
-| gpt-5.2-pro | GPT-5.2 Pro | Yes | Yes | Enhanced capabilities |
-| gpt-5.2-codex | GPT-5.2 Codex | Yes | Yes | Code specialized |
-| gpt-5.1 | GPT-5.1 | Yes | Yes | |
-| gpt-5.1-codex | GPT-5.1 Codex | Yes | Yes | Code specialized |
-| gpt-5.1-codex-mini | GPT-5.1 Codex Mini | Yes | Yes | Smaller codex |
-| gpt-5.1-codex-max | GPT-5.1 Codex Max | Yes | Yes | Largest codex |
-| gpt-5 | GPT-5 | Yes | Yes | |
-| gpt-5-mini | GPT-5 Mini | Yes | Yes | Smaller, faster |
-| gpt-5-nano | GPT-5 Nano | No | Yes | Lightweight |
-| gpt-5-codex | GPT-5 Codex | Yes | Yes | Code specialized |
-| gpt-5-thinking | GPT-5 Thinking | Yes | Yes | Extended reasoning |
-| gpt-4.1 | GPT-4.1 | No | Yes | |
-| gpt-4.1-mini | GPT-4.1 Mini | No | Yes | |
-| gpt-4.1-nano | GPT-4.1 Nano | No | Yes | |
-| gpt-4o | GPT-4o | No | No | Multimodal |
-| gpt-4o-mini | GPT-4o Mini | No | No | Cost-effective |
-| o4-mini | o4-mini | Yes | Yes | Reasoning focused |
-| o4-mini-deep-research | o4-mini Deep Research | Yes | Yes | Research focused |
-| o3 | o3 | Yes | Yes | Reasoning focused |
-| o3-mini | o3-mini | Yes | Yes | Smaller reasoning |
-| o1 | o1 | Yes | No | Reasoning focused |
-| o1-pro | o1 Pro | Yes | No | Enhanced reasoning |
+| Model | Display Name | Route | Reasoning | Built-in Tools | Notes |
+|-------|--------------|-------|-----------|----------------|-------|
+| gpt-5.6 | GPT-5.6 | Responses | Yes | Yes | Latest flagship |
+| gpt-5.6-luna | GPT-5.6 Luna | Responses | Yes | Yes | GPT-5.6 variant |
+| gpt-5.6-sol | GPT-5.6 Sol | Responses | Yes | Yes | GPT-5.6 variant |
+| gpt-5.6-terra | GPT-5.6 Terra | Responses | Yes | Yes | GPT-5.6 variant |
+| gpt-5.5 | GPT-5.5 | Responses | Yes | Yes |  |
+| gpt-5.5-pro | GPT-5.5 Pro | Responses | Yes | Yes | Enhanced capabilities |
+| gpt-5.3-codex | GPT-5.3 Codex | Responses | Yes | Yes | Code specialized |
+| gpt-5.3-codex-spark | GPT-5.3 Codex Spark | Responses | Yes | Yes | Code specialized, lightweight |
+| gpt-5.4 | GPT-5.4 | Responses | Yes | Yes |  |
+| gpt-5.4-pro | GPT-5.4 Pro | Responses | Yes | Yes | Enhanced capabilities |
+| gpt-5.4-mini | GPT-5.4 Mini | Responses | Yes | Yes | Smaller, faster |
+| gpt-5.4-nano | GPT-5.4 Nano | Responses | Yes | Yes | Lightweight |
+| gpt-5.2 | GPT-5.2 | Responses | Yes | Yes |  |
+| gpt-5.2-pro | GPT-5.2 Pro | Responses | Yes | Yes | Enhanced capabilities |
+| gpt-5.2-codex | GPT-5.2 Codex | Responses | Yes | Yes | Code specialized |
+| gpt-5.1 | GPT-5.1 | Responses | Yes | Yes |  |
+| gpt-5.1-codex | GPT-5.1 Codex | Responses | Yes | Yes | Code specialized |
+| gpt-5.1-codex-mini | GPT-5.1 Codex Mini | Responses | Yes | Yes | Smaller codex |
+| gpt-5.1-codex-max | GPT-5.1 Codex Max | Responses | Yes | Yes | Largest codex |
+| gpt-5 | GPT-5 | Responses | Yes | Yes |  |
+| gpt-5-mini | GPT-5 Mini | Responses | Yes | Yes | Smaller, faster |
+| gpt-5-nano | GPT-5 Nano | Responses | No | Yes | Lightweight |
+| gpt-5-pro | GPT-5 Pro | Responses | Yes | Yes | Enhanced capabilities |
+| gpt-5-codex | GPT-5 Codex | Responses | Yes | Yes | Code specialized |
+| gpt-5-thinking | GPT-5 Thinking | Responses | Yes | Yes | Extended reasoning |
+| gpt-4.1 | GPT-4.1 | Responses | No | Yes |  |
+| gpt-4.1-mini | GPT-4.1 Mini | Responses | No | Yes |  |
+| gpt-4.1-nano | GPT-4.1 Nano | Responses | No | Yes |  |
+| gpt-4o | GPT-4o | Chat Completions | No | No | Multimodal |
+| gpt-4o-mini | GPT-4o Mini | Chat Completions | No | No | Cost-effective |
+| gpt-4-turbo | GPT-4 Turbo | Chat Completions | No | No | Legacy |
+| gpt-4 | GPT-4 | Chat Completions | No | No | Legacy |
+| gpt-3.5-turbo | GPT-3.5 Turbo | Chat Completions | No | No | Legacy; no structured output |
+| gpt-3.5-turbo-16k | GPT-3.5 Turbo 16k | Chat Completions | No | No | Legacy, 16K context |
+| gpt-3.5-turbo-instruct | GPT-3.5 Turbo Instruct | Chat Completions | No | No | Legacy; no tool calling |
+| o4-mini | o4-mini | Responses | Yes | Yes | Reasoning focused |
+| o4-mini-deep-research | o4-mini Deep Research | Responses | Yes | Yes | Research focused |
+| o3 | o3 | Responses | Yes | Yes | Reasoning focused |
+| o3-pro | o3-pro | Responses | Yes | Yes | Enhanced reasoning |
+| o3-mini | o3-mini | Responses | Yes | Yes | Smaller reasoning |
+| o1 | o1 | Responses | Yes | No | Reasoning focused |
+| o1-pro | o1 Pro | Responses | Yes | No | Enhanced reasoning |
 
-**Image Generation Models**: gpt-image-1.5, gpt-image-1, gpt-image-1-mini, dall-e-3, dall-e-2, chatgpt-image-latest
+**Image Generation Models**: gpt-image-2, gpt-image-1.5, gpt-image-1, gpt-image-1-mini, dall-e-3, dall-e-2, chatgpt-image-latest
 
 **Structured Output**: `ResponseJSONSchema` works on both the Chat Completions API and the Responses API (GPT-5.x), mapped to each API's native `response_format`/`text.format` shape respectively. Requesting it against a Chat Completions-only model that lacks `core.FeatureStructuredOutput` (e.g. gpt-3.5-turbo) fails with `core.ErrStructuredOutputUnsupported`.
 
@@ -113,7 +130,14 @@ resp, err := client.Chat(openai.ModelGPT4o).
 
 | Model | Display Name | Reasoning | Notes |
 |-------|--------------|-----------|-------|
-| claude-opus-4-7 | Claude Opus 4.7 | Yes | Latest flagship |
+| claude-opus-5 | Claude Opus 5 | Yes | Latest flagship |
+| claude-opus-5-thinking | Claude Opus 5 (Thinking) | Yes | Extended reasoning |
+| claude-sonnet-5 | Claude Sonnet 5 | Yes | Balanced performance |
+| claude-sonnet-5-thinking | Claude Sonnet 5 (Thinking) | Yes | Extended reasoning |
+| claude-fable-5 | Claude Fable 5 | Yes |  |
+| claude-opus-4-8 | Claude Opus 4.8 | Yes | High capability |
+| claude-opus-4-8-thinking | Claude Opus 4.8 (Thinking) | Yes | Extended reasoning |
+| claude-opus-4-7 | Claude Opus 4.7 | Yes | High capability |
 | claude-sonnet-4-6 | Claude Sonnet 4.6 | Yes | Balanced performance |
 | claude-sonnet-4-6-thinking | Claude Sonnet 4.6 (Thinking) | Yes | Extended reasoning |
 | claude-opus-4-6 | Claude Opus 4.6 | Yes | High capability |

--- a/docs/changes/2026-08-19_v0.18.0_readme-docs-restructure.md
+++ b/docs/changes/2026-08-19_v0.18.0_readme-docs-restructure.md
@@ -290,3 +290,112 @@ The assertion was not weakened. Verified by mutation:
 - **Fence balance**: every file has an even number of ``` fences.
 - **Build and tests**: `go build ./...`, `go vet ./...`, `gofmt -l .`, and
   `go test ./...` (23 packages) all pass on the final state.
+
+---
+
+## Revision: 2026-08-19T01:00Z
+
+Follow-up: the OpenAI and Anthropic model tables, listed under
+**Deferred / Out of Scope** above as unaudited, have now been reconciled against
+code. That deferral no longer applies — every model table in `docs/PROVIDERS.md`
+is now code-verified.
+
+### What Changed
+
+**`docs/PROVIDERS.md`** — OpenAI and Anthropic sections only.
+
+Both catalogs were diffed against their `Models()` output in each direction, and
+every documented Reasoning and Built-in Tools cell was compared against that
+model's `Capabilities`. Every cell already present was correct; all defects were
+omissions.
+
+New OpenAI rows (15 chat models):
+
+| Model | Route | Reasoning | Built-in Tools |
+|-------|-------|-----------|----------------|
+| `gpt-5.6` | Responses | Yes | Yes |
+| `gpt-5.6-luna` | Responses | Yes | Yes |
+| `gpt-5.6-sol` | Responses | Yes | Yes |
+| `gpt-5.6-terra` | Responses | Yes | Yes |
+| `gpt-5.5` | Responses | Yes | Yes |
+| `gpt-5.5-pro` | Responses | Yes | Yes |
+| `gpt-5.3-codex` | Responses | Yes | Yes |
+| `gpt-5.3-codex-spark` | Responses | Yes | Yes |
+| `gpt-5-pro` | Responses | Yes | Yes |
+| `o3-pro` | Responses | Yes | Yes |
+| `gpt-4-turbo` | Chat Completions | No | No |
+| `gpt-4` | Chat Completions | No | No |
+| `gpt-3.5-turbo` | Chat Completions | No | No |
+| `gpt-3.5-turbo-16k` | Chat Completions | No | No |
+| `gpt-3.5-turbo-instruct` | Chat Completions | No | No |
+
+The GPT-4 and GPT-3.5 series were named in the section's prose ("Chat Completions
+API (GPT-4o, GPT-4, GPT-3.5 series)") and referenced by the structured-output note
+(`gpt-3.5-turbo`), but had no table rows.
+
+New Anthropic rows (7 models, all `chat`, `chat_streaming`, `tool_calling`,
+`reasoning`): `claude-opus-5`, `claude-opus-5-thinking`, `claude-sonnet-5`,
+`claude-sonnet-5-thinking`, `claude-fable-5`, `claude-opus-4-8`,
+`claude-opus-4-8-thinking`.
+
+Other corrections:
+
+- `gpt-image-2` added to the OpenAI **Image Generation Models** list; it existed
+  in code and in `docs/guides/multimodal.md` but was missing here.
+- Stale "Latest flagship" notes moved: `gpt-5.4` → `gpt-5.6`, and
+  `claude-opus-4-7` → `claude-opus-5`.
+- The OpenAI **API Types** blurb now states that the route is selected per model
+  from each model's `APIEndpoint`, and that the Responses route is what enables
+  reasoning, built-in tools, and response chaining.
+
+### New Additions
+
+The OpenAI model table gained a **Route** column:
+
+```
+| Model | Display Name | Route | Reasoning | Built-in Tools | Notes |
+|-------|--------------|-------|-----------|----------------|-------|
+| gpt-5.6 | GPT-5.6 | Responses | Yes | Yes | Latest flagship |
+| gpt-4o | GPT-4o | Chat Completions | No | No | Multimodal |
+```
+
+`Route` is derived from `core.ModelInfo.GetAPIEndpoint()` — `Responses` for
+`core.APIEndpointResponses`, `Chat Completions` otherwise. It determines which
+request shape the provider builds and therefore whether reasoning, built-in
+tools, and response chaining are available for that model. Previously this was
+only described in prose above the table.
+
+### Modifications
+
+No Go source changed. No schema, CLI, API, or exported identifier changed.
+
+### Removals
+
+The **Deferred / Out of Scope** bullet stating that OpenAI and Anthropic were not
+audited is superseded by this revision. It is retained above as a record of the
+original scope.
+
+### Testing Notes
+
+Audit method: for each provider, the documented table was parsed out of
+`docs/PROVIDERS.md` and compared against `Models()` in both directions, then each
+Reasoning / Built-in Tools cell was checked against `ModelInfo.HasCapability`.
+
+Final state, all providers:
+
+| Provider | Models added | Cell mismatches | Now documented |
+|---|---|---|---|
+| OpenAI | 16 (15 chat + `gpt-image-2`) | 0 | 49 (42 chat + 7 image) |
+| Anthropic | 7 | 0 | 18 |
+| xAI | 3 | 0 | 15 |
+| Z.ai | 1 | 0 | 20 |
+| Gemini | 5 | 0 | 14 |
+| Perplexity | 0 | 0 | 4 (already accurate) |
+| Ollama | 1 (`codellama`) | 0 | 8 |
+
+No model is documented that does not exist in code. The final audit run reports
+zero problems for every provider.
+
+`go build ./...`, `go vet ./...`, `gofmt -l .`, and `go test ./...` (23 packages)
+all pass. `TestProvidersDocExists` and `TestProvidersDocMatrixAccuracy` pass
+against the updated file.


### PR DESCRIPTION
Follow-up to #88, which is now merged. That PR deferred the OpenAI and Anthropic
model tables as unaudited; this reconciles them against code, so every model table
in `docs/PROVIDERS.md` is now code-verified.

Documentation only. No Go source changed.

## Method

Both catalogs were diffed against their `Models()` output in each direction —
models in code but absent from the docs, and models documented but absent from
code — and every documented Reasoning / Built-in Tools cell was compared against
that model's `Capabilities`.

**Every cell already present was correct.** All defects were omissions.

## OpenAI

15 chat models added:

| Model | Route | Reasoning | Built-in Tools |
|-------|-------|-----------|----------------|
| `gpt-5.6` | Responses | Yes | Yes |
| `gpt-5.6-luna` | Responses | Yes | Yes |
| `gpt-5.6-sol` | Responses | Yes | Yes |
| `gpt-5.6-terra` | Responses | Yes | Yes |
| `gpt-5.5` | Responses | Yes | Yes |
| `gpt-5.5-pro` | Responses | Yes | Yes |
| `gpt-5.3-codex` | Responses | Yes | Yes |
| `gpt-5.3-codex-spark` | Responses | Yes | Yes |
| `gpt-5-pro` | Responses | Yes | Yes |
| `o3-pro` | Responses | Yes | Yes |
| `gpt-4-turbo` | Chat Completions | No | No |
| `gpt-4` | Chat Completions | No | No |
| `gpt-3.5-turbo` | Chat Completions | No | No |
| `gpt-3.5-turbo-16k` | Chat Completions | No | No |
| `gpt-3.5-turbo-instruct` | Chat Completions | No | No |

The GPT-4 and GPT-3.5 series were named in the section's own prose and referenced
by its structured-output note, but had no table rows at all.

`gpt-image-2` was also missing from the **Image Generation Models** list, despite
existing in code and appearing in `docs/guides/multimodal.md`.

## Anthropic

7 models added, all `chat` / `chat_streaming` / `tool_calling` / `reasoning`:
`claude-opus-5`, `claude-opus-5-thinking`, `claude-sonnet-5`,
`claude-sonnet-5-thinking`, `claude-fable-5`, `claude-opus-4-8`,
`claude-opus-4-8-thinking`.

## Other corrections

- Stale "Latest flagship" notes moved: `gpt-5.4` → `gpt-5.6`, and
  `claude-opus-4-7` → `claude-opus-5`.
- New **Route** column on the OpenAI table, derived from
  `ModelInfo.GetAPIEndpoint()`. The route determines whether reasoning, built-in
  tools, and response chaining are available for a model; it was previously only
  described in prose above the table.
- The OpenAI **API Types** blurb now says the route is chosen per model from that
  model's `APIEndpoint`.

## Final state across all providers

| Provider | Models added | Cell mismatches | Now documented |
|---|---|---|---|
| OpenAI | 16 (15 chat + `gpt-image-2`) | 0 | 49 (42 chat + 7 image) |
| Anthropic | 7 | 0 | 18 |
| xAI | 3 | 0 | 15 |
| Z.ai | 1 | 0 | 20 |
| Gemini | 5 | 0 | 14 |
| Perplexity | 0 | 0 | 4 (already accurate) |
| Ollama | 1 (`codellama`) | 0 | 8 |

No model is documented that does not exist in code.

## Notes

The change record is appended to the existing
`docs/changes/2026-08-19_v0.18.0_readme-docs-restructure.md` as a
`## Revision:` section rather than edited inline, per the repository
documentation policy for iterative work on an existing feature doc. That file's
diff is purely additive.

`go build ./...`, `go vet ./...`, `gofmt -l .`, and `go test ./...` (23 packages)
all pass, including `TestProvidersDocExists` and `TestProvidersDocMatrixAccuracy`.
