### PR TITLE
fix(providers): GetModelInfo returns copies, not shared registry pointers

### DIFF
--- a/internal/gen/models/generator.go
+++ b/internal/gen/models/generator.go
@@ -268,8 +268,20 @@ func buildModelRegistry() map[core.ModelID]*core.ModelInfo {
 	return registry
 }
 
-// GetModelInfo returns the ModelInfo for a given model ID, or nil if not found.
+// GetModelInfo returns a copy of the ModelInfo for a given model ID, or nil
+// if not found. The returned pointer references a fresh copy whose fields
+// (including the Capabilities slice) do not alias the package's static
+// catalog, so mutating it cannot affect subsequent GetModelInfo or Models calls.
 func GetModelInfo(id core.ModelID) *core.ModelInfo {
-	return modelRegistry[id]
+	m, ok := modelRegistry[id]
+	if !ok {
+		return nil
+	}
+	cp := *m
+	if caps := cp.Capabilities; caps != nil {
+		cp.Capabilities = make([]core.Feature, len(caps))
+		copy(cp.Capabilities, caps)
+	}
+	return &cp
 }
 `))

--- a/providers/anthropic/models.go
+++ b/providers/anthropic/models.go
@@ -237,7 +237,19 @@ func buildModelRegistry() map[core.ModelID]*core.ModelInfo {
 	return registry
 }
 
-// GetModelInfo returns the ModelInfo for a given model ID, or nil if not found.
+// GetModelInfo returns a copy of the ModelInfo for a given model ID, or nil
+// if not found. The returned pointer references a fresh copy whose fields
+// (including the Capabilities slice) do not alias the package's static
+// catalog, so mutating it cannot affect subsequent GetModelInfo or Models calls.
 func GetModelInfo(id core.ModelID) *core.ModelInfo {
-	return modelRegistry[id]
+	m, ok := modelRegistry[id]
+	if !ok {
+		return nil
+	}
+	cp := *m
+	if caps := cp.Capabilities; caps != nil {
+		cp.Capabilities = make([]core.Feature, len(caps))
+		copy(cp.Capabilities, caps)
+	}
+	return &cp
 }

--- a/providers/azurefoundry/models.go
+++ b/providers/azurefoundry/models.go
@@ -482,12 +482,21 @@ var models = []core.ModelInfo{
 	},
 }
 
-// GetModelInfo returns the model info for a given model ID, or nil if not found.
+// GetModelInfo returns a copy of the model info for a given model ID, or nil
+// if not found. The returned pointer references a fresh copy whose fields
+// (including the Capabilities slice) do not alias the package's static
+// catalog, so mutating it cannot affect subsequent GetModelInfo or Models calls.
 func GetModelInfo(id core.ModelID) *core.ModelInfo {
 	for i := range models {
-		if models[i].ID == id {
-			return &models[i]
+		if models[i].ID != id {
+			continue
 		}
+		cp := models[i]
+		if caps := cp.Capabilities; caps != nil {
+			cp.Capabilities = make([]core.Feature, len(caps))
+			copy(cp.Capabilities, caps)
+		}
+		return &cp
 	}
 	return nil
 }

--- a/providers/gemini/models.go
+++ b/providers/gemini/models.go
@@ -192,9 +192,21 @@ func buildModelRegistry() map[core.ModelID]*core.ModelInfo {
 	return registry
 }
 
-// GetModelInfo returns the ModelInfo for a given model ID, or nil if not found.
+// GetModelInfo returns a copy of the ModelInfo for a given model ID, or nil
+// if not found. The returned pointer references a fresh copy whose fields
+// (including the Capabilities slice) do not alias the package's static
+// catalog, so mutating it cannot affect subsequent GetModelInfo or Models calls.
 func GetModelInfo(id core.ModelID) *core.ModelInfo {
-	return modelRegistry[id]
+	m, ok := modelRegistry[id]
+	if !ok {
+		return nil
+	}
+	cp := *m
+	if caps := cp.Capabilities; caps != nil {
+		cp.Capabilities = make([]core.Feature, len(caps))
+		copy(cp.Capabilities, caps)
+	}
+	return &cp
 }
 
 // isGemini3Model returns true if the model is a Gemini 3 series model.

--- a/providers/openai/models.go
+++ b/providers/openai/models.go
@@ -714,7 +714,19 @@ func buildModelRegistry() map[core.ModelID]*core.ModelInfo {
 	return registry
 }
 
-// GetModelInfo returns the ModelInfo for a given model ID, or nil if not found.
+// GetModelInfo returns a copy of the ModelInfo for a given model ID, or nil
+// if not found. The returned pointer references a fresh copy whose fields
+// (including the Capabilities slice) do not alias the package's static
+// catalog, so mutating it cannot affect subsequent GetModelInfo or Models calls.
 func GetModelInfo(id core.ModelID) *core.ModelInfo {
-	return modelRegistry[id]
+	m, ok := modelRegistry[id]
+	if !ok {
+		return nil
+	}
+	cp := *m
+	if caps := cp.Capabilities; caps != nil {
+		cp.Capabilities = make([]core.Feature, len(caps))
+		copy(cp.Capabilities, caps)
+	}
+	return &cp
 }

--- a/providers/perplexity/models.go
+++ b/providers/perplexity/models.go
@@ -76,7 +76,19 @@ func buildModelRegistry() map[core.ModelID]*core.ModelInfo {
 	return registry
 }
 
-// GetModelInfo returns the ModelInfo for a given model ID, or nil if not found.
+// GetModelInfo returns a copy of the ModelInfo for a given model ID, or nil
+// if not found. The returned pointer references a fresh copy whose fields
+// (including the Capabilities slice) do not alias the package's static
+// catalog, so mutating it cannot affect subsequent GetModelInfo or Models calls.
 func GetModelInfo(id core.ModelID) *core.ModelInfo {
-	return modelRegistry[id]
+	m, ok := modelRegistry[id]
+	if !ok {
+		return nil
+	}
+	cp := *m
+	if caps := cp.Capabilities; caps != nil {
+		cp.Capabilities = make([]core.Feature, len(caps))
+		copy(cp.Capabilities, caps)
+	}
+	return &cp
 }

--- a/providers/voyageai/models.go
+++ b/providers/voyageai/models.go
@@ -152,7 +152,19 @@ func buildModelRegistry() map[core.ModelID]*core.ModelInfo {
 	return registry
 }
 
-// GetModelInfo returns the ModelInfo for a given model ID, or nil if not found.
+// GetModelInfo returns a copy of the ModelInfo for a given model ID, or nil
+// if not found. The returned pointer references a fresh copy whose fields
+// (including the Capabilities slice) do not alias the package's static
+// catalog, so mutating it cannot affect subsequent GetModelInfo or Models calls.
 func GetModelInfo(id core.ModelID) *core.ModelInfo {
-	return modelRegistry[id]
+	m, ok := modelRegistry[id]
+	if !ok {
+		return nil
+	}
+	cp := *m
+	if caps := cp.Capabilities; caps != nil {
+		cp.Capabilities = make([]core.Feature, len(caps))
+		copy(cp.Capabilities, caps)
+	}
+	return &cp
 }

--- a/providers/xai/models.go
+++ b/providers/xai/models.go
@@ -221,7 +221,19 @@ func buildModelRegistry() map[core.ModelID]*core.ModelInfo {
 	return registry
 }
 
-// GetModelInfo returns the ModelInfo for a given model ID, or nil if not found.
+// GetModelInfo returns a copy of the ModelInfo for a given model ID, or nil
+// if not found. The returned pointer references a fresh copy whose fields
+// (including the Capabilities slice) do not alias the package's static
+// catalog, so mutating it cannot affect subsequent GetModelInfo or Models calls.
 func GetModelInfo(id core.ModelID) *core.ModelInfo {
-	return modelRegistry[id]
+	m, ok := modelRegistry[id]
+	if !ok {
+		return nil
+	}
+	cp := *m
+	if caps := cp.Capabilities; caps != nil {
+		cp.Capabilities = make([]core.Feature, len(caps))
+		copy(cp.Capabilities, caps)
+	}
+	return &cp
 }

--- a/providers/zai/models.go
+++ b/providers/zai/models.go
@@ -270,7 +270,19 @@ func buildModelRegistry() map[core.ModelID]*core.ModelInfo {
 	return registry
 }
 
-// GetModelInfo returns the ModelInfo for a given model ID, or nil if not found.
+// GetModelInfo returns a copy of the ModelInfo for a given model ID, or nil
+// if not found. The returned pointer references a fresh copy whose fields
+// (including the Capabilities slice) do not alias the package's static
+// catalog, so mutating it cannot affect subsequent GetModelInfo or Models calls.
 func GetModelInfo(id core.ModelID) *core.ModelInfo {
-	return modelRegistry[id]
+	m, ok := modelRegistry[id]
+	if !ok {
+		return nil
+	}
+	cp := *m
+	if caps := cp.Capabilities; caps != nil {
+		cp.Capabilities = make([]core.Feature, len(caps))
+		copy(cp.Capabilities, caps)
+	}
+	return &cp
 }

--- a/tests/getmodelinfo_test.go
+++ b/tests/getmodelinfo_test.go
@@ -5,16 +5,6 @@ import (
 
 	"github.com/petal-labs/iris/core"
 	"github.com/petal-labs/iris/providers"
-	_ "github.com/petal-labs/iris/providers/anthropic"
-	_ "github.com/petal-labs/iris/providers/azurefoundry"
-	_ "github.com/petal-labs/iris/providers/gemini"
-	_ "github.com/petal-labs/iris/providers/ollama"
-	_ "github.com/petal-labs/iris/providers/openai"
-	_ "github.com/petal-labs/iris/providers/perplexity"
-	_ "github.com/petal-labs/iris/providers/voyageai"
-	_ "github.com/petal-labs/iris/providers/xai"
-	_ "github.com/petal-labs/iris/providers/zai"
-
 	"github.com/petal-labs/iris/providers/anthropic"
 	"github.com/petal-labs/iris/providers/azurefoundry"
 	"github.com/petal-labs/iris/providers/gemini"

--- a/tests/getmodelinfo_test.go
+++ b/tests/getmodelinfo_test.go
@@ -1,0 +1,154 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers"
+	_ "github.com/petal-labs/iris/providers/anthropic"
+	_ "github.com/petal-labs/iris/providers/azurefoundry"
+	_ "github.com/petal-labs/iris/providers/gemini"
+	_ "github.com/petal-labs/iris/providers/ollama"
+	_ "github.com/petal-labs/iris/providers/openai"
+	_ "github.com/petal-labs/iris/providers/perplexity"
+	_ "github.com/petal-labs/iris/providers/voyageai"
+	_ "github.com/petal-labs/iris/providers/xai"
+	_ "github.com/petal-labs/iris/providers/zai"
+
+	"github.com/petal-labs/iris/providers/anthropic"
+	"github.com/petal-labs/iris/providers/azurefoundry"
+	"github.com/petal-labs/iris/providers/gemini"
+	"github.com/petal-labs/iris/providers/openai"
+	"github.com/petal-labs/iris/providers/perplexity"
+	"github.com/petal-labs/iris/providers/voyageai"
+	"github.com/petal-labs/iris/providers/xai"
+	"github.com/petal-labs/iris/providers/zai"
+)
+
+// TestGetModelInfoMutationIsolation verifies that GetModelInfo in every
+// provider returns an independent copy: mutating the returned pointer must
+// not corrupt the package's static catalog, so subsequent GetModelInfo and
+// Models calls still see the original values. Regression guard for issue #64.
+func TestGetModelInfoMutationIsolation(t *testing.T) {
+	tests := []struct {
+		name         string
+		providerID   string // registry ID, for constructing a provider to call Models()
+		getModelInfo func(core.ModelID) *core.ModelInfo
+		id           core.ModelID
+	}{
+		{"openai", "openai", openai.GetModelInfo, openai.ModelGPT56},
+		{"anthropic", "anthropic", anthropic.GetModelInfo, anthropic.ModelClaudeOpus5},
+		{"gemini", "gemini", gemini.GetModelInfo, gemini.ModelGemini36Flash},
+		{"xai", "xai", xai.GetModelInfo, xai.ModelGrok45},
+		{"zai", "zai", zai.GetModelInfo, zai.ModelGLM52},
+		{"perplexity", "perplexity", perplexity.GetModelInfo, perplexity.ModelSonar},
+		{"voyageai", "voyageai", voyageai.GetModelInfo, voyageai.ModelVoyage4Large},
+		{"azurefoundry", "azurefoundry", azurefoundry.GetModelInfo, "gpt-4o"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Snapshot the original values from a fresh GetModelInfo call.
+			orig := tt.getModelInfo(tt.id)
+			if orig == nil {
+				t.Fatalf("GetModelInfo(%q) = nil, want non-nil", tt.id)
+			}
+			origDisplayName := orig.DisplayName
+			origID := orig.ID
+			origCapabilities := make([]core.Feature, len(orig.Capabilities))
+			copy(origCapabilities, orig.Capabilities)
+
+			// Mutate the returned pointer aggressively: scalar fields and the
+			// Capabilities slice (both element assignment and append).
+			mut := tt.getModelInfo(tt.id)
+			if mut == nil {
+				t.Fatalf("GetModelInfo(%q) = nil on second call", tt.id)
+			}
+			mut.DisplayName = "HACKED"
+			mut.ID = "HACKED-ID"
+			if len(mut.Capabilities) > 0 {
+				mut.Capabilities[0] = core.FeatureImageGeneration // overwrite an element
+			}
+			mut.Capabilities = append(mut.Capabilities, core.FeatureReranking)
+
+			// Subsequent GetModelInfo must return the original, uncorrupted values.
+			after := tt.getModelInfo(tt.id)
+			if after == nil {
+				t.Fatalf("GetModelInfo(%q) = nil on third call", tt.id)
+			}
+			if after.DisplayName != origDisplayName {
+				t.Errorf("DisplayName after mutation = %q, want %q (static catalog corrupted)", after.DisplayName, origDisplayName)
+			}
+			if after.ID != origID {
+				t.Errorf("ID after mutation = %q, want %q (static catalog corrupted)", after.ID, origID)
+			}
+			if !equalFeatures(after.Capabilities, origCapabilities) {
+				t.Errorf("Capabilities after mutation = %v, want %v (static catalog corrupted)", after.Capabilities, origCapabilities)
+			}
+
+			// Models() must also return the original, uncorrupted values.
+			provider, err := providers.Create(tt.providerID, "test-key")
+			if err != nil {
+				t.Fatalf("providers.Create(%q) error = %v", tt.providerID, err)
+			}
+			for _, m := range provider.Models() {
+				if m.ID != tt.id {
+					continue
+				}
+				if m.DisplayName != origDisplayName {
+					t.Errorf("Models() DisplayName = %q, want %q (static catalog corrupted)", m.DisplayName, origDisplayName)
+				}
+				if !equalFeatures(m.Capabilities, origCapabilities) {
+					t.Errorf("Models() Capabilities = %v, want %v (static catalog corrupted)", m.Capabilities, origCapabilities)
+				}
+				return
+			}
+			t.Errorf("Models() did not return model %q", tt.id)
+		})
+	}
+}
+
+// TestGetModelInfoReturnedPointersAreDistinct verifies that repeated calls
+// to GetModelInfo return distinct pointers, so callers cannot accidentally
+// share mutable state with each other. Regression guard for issue #64.
+func TestGetModelInfoReturnedPointersAreDistinct(t *testing.T) {
+	tests := []struct {
+		name         string
+		getModelInfo func(core.ModelID) *core.ModelInfo
+		id           core.ModelID
+	}{
+		{"openai", openai.GetModelInfo, openai.ModelGPT56},
+		{"anthropic", anthropic.GetModelInfo, anthropic.ModelClaudeOpus5},
+		{"gemini", gemini.GetModelInfo, gemini.ModelGemini36Flash},
+		{"xai", xai.GetModelInfo, xai.ModelGrok45},
+		{"zai", zai.GetModelInfo, zai.ModelGLM52},
+		{"perplexity", perplexity.GetModelInfo, perplexity.ModelSonar},
+		{"voyageai", voyageai.GetModelInfo, voyageai.ModelVoyage4Large},
+		{"azurefoundry", azurefoundry.GetModelInfo, "gpt-4o"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := tt.getModelInfo(tt.id)
+			b := tt.getModelInfo(tt.id)
+			if a == nil || b == nil {
+				t.Fatalf("GetModelInfo(%q) = nil", tt.id)
+			}
+			if a == b {
+				t.Errorf("GetModelInfo returned the same pointer on repeated calls; callers may share mutable state")
+			}
+		})
+	}
+}
+
+func equalFeatures(a, b []core.Feature) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Closes #64. `GetModelInfo` in all 8 provider packages returned a pointer into the package-level static model registry, so any caller mutation corrupted global state for the whole process:

```go
mi := openai.GetModelInfo(openai.ModelGPT56)
mi.DisplayName = "hacked" // mutates the shared static catalog for every future call
```

`Models()` was already copy-safe (returns a fresh slice); only `GetModelInfo` was dangerous.

### Acceptance criteria

- [x] Mutating the result of `GetModelInfo` in any provider does not affect subsequent `GetModelInfo`/`Models` calls
- [x] Regression test that exercises this per provider (table-driven over all 8 packages)

### Fix

Copy the struct and deep-copy its `Capabilities` slice before returning a pointer. The signature stays `func GetModelInfo(id core.ModelID) *core.ModelInfo` so this is **non-breaking** (option 2 from the issue, chosen for the `api-stability` label).

| Provider | Pattern | File |
|---|---|---|
| openai, xai, zai, anthropic, gemini, perplexity, voyageai | registry-map | `providers/<p>/models.go` |
| azurefoundry | linear-scan | `providers/azurefoundry/models.go` |

The `internal/gen/models/generator.go` template is also updated so future regeneration produces safe code.

### Regression tests (`tests/getmodelinfo_test.go`)

Table-driven over all 8 providers:
- `TestGetModelInfoMutationIsolation` — mutates the returned pointer's `DisplayName`, `ID`, and `Capabilities` (both element assignment and append), then verifies subsequent `GetModelInfo` and `Models()` calls return the original uncorrupted values.
- `TestGetModelInfoReturnedPointersAreDistinct` — verifies repeated calls return distinct pointers, so callers cannot accidentally share mutable state with each other.

Verified the guards catch the old bug: temporarily reverted `openai` → both tests failed with clear corruption diagnostics (`DisplayName after mutation = "HACKED"`, `returned the same pointer on repeated calls`); restored → pass.

### Verification

```
make lint      # gofmt clean, go vet clean
make build     # ok
go test ./...  # all pass except pre-existing TestNewKeystoreLegacyMode (unrelated)
```

### Test notes

- [x] `make lint`, `make build` pass locally.
- [x] `go test ./...` passes (except the pre-existing `TestNewKeystoreLegacyMode` in `cli/keystore`, which fails on clean `main` and is unrelated to this issue).
- [ ] Integration tests: not run (pure in-process change; covered by unit tests).