### PR TITLE
docs: fix non-compiling example snippets

### DIFF
--- a/core/doc.go
+++ b/core/doc.go
@@ -148,11 +148,11 @@
 //
 // Configure retry behavior with [RetryPolicy]:
 //
-//	policy := &core.ExponentialBackoff{
-//	    MaxRetries:  3,
-//	    BaseDelay:   time.Second,
-//	    MaxDelay:    30 * time.Second,
-//	}
+//	policy := core.NewRetryPolicy(core.RetryConfig{
+//	    MaxRetries: 3,
+//	    BaseDelay:  time.Second,
+//	    MaxDelay:   30 * time.Second,
+//	})
 //	client := core.NewClient(provider, core.WithRetryPolicy(policy))
 //
 // The default policy retries transient errors (rate limits, server errors) with

--- a/docs/guides/provider-quickstarts.md
+++ b/docs/guides/provider-quickstarts.md
@@ -90,8 +90,8 @@ resp, err := client.Chat("gemini-2.5-pro").
     GetResponse(ctx)
 
 // Access reasoning if available
-if resp.Reasoning != nil && resp.Reasoning.Output != "" {
-    fmt.Println("Thinking:", resp.Reasoning.Output)
+if resp.Reasoning != nil && len(resp.Reasoning.Summary) > 0 {
+    fmt.Println("Thinking:", resp.Reasoning.Summary[0])
 }
 ```
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -10,8 +10,8 @@ import "github.com/petal-labs/iris/testing"
 
 // MockProvider for predictable responses
 mock := testing.NewMockProvider().
-    WithResponse("Hello!").
-    WithResponse("Follow-up response")
+    WithResponse(core.ChatResponse{Output: "Hello!"}).
+    WithResponse(core.ChatResponse{Output: "Follow-up response"})
 
 client := core.NewClient(mock)
 resp, _ := client.Chat("any-model").User("Hi").GetResponse(ctx)
@@ -24,7 +24,7 @@ client := core.NewClient(recorder)
 // ... run your code ...
 
 // Inspect recorded calls
-for _, call := range recorder.Calls() {
+for _, call := range recorder.Recordings() {
     fmt.Printf("Model: %s, Messages: %d\n", call.Request.Model, len(call.Request.Messages))
 }
 ```

--- a/iris.go
+++ b/iris.go
@@ -40,7 +40,7 @@ var ErrNoAPIKey = errors.New("no API key found in environment")
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
-//	resp, _ := client.Chat("gpt-4o").User("Hello!").Send(ctx)
+//	resp, _ := client.Chat("gpt-4o").User("Hello!").GetResponse(ctx)
 func OpenAI() (*core.Client, error) {
 	provider, err := openai.NewFromEnv()
 	if err != nil {
@@ -57,7 +57,7 @@ func OpenAI() (*core.Client, error) {
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
-//	resp, _ := client.Chat("claude-sonnet-4-5").User("Hello!").Send(ctx)
+//	resp, _ := client.Chat("claude-sonnet-4-5").User("Hello!").GetResponse(ctx)
 func Anthropic() (*core.Client, error) {
 	provider, err := anthropic.NewFromEnv()
 	if err != nil {
@@ -74,7 +74,7 @@ func Anthropic() (*core.Client, error) {
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
-//	resp, _ := client.Chat("gemini-2.5-flash").User("Hello!").Send(ctx)
+//	resp, _ := client.Chat("gemini-2.5-flash").User("Hello!").GetResponse(ctx)
 func Gemini() (*core.Client, error) {
 	provider, err := gemini.NewFromEnv()
 	if err != nil {
@@ -91,7 +91,7 @@ func Gemini() (*core.Client, error) {
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
-//	resp, _ := client.Chat("grok-2").User("Hello!").Send(ctx)
+//	resp, _ := client.Chat("grok-2").User("Hello!").GetResponse(ctx)
 func XAI() (*core.Client, error) {
 	provider, err := xai.NewFromEnv()
 	if err != nil {
@@ -109,7 +109,7 @@ func XAI() (*core.Client, error) {
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
-//	resp, _ := client.Chat("llama3.2").User("Hello!").Send(ctx)
+//	resp, _ := client.Chat("llama3.2").User("Hello!").GetResponse(ctx)
 func Ollama() (*core.Client, error) {
 	provider := ollama.New()
 	return core.NewClient(provider), nil

--- a/tests/docs_test.go
+++ b/tests/docs_test.go
@@ -428,3 +428,96 @@ func readCoreDocFile(t *testing.T) string {
 
 	return string(content)
 }
+
+// TestDocSnippetsNoBrokenAPIs scans Go code in doc comments (iris.go,
+// core/doc.go) and markdown guides for API references that do not exist in
+// the current SDK, so documentation cannot silently drift from the code.
+//
+// Each check targets a specific class of broken reference previously merged
+// (issue #63). The scan is regex-based rather than a full compile because doc
+// snippets deliberately omit package declarations, imports, and context
+// setup; a compile pass would require scaffolding each fragment, while these
+// targeted guards catch the high-risk seams at low maintenance cost.
+func TestDocSnippetsNoBrokenAPIs(t *testing.T) {
+	sources := docSnippetSources(t)
+
+	type check struct {
+		name    string
+		pattern *regexp.Regexp
+	}
+	checks := []check{
+		{
+			name:    "ChatBuilder has no Send method (use GetResponse)",
+			pattern: regexp.MustCompile(`\.User\([^)]*\)\.Send\(`),
+		},
+		{
+			name:    "exponentialBackoff is unexported (use NewRetryPolicy)",
+			pattern: regexp.MustCompile(`(core\.)?ExponentialBackoff\{`),
+		},
+		{
+			name:    "ReasoningOutput has no Output field (use Summary)",
+			pattern: regexp.MustCompile(`\.Reasoning\.Output\b`),
+		},
+		{
+			name:    "WithResponse takes core.ChatResponse not a string",
+			pattern: regexp.MustCompile(`WithResponse\(\s*"`),
+		},
+		{
+			name:    "RecordingProvider has Recordings not Calls",
+			pattern: regexp.MustCompile(`recorder\.Calls\(\)`),
+		},
+	}
+
+	for _, src := range sources {
+		for _, c := range checks {
+			if loc := c.pattern.FindStringIndex(src.content); loc != nil {
+				line := strings.Count(src.content[:loc[0]], "\n") + 1
+				t.Errorf("%s:%d: %s", src.path, line, c.name)
+			}
+		}
+	}
+}
+
+type docSource struct {
+	path    string
+	content string
+}
+
+// docSnippetSources collects the files whose Go snippets are checked for
+// broken API references: the convenience-package doc comments, the core
+// package doc, and every markdown guide under docs/guides/.
+func docSnippetSources(t *testing.T) []docSource {
+	t.Helper()
+
+	var sources []docSource
+
+	// iris.go and core/doc.go carry illustrative snippets in their package
+	// doc comments.
+	for _, rel := range []string{filepath.Join("..", "iris.go"), filepath.Join("..", "core", "doc.go")} {
+		content, err := os.ReadFile(rel)
+		if err != nil {
+			t.Fatalf("Failed to read %s: %v", rel, err)
+		}
+		sources = append(sources, docSource{path: rel, content: string(content)})
+	}
+
+	// Markdown guides.
+	guidesDir := filepath.Join("..", "docs", "guides")
+	entries, err := os.ReadDir(guidesDir)
+	if err != nil {
+		t.Fatalf("Failed to read docs/guides: %v", err)
+	}
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		p := filepath.Join(guidesDir, e.Name())
+		content, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("Failed to read %s: %v", p, err)
+		}
+		sources = append(sources, docSource{path: p, content: string(content)})
+	}
+
+	return sources
+}


### PR DESCRIPTION
## Summary

Closes #63. Fixes five classes of broken API references in doc comments and markdown guides, and adds a regression guard so docs cannot silently drift from the code again.

### Acceptance criteria

- [x] All godoc examples compile (verified against current signatures)
- [x] README/guide snippets verified against current signatures
- [x] CI docs check extended (`TestDocSnippetsNoBrokenAPIs` in `tests/docs_test.go`)

### Changes

| Location | Before | After | Why |
|---|---|---|---|
| `iris.go` (×5) | `client.Chat(model).User("...").Send(ctx)` | `…GetResponse(ctx)` | `ChatBuilder` has no `Send` method |
| `core/doc.go` | `&core.ExponentialBackoff{…}` | `core.NewRetryPolicy(core.RetryConfig{…})` | `exponentialBackoff` is unexported (`core/retry.go:55`) |
| `docs/guides/provider-quickstarts.md` | `resp.Reasoning.Output` | `resp.Reasoning.Summary[0]` | `ReasoningOutput` has only `ID` and `Summary` (`core/types.go:77-80`); matches the xAI/Z.ai pattern already used |
| `docs/guides/testing.md` | `WithResponse("Hello!")` | `WithResponse(core.ChatResponse{Output: "Hello!"})` | `WithResponse` takes `core.ChatResponse`, not a string (`testing/mock_provider.go:107`) |
| `docs/guides/testing.md` | `recorder.Calls()` | `recorder.Recordings()` | `RecordingProvider` exposes `Recordings()`, not `Calls()` (`testing/recording_provider.go:98`); `Calls()` exists only on `MockProvider` |

### Regression guard

`TestDocSnippetsNoBrokenAPIs` scans `iris.go`, `core/doc.go`, and every `docs/guides/*.md` for the five broken-API patterns above and reports the offending file:line. Verified it catches regressions: temporarily re-introduced `WithResponse("oops")` → the test failed with `docs/guides/testing.md:37: WithResponse takes core.ChatResponse not a string`; restored → passed.

The scan is regex-based rather than a full compile because doc snippets deliberately omit package declarations, imports, and context setup; scaffolding each fragment would be high-maintenance, while these targeted guards catch the high-risk seams.

### Verification

```
make lint      # gofmt clean, go vet clean
make build     # ok
go test ./tests/ -run TestDocSnippetsNoBrokenAPIs -v   # PASS
go test ./...  # all pass except pre-existing TestNewKeystoreLegacyMode (unrelated)
```

### Test notes

- [x] `make lint`, `make build` pass locally.
- [x] `go test ./...` passes (except the pre-existing `TestNewKeystoreLegacyMode` in `cli/keystore`, which fails on clean `main` and is unrelated to this issue).
- [ ] Integration tests: not run (docs-only change).