### PR TITLE
[codex] Normalize provider error classification

### DIFF
--- a/core/doc.go
+++ b/core/doc.go
@@ -118,9 +118,11 @@
 //   - [ErrUnauthorized]: Invalid or missing API key
 //   - [ErrRateLimited]: Provider rate limit exceeded
 //   - [ErrBadRequest]: Invalid request parameters
+//   - [ErrNotFound]: Requested provider resource was not found
 //   - [ErrServer]: Provider server error (5xx)
 //   - [ErrNetwork]: Network connectivity issues
 //   - [ErrDecode]: Response parsing failed
+//   - [ErrNilStream]: A nil stream was passed to [DrainStream]
 //   - [ErrModelRequired]: Model ID not specified
 //   - [ErrNoMessages]: No messages in request
 //

--- a/core/errors.go
+++ b/core/errors.go
@@ -49,10 +49,13 @@ var (
 	ErrNotSupported = errors.New("operation not supported")
 )
 
+// ErrNilStream indicates that DrainStream was called without a stream.
+var ErrNilStream = errors.New("nil chat stream")
+
 // Batch processing errors.
 var (
 	ErrBatchTimeout   = errors.New("batch processing timed out")
-	ErrBatchNotFound  = errors.New("batch not found")
+	ErrBatchNotFound  = fmt.Errorf("batch %w", ErrNotFound)
 	ErrBatchCancelled = errors.New("batch was cancelled")
 )
 

--- a/core/errors_test.go
+++ b/core/errors_test.go
@@ -108,6 +108,12 @@ func TestErrNotFound(t *testing.T) {
 	}
 }
 
+func TestErrBatchNotFoundClassifiesAsNotFound(t *testing.T) {
+	if !errors.Is(ErrBatchNotFound, ErrNotFound) {
+		t.Errorf("ErrBatchNotFound = %v, want ErrNotFound classification", ErrBatchNotFound)
+	}
+}
+
 func TestProviderErrorUnwrapsNotFound(t *testing.T) {
 	err := &ProviderError{
 		Provider: "test",

--- a/core/retry.go
+++ b/core/retry.go
@@ -13,6 +13,8 @@ type RetryPolicy interface {
 	// NextDelay returns the delay before the next retry attempt and whether to retry.
 	// If ok is false, no more retries should be attempted.
 	// attempt starts at 0 for the first retry after the initial failure.
+	// The default policy retries only errors explicitly classified as transient;
+	// custom policies may opt into retrying additional error types.
 	NextDelay(attempt int, err error) (delay time.Duration, ok bool)
 }
 
@@ -26,6 +28,8 @@ type RetryConfig struct {
 
 // DefaultRetryPolicy returns a retry policy with sensible defaults.
 // Uses exponential backoff with jitter, max 3 retries, 30s max delay.
+// It retries network, rate-limit, and server errors (including HTTP 429 and
+// 5xx provider errors). Unknown errors are not retried by default.
 func DefaultRetryPolicy() RetryPolicy {
 	return NewRetryPolicy(RetryConfig{
 		MaxRetries: 3,

--- a/core/streaming.go
+++ b/core/streaming.go
@@ -29,6 +29,7 @@ type ChatStream struct {
 
 // DrainStream accumulates all deltas and returns the final ChatResponse.
 // Blocks until stream completes or context cancels.
+// Returns [ErrNilStream] when s is nil.
 //
 // Behavior:
 //  1. Read all chunks from Ch, accumulating Delta into output string
@@ -44,7 +45,7 @@ type ChatStream struct {
 //     context error, then return ctx.Err().
 func DrainStream(ctx context.Context, s *ChatStream) (*ChatResponse, error) {
 	if s == nil {
-		return nil, ErrBadRequest
+		return nil, ErrNilStream
 	}
 
 	var accumulated strings.Builder

--- a/core/streaming_test.go
+++ b/core/streaming_test.go
@@ -175,8 +175,11 @@ func TestDrainStreamToolCallsPreserved(t *testing.T) {
 
 func TestDrainStreamNilStream(t *testing.T) {
 	_, err := DrainStream(context.Background(), nil)
-	if !errors.Is(err, ErrBadRequest) {
-		t.Errorf("err = %v, want ErrBadRequest", err)
+	if !errors.Is(err, ErrNilStream) {
+		t.Errorf("err = %v, want ErrNilStream", err)
+	}
+	if errors.Is(err, ErrBadRequest) {
+		t.Errorf("err = %v, must not report a provider bad request", err)
 	}
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -266,6 +266,13 @@ func isRetryable(err error) bool {
 }
 ```
 
+The default policy is intentionally classification-based: network failures,
+rate limits, and server failures are retried, while cancellation, timeouts,
+authentication, bad requests, not-found responses, decode failures, and
+unknown errors are not. This avoids replaying requests when an undecorated
+error has unclear side effects. Applications that can safely retry additional
+error types can supply a custom `RetryPolicy` with `core.WithRetryPolicy`.
+
 ---
 
 ## Default Execution Timeout

--- a/providers/anthropic/errors.go
+++ b/providers/anthropic/errors.go
@@ -51,11 +51,7 @@ func normalizeError(status int, body []byte, requestID string) error {
 		code = "unknown_error"
 	}
 
-	sentinel := normalize.SentinelForStatusWithOverrides(status, map[int]error{
-		http.StatusNotFound: core.ErrNotFound,
-	})
-
-	pe := normalize.ProviderError("anthropic", status, requestID, code, message, sentinel)
+	pe := normalize.ProviderError("anthropic", status, requestID, code, message, normalize.SentinelForStatus(status))
 	pe.(*core.ProviderError).Body = bodyStr
 	return pe
 }

--- a/providers/azurefoundry/errors.go
+++ b/providers/azurefoundry/errors.go
@@ -22,10 +22,10 @@ var (
 	ErrToolArgsInvalidJSON = errors.New("azurefoundry: tool arguments are not valid JSON")
 
 	// ErrDeploymentNotFound is returned when the specified deployment does not exist.
-	ErrDeploymentNotFound = errors.New("azurefoundry: deployment not found")
+	ErrDeploymentNotFound = fmt.Errorf("azurefoundry: deployment %w", core.ErrNotFound)
 
 	// ErrModelNotFound is returned when the specified model is not available.
-	ErrModelNotFound = errors.New("azurefoundry: model not found")
+	ErrModelNotFound = fmt.Errorf("azurefoundry: model %w", core.ErrNotFound)
 
 	// ErrQuotaExceeded is returned when the account quota has been exceeded.
 	ErrQuotaExceeded = errors.New("azurefoundry: quota exceeded")

--- a/providers/azurefoundry/errors_test.go
+++ b/providers/azurefoundry/errors_test.go
@@ -124,6 +124,9 @@ func TestNormalizeErrorDeploymentNotFound(t *testing.T) {
 	if !errors.Is(err, ErrDeploymentNotFound) {
 		t.Errorf("expected error to wrap ErrDeploymentNotFound, got %v", err)
 	}
+	if !errors.Is(err, core.ErrNotFound) {
+		t.Errorf("expected error to wrap core.ErrNotFound, got %v", err)
+	}
 }
 
 func TestNormalizeErrorContextLength(t *testing.T) {

--- a/providers/gemini/client_test.go
+++ b/providers/gemini/client_test.go
@@ -274,6 +274,12 @@ func TestDoChatError(t *testing.T) {
 			wantSentinel: core.ErrUnauthorized,
 		},
 		{
+			name:         "not found",
+			statusCode:   404,
+			body:         `{"error":{"code":404,"message":"Model not found","status":"NOT_FOUND"}}`,
+			wantSentinel: core.ErrNotFound,
+		},
+		{
 			name:         "rate limited",
 			statusCode:   429,
 			body:         `{"error":{"code":429,"message":"Resource exhausted","status":"RESOURCE_EXHAUSTED"}}`,

--- a/providers/gemini/errors.go
+++ b/providers/gemini/errors.go
@@ -54,11 +54,7 @@ func normalizeError(status int, body []byte) error {
 		code = "unknown_error"
 	}
 
-	sentinel := normalize.SentinelForStatusWithOverrides(status, map[int]error{
-		http.StatusNotFound: core.ErrBadRequest,
-	})
-
-	pe := normalize.ProviderError("gemini", status, "", code, message, sentinel)
+	pe := normalize.ProviderError("gemini", status, "", code, message, normalize.SentinelForStatus(status))
 	pe.(*core.ProviderError).Body = bodyStr
 	return pe
 }

--- a/providers/gemini/errors_test.go
+++ b/providers/gemini/errors_test.go
@@ -36,7 +36,7 @@ func TestNormalizeError(t *testing.T) {
 			name:         "not found",
 			status:       404,
 			body:         `{"error":{"code":404,"message":"Not found","status":"NOT_FOUND"}}`,
-			wantSentinel: core.ErrBadRequest,
+			wantSentinel: core.ErrNotFound,
 		},
 		{
 			name:         "rate limited",

--- a/providers/internal/normalize/errors.go
+++ b/providers/internal/normalize/errors.go
@@ -144,6 +144,8 @@ func SentinelForStatusWithOverrides(status int, overrides map[int]error) error {
 		return core.ErrBadRequest
 	case status == http.StatusUnauthorized || status == http.StatusForbidden:
 		return core.ErrUnauthorized
+	case status == http.StatusNotFound:
+		return core.ErrNotFound
 	case status == http.StatusTooManyRequests:
 		return core.ErrRateLimited
 	case status >= 500:

--- a/providers/internal/normalize/errors_test.go
+++ b/providers/internal/normalize/errors_test.go
@@ -176,6 +176,13 @@ func TestSentinelForStatusWithOverrides(t *testing.T) {
 	}
 }
 
+func TestSentinelForStatusNotFound(t *testing.T) {
+	sentinel := SentinelForStatus(http.StatusNotFound)
+	if !errors.Is(sentinel, core.ErrNotFound) {
+		t.Errorf("sentinel = %v, want ErrNotFound", sentinel)
+	}
+}
+
 func TestRequireAPIKey(t *testing.T) {
 	if err := RequireAPIKey("acme", core.NewSecret("sk-x")); err != nil {
 		t.Fatalf("non-empty key should pass: %v", err)

--- a/providers/ollama/chat.go
+++ b/providers/ollama/chat.go
@@ -17,14 +17,14 @@ func (p *Ollama) doChat(ctx context.Context, req *core.ChatRequest) (*core.ChatR
 
 	body, err := json.Marshal(ollamaReq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, newDecodeError(fmt.Errorf("failed to marshal request: %w", err))
 	}
 
 	// Create HTTP request
 	url := p.config.BaseURL + "/api/chat"
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, newNetworkError(fmt.Errorf("failed to create request: %w", err))
 	}
 
 	// Set headers
@@ -37,12 +37,7 @@ func (p *Ollama) doChat(ctx context.Context, req *core.ChatRequest) (*core.ChatR
 	// Send request
 	resp, err := p.config.HTTPClient.Do(httpReq)
 	if err != nil {
-		return nil, &core.ProviderError{
-			Provider: "ollama",
-			Code:     "network_error",
-			Message:  err.Error(),
-			Err:      fmt.Errorf("%w: %w", core.ErrNetwork, err),
-		}
+		return nil, newNetworkError(err)
 	}
 	defer resp.Body.Close()
 
@@ -54,7 +49,7 @@ func (p *Ollama) doChat(ctx context.Context, req *core.ChatRequest) (*core.ChatR
 	// Parse response
 	var ollamaResp ollamaResponse
 	if err := json.NewDecoder(resp.Body).Decode(&ollamaResp); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+		return nil, newDecodeError(fmt.Errorf("failed to decode response: %w", err))
 	}
 
 	// Check for inline error

--- a/providers/ollama/embeddings.go
+++ b/providers/ollama/embeddings.go
@@ -41,13 +41,13 @@ func (p *Ollama) CreateEmbeddings(ctx context.Context, req *core.EmbeddingReques
 
 	body, err := json.Marshal(ollamaReq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, newDecodeError(fmt.Errorf("failed to marshal request: %w", err))
 	}
 
 	url := p.config.BaseURL + embedPath
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, newNetworkError(fmt.Errorf("failed to create request: %w", err))
 	}
 
 	for key, values := range p.buildHeaders() {
@@ -58,12 +58,7 @@ func (p *Ollama) CreateEmbeddings(ctx context.Context, req *core.EmbeddingReques
 
 	resp, err := p.config.HTTPClient.Do(httpReq)
 	if err != nil {
-		return nil, &core.ProviderError{
-			Provider: "ollama",
-			Code:     "network_error",
-			Message:  err.Error(),
-			Err:      fmt.Errorf("%w: %w", core.ErrNetwork, err),
-		}
+		return nil, newNetworkError(err)
 	}
 	defer resp.Body.Close()
 
@@ -73,7 +68,7 @@ func (p *Ollama) CreateEmbeddings(ctx context.Context, req *core.EmbeddingReques
 
 	var embedResp ollamaEmbedResponse
 	if err := json.NewDecoder(resp.Body).Decode(&embedResp); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+		return nil, newDecodeError(fmt.Errorf("failed to decode response: %w", err))
 	}
 
 	if embedResp.Error != "" {

--- a/providers/ollama/embeddings_test.go
+++ b/providers/ollama/embeddings_test.go
@@ -269,8 +269,8 @@ func TestCreateEmbeddings_HTTPError(t *testing.T) {
 	if provErr.Provider != "ollama" {
 		t.Errorf("Provider = %q, want ollama", provErr.Provider)
 	}
-	if !errors.Is(provErr, core.ErrBadRequest) {
-		t.Errorf("Expected ErrBadRequest for 404, got %v", provErr.Err)
+	if !errors.Is(provErr, core.ErrNotFound) {
+		t.Errorf("Expected ErrNotFound for 404, got %v", provErr.Err)
 	}
 }
 
@@ -290,6 +290,7 @@ func TestCreateEmbeddings_MalformedResponse(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error for malformed response, got nil")
 	}
+	assertNormalizedError(t, err, core.ErrDecode)
 }
 
 func TestCreateEmbeddings_ContextCancellation(t *testing.T) {

--- a/providers/ollama/errors.go
+++ b/providers/ollama/errors.go
@@ -14,12 +14,14 @@ import (
 func parseErrorResponse(resp *http.Response) error {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return &core.ProviderError{
-			Provider: "ollama",
-			Code:     "read_error",
-			Message:  fmt.Sprintf("failed to read error response: %v", err),
-			Status:   resp.StatusCode,
-		}
+		return normalize.ProviderError(
+			"ollama",
+			resp.StatusCode,
+			"",
+			"read_error",
+			fmt.Sprintf("failed to read error response: %v", err),
+			fmt.Errorf("%w: %w", core.ErrNetwork, err),
+		)
 	}
 
 	var errResp ollamaErrorResponse
@@ -58,26 +60,30 @@ func mapOllamaError(statusCode int, errMsg string) error {
 		errType = "unknown"
 	}
 
-	baseErr := normalize.SentinelForStatusWithOverrides(statusCode, map[int]error{
-		http.StatusNotFound: core.ErrBadRequest,
-	})
+	baseErr := normalize.SentinelForStatus(statusCode)
 
-	return &core.ProviderError{
-		Provider: "ollama",
-		Code:     errType,
-		Message:  errMsg,
-		Status:   statusCode,
-		Err:      baseErr,
-	}
+	return normalize.ProviderError("ollama", statusCode, "", errType, errMsg, baseErr)
 }
 
 // newStreamError creates an error from an inline stream error.
 func newStreamError(errMsg string) error {
-	return &core.ProviderError{
-		Provider: "ollama",
-		Code:     "stream_error",
-		Message:  errMsg,
-		Status:   0,
-		Err:      core.ErrServer,
-	}
+	return normalize.ProviderError("ollama", 0, "", "stream_error", errMsg, core.ErrServer)
+}
+
+// newNetworkError creates a ProviderError for network-related failures.
+func newNetworkError(err error) error {
+	providerErr := normalize.NetworkError("ollama", err).(*core.ProviderError)
+	providerErr.Code = "network_error"
+	return providerErr
+}
+
+// newDecodeError creates a ProviderError for JSON encoding and decoding failures.
+func newDecodeError(err error) error {
+	return normalize.DecodeError("ollama", err)
+}
+
+// newDecodeErrorWithBody creates a ProviderError for JSON decoding failures
+// and preserves the payload that could not be decoded.
+func newDecodeErrorWithBody(err error, body []byte) error {
+	return normalize.DecodeErrorWithBody("ollama", err, body)
 }

--- a/providers/ollama/errors_test.go
+++ b/providers/ollama/errors_test.go
@@ -1,0 +1,180 @@
+package ollama
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func assertNormalizedError(t *testing.T, err, sentinel error) {
+	t.Helper()
+
+	var providerErr *core.ProviderError
+	if !errors.As(err, &providerErr) {
+		t.Fatalf("error = %v (%T), want *core.ProviderError", err, err)
+	}
+	if providerErr.Provider != "ollama" {
+		t.Errorf("Provider = %q, want ollama", providerErr.Provider)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("error = %v, want sentinel %v", err, sentinel)
+	}
+}
+
+func TestErrorConformance(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		sentinel error
+	}{
+		{name: "network", err: newNetworkError(errors.New("connection refused")), sentinel: core.ErrNetwork},
+		{name: "decode", err: newDecodeError(errors.New("invalid JSON")), sentinel: core.ErrDecode},
+		{name: "not found", err: mapOllamaError(http.StatusNotFound, "model not found"), sentinel: core.ErrNotFound},
+		{name: "stream", err: newStreamError("model crashed"), sentinel: core.ErrServer},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertNormalizedError(t, tt.err, tt.sentinel)
+		})
+	}
+}
+
+func TestChatMalformedResponseIsNormalized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("not JSON"))
+	}))
+	defer server.Close()
+
+	provider := New(WithBaseURL(server.URL))
+	_, err := provider.Chat(context.Background(), &core.ChatRequest{Model: "llama3.2"})
+	assertNormalizedError(t, err, core.ErrDecode)
+}
+
+func TestStreamMalformedChunkIsNormalized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		_, _ = w.Write([]byte("not JSON\n"))
+	}))
+	defer server.Close()
+
+	provider := New(WithBaseURL(server.URL))
+	stream, err := provider.StreamChat(context.Background(), &core.ChatRequest{Model: "llama3.2"})
+	if err != nil {
+		t.Fatalf("StreamChat() error = %v", err)
+	}
+
+	_, err = core.DrainStream(context.Background(), stream)
+	assertNormalizedError(t, err, core.ErrDecode)
+}
+
+func TestErrorResponseReadFailureIsNormalized(t *testing.T) {
+	response := &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Body:       io.NopCloser(errorReader{}),
+	}
+
+	err := parseErrorResponse(response)
+	assertNormalizedError(t, err, core.ErrNetwork)
+
+	var providerErr *core.ProviderError
+	errors.As(err, &providerErr)
+	if providerErr.Status != http.StatusBadGateway {
+		t.Errorf("Status = %d, want %d", providerErr.Status, http.StatusBadGateway)
+	}
+	if providerErr.Code != "read_error" {
+		t.Errorf("Code = %q, want read_error", providerErr.Code)
+	}
+}
+
+func TestRequestCreationFailuresAreNormalized(t *testing.T) {
+	provider := New(WithBaseURL("://invalid"))
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "chat",
+			call: func() error {
+				_, err := provider.Chat(context.Background(), &core.ChatRequest{Model: "llama3.2"})
+				return err
+			},
+		},
+		{
+			name: "stream",
+			call: func() error {
+				_, err := provider.StreamChat(context.Background(), &core.ChatRequest{Model: "llama3.2"})
+				return err
+			},
+		},
+		{
+			name: "embeddings",
+			call: func() error {
+				_, err := provider.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{Model: "nomic-embed-text"})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertNormalizedError(t, tt.call(), core.ErrNetwork)
+		})
+	}
+}
+
+func TestStreamReadFailureIsNormalized(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(errorReader{}),
+		}, nil
+	})}
+	provider := New(WithHTTPClient(client))
+
+	stream, err := provider.StreamChat(context.Background(), &core.ChatRequest{Model: "llama3.2"})
+	if err != nil {
+		t.Fatalf("StreamChat() error = %v", err)
+	}
+	_, err = core.DrainStream(context.Background(), stream)
+	assertNormalizedError(t, err, core.ErrNetwork)
+}
+
+func TestInlineErrorsAreNormalized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		switch r.URL.Path {
+		case "/api/chat":
+			_, _ = w.Write([]byte(`{"error":"chat failed"}`))
+		case embedPath:
+			_, _ = w.Write([]byte(`{"error":"embedding failed"}`))
+		}
+	}))
+	defer server.Close()
+
+	provider := New(WithBaseURL(server.URL))
+	_, chatErr := provider.Chat(context.Background(), &core.ChatRequest{Model: "llama3.2"})
+	assertNormalizedError(t, chatErr, core.ErrServer)
+
+	_, embeddingErr := provider.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{Model: "nomic-embed-text"})
+	assertNormalizedError(t, embeddingErr, core.ErrServer)
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+type errorReader struct{}
+
+func (errorReader) Read([]byte) (int, error) {
+	return 0, errors.New("read failed")
+}

--- a/providers/ollama/provider_test.go
+++ b/providers/ollama/provider_test.go
@@ -3,6 +3,7 @@ package ollama
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -64,6 +65,42 @@ func TestNew(t *testing.T) {
 		}
 		if p.config.APIKey.Expose() != "cloud-key" {
 			t.Errorf("APIKey = %q, want %q", p.config.APIKey.Expose(), "cloud-key")
+		}
+	})
+}
+
+func TestNewLocalUsesConfiguredHost(t *testing.T) {
+	t.Setenv(OllamaHostEnvVar, "http://ollama.internal:11434")
+
+	provider := NewLocal()
+	if provider.config.BaseURL != "http://ollama.internal:11434" {
+		t.Errorf("BaseURL = %q, want configured Ollama host", provider.config.BaseURL)
+	}
+}
+
+func TestNewCloudFromEnv(t *testing.T) {
+	t.Run("missing API key", func(t *testing.T) {
+		t.Setenv(OllamaAPIKeyEnvVar, "")
+		provider, err := NewCloudFromEnv()
+		if !errors.Is(err, ErrAPIKeyNotFound) {
+			t.Errorf("error = %v, want ErrAPIKeyNotFound", err)
+		}
+		if provider != nil {
+			t.Errorf("provider = %#v, want nil", provider)
+		}
+	})
+
+	t.Run("configured API key", func(t *testing.T) {
+		t.Setenv(OllamaAPIKeyEnvVar, "test-key")
+		provider, err := NewCloudFromEnv()
+		if err != nil {
+			t.Fatalf("NewCloudFromEnv() error = %v", err)
+		}
+		if provider.config.BaseURL != DefaultCloudURL {
+			t.Errorf("BaseURL = %q, want %q", provider.config.BaseURL, DefaultCloudURL)
+		}
+		if provider.config.APIKey.Expose() != "test-key" {
+			t.Error("API key was not loaded from the environment")
 		}
 	})
 }
@@ -577,6 +614,58 @@ func TestMapRequest(t *testing.T) {
 			t.Errorf("Think should be nil, got %v", *ollamaReq.Think)
 		}
 	})
+}
+
+func TestMapMessagesPreservesToolData(t *testing.T) {
+	messages := []core.Message{
+		{
+			Role: core.RoleAssistant,
+			ToolCalls: []core.ToolCall{
+				{Name: "weather", Arguments: json.RawMessage(`{"city":"Portland"}`)},
+				{Name: "invalid", Arguments: json.RawMessage(`not JSON`)},
+			},
+		},
+		{
+			Role: core.RoleTool,
+			ToolResults: []core.ToolResult{
+				{Content: "sunny"},
+				{Content: map[string]any{"temperature": 72}},
+			},
+		},
+	}
+
+	mapped := mapMessages(messages)
+	if len(mapped) != 3 {
+		t.Fatalf("len(mapped) = %d, want 3", len(mapped))
+	}
+	if got := mapped[0].ToolCalls[0].Function.Arguments["city"]; got != "Portland" {
+		t.Errorf("valid tool arguments = %#v, want Portland", got)
+	}
+	if len(mapped[0].ToolCalls[1].Function.Arguments) != 0 {
+		t.Errorf("invalid tool arguments = %#v, want empty object", mapped[0].ToolCalls[1].Function.Arguments)
+	}
+	if mapped[1].Content != "sunny" {
+		t.Errorf("string tool result = %q, want sunny", mapped[1].Content)
+	}
+	if mapped[2].Content != `{"temperature":72}` {
+		t.Errorf("object tool result = %q, want JSON object", mapped[2].Content)
+	}
+}
+
+func TestMapMessagesHandlesUnencodableToolResult(t *testing.T) {
+	mapped := mapMessages([]core.Message{{
+		Role: core.RoleTool,
+		ToolResults: []core.ToolResult{{
+			Content: func() {},
+		}},
+	}})
+
+	if len(mapped) != 1 {
+		t.Fatalf("len(mapped) = %d, want 1", len(mapped))
+	}
+	if mapped[0].Content != `{"error": "failed to marshal tool result"}` {
+		t.Errorf("Content = %q, want marshal error JSON", mapped[0].Content)
+	}
 }
 
 // TestMapResponse tests response mapping.

--- a/providers/ollama/stream.go
+++ b/providers/ollama/stream.go
@@ -18,14 +18,14 @@ func (p *Ollama) doStreamChat(ctx context.Context, req *core.ChatRequest) (*core
 
 	body, err := json.Marshal(ollamaReq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, newDecodeError(fmt.Errorf("failed to marshal request: %w", err))
 	}
 
 	// Create HTTP request
 	url := p.config.BaseURL + "/api/chat"
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, newNetworkError(fmt.Errorf("failed to create request: %w", err))
 	}
 
 	// Set headers
@@ -38,12 +38,7 @@ func (p *Ollama) doStreamChat(ctx context.Context, req *core.ChatRequest) (*core
 	// Send request
 	resp, err := p.config.HTTPClient.Do(httpReq)
 	if err != nil {
-		return nil, &core.ProviderError{
-			Provider: "ollama",
-			Code:     "network_error",
-			Message:  err.Error(),
-			Err:      fmt.Errorf("%w: %w", core.ErrNetwork, err),
-		}
+		return nil, newNetworkError(err)
 	}
 
 	// Check for errors
@@ -103,7 +98,7 @@ func (p *Ollama) processNDJSONStream(
 
 		var chunk ollamaResponse
 		if err := json.Unmarshal(line, &chunk); err != nil {
-			errCh <- fmt.Errorf("failed to parse stream chunk: %w", err)
+			errCh <- newDecodeErrorWithBody(fmt.Errorf("failed to parse stream chunk: %w", err), line)
 			return
 		}
 
@@ -145,7 +140,7 @@ func (p *Ollama) processNDJSONStream(
 	}
 
 	if err := scanner.Err(); err != nil {
-		errCh <- fmt.Errorf("stream read error: %w", err)
+		errCh <- newNetworkError(fmt.Errorf("stream read error: %w", err))
 		return
 	}
 

--- a/providers/openai/client_files.go
+++ b/providers/openai/client_files.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
 	"github.com/petal-labs/iris/providers/internal/timeoutx"
 )
 
@@ -126,21 +127,7 @@ func (p *OpenAI) parseFileError(resp *http.Response) error {
 
 // mapStatusToSentinel maps HTTP status codes to sentinel errors.
 func (p *OpenAI) mapStatusToSentinel(status int) error {
-	switch status {
-	case http.StatusUnauthorized, http.StatusForbidden:
-		return core.ErrUnauthorized
-	case http.StatusNotFound:
-		return core.ErrNotFound
-	case http.StatusTooManyRequests:
-		return core.ErrRateLimited
-	case http.StatusBadRequest:
-		return core.ErrBadRequest
-	default:
-		if status >= 500 {
-			return core.ErrServer
-		}
-		return core.ErrBadRequest
-	}
+	return normalize.SentinelForStatus(status)
 }
 
 // ListFiles returns a list of files.

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -102,6 +102,7 @@ var (
 	ErrUnauthorized  = core.ErrUnauthorized
 	ErrRateLimited   = core.ErrRateLimited
 	ErrBadRequest    = core.ErrBadRequest
+	ErrNotFound      = core.ErrNotFound
 	ErrServer        = core.ErrServer
 	ErrNetwork       = core.ErrNetwork
 	ErrDecode        = core.ErrDecode

--- a/providers/provider_test.go
+++ b/providers/provider_test.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/petal-labs/iris/core"
@@ -67,6 +68,12 @@ func TestProviderImplementsInterface(t *testing.T) {
 
 	if p.ID() != "test" {
 		t.Errorf("ID() = %v, want test", p.ID())
+	}
+}
+
+func TestErrNotFoundAlias(t *testing.T) {
+	if !errors.Is(ErrNotFound, core.ErrNotFound) {
+		t.Errorf("ErrNotFound = %v, want core.ErrNotFound", ErrNotFound)
 	}
 }
 

--- a/providers/zai/errors.go
+++ b/providers/zai/errors.go
@@ -53,11 +53,7 @@ func normalizeError(status int, body []byte, requestID string) error {
 
 	code := errResp.Error.Code
 
-	sentinel := normalize.SentinelForStatusWithOverrides(status, map[int]error{
-		http.StatusNotFound: core.ErrBadRequest,
-	})
-
-	pe := normalize.ProviderError("zai", status, requestID, code, message, sentinel)
+	pe := normalize.ProviderError("zai", status, requestID, code, message, normalize.SentinelForStatus(status))
 	pe.(*core.ProviderError).Body = bodyStr
 	return pe
 }

--- a/providers/zai/errors_test.go
+++ b/providers/zai/errors_test.go
@@ -1,0 +1,25 @@
+package zai
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestNormalizeErrorNotFound(t *testing.T) {
+	err := normalizeError(
+		http.StatusNotFound,
+		[]byte(`{"error":{"code":"model_not_found","message":"Model not found"}}`),
+		"req-123",
+	)
+
+	var providerErr *core.ProviderError
+	if !errors.As(err, &providerErr) {
+		t.Fatalf("error = %v (%T), want *core.ProviderError", err, err)
+	}
+	if !errors.Is(err, core.ErrNotFound) {
+		t.Errorf("error = %v, want ErrNotFound", err)
+	}
+}

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -8,9 +8,14 @@ import (
 	"sync"
 )
 
-// ErrDuplicateTool is returned when attempting to register a tool with a name
-// that is already registered.
-var ErrDuplicateTool = errors.New("tool already registered")
+var (
+	// ErrDuplicateTool is returned when attempting to register a tool with a
+	// name that is already registered.
+	ErrDuplicateTool = errors.New("tool already registered")
+
+	// ErrToolNotFound is returned when attempting to execute an unregistered tool.
+	ErrToolNotFound = errors.New("tool not found")
+)
 
 // RegistryOption configures a Registry.
 type RegistryOption func(*Registry)
@@ -103,11 +108,12 @@ func (r *Registry) List() []Tool {
 }
 
 // Execute finds a tool by name and calls it with the given arguments.
-// Returns an error if the tool is not found or if execution fails.
+// Returns an error wrapping ErrToolNotFound if the tool is not registered, or
+// returns the tool's execution error unchanged.
 func (r *Registry) Execute(ctx context.Context, name string, args json.RawMessage) (any, error) {
 	tool, ok := r.Get(name)
 	if !ok {
-		return nil, fmt.Errorf("tool %q not found", name)
+		return nil, fmt.Errorf("%w: %q", ErrToolNotFound, name)
 	}
 	return tool.Call(ctx, args)
 }

--- a/tools/registry_test.go
+++ b/tools/registry_test.go
@@ -3,6 +3,7 @@ package tools_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync"
 	"testing"
 
@@ -54,6 +55,15 @@ func TestRegistryGetNotFound(t *testing.T) {
 	_, ok := r.Get("nonexistent")
 	if ok {
 		t.Error("Get() returned true for nonexistent tool, want false")
+	}
+}
+
+func TestRegistryExecuteNotFound(t *testing.T) {
+	r := tools.NewRegistry()
+
+	_, err := r.Execute(context.Background(), "nonexistent", nil)
+	if !errors.Is(err, tools.ErrToolNotFound) {
+		t.Errorf("Execute() error = %v, want ErrToolNotFound", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #65.

Iris promises consistent error classification across providers, but several paths bypassed or overrode the shared normalization layer. A nil stream was reported as a provider bad request, HTTP 404 responses could resolve to server or bad-request sentinels, Ollama returned raw encoding and parsing errors, and missing tools had no sentinel callers could match.

This change adds `core.ErrNilStream`, maps 404 through the shared `core.ErrNotFound` classification, and preserves provider-specific Azure and batch not-found errors while making them unwrap to the common sentinel. OpenAI Files, Anthropic, Gemini, Z.ai, and Ollama now use the shared status mapper.

Ollama request construction, transport, response decoding, NDJSON parsing, stream reads, and inline provider failures now return `*core.ProviderError` values wrapping the appropriate `core.ErrNetwork`, `core.ErrDecode`, `core.ErrNotFound`, or `core.ErrServer` sentinel. Existing human-readable context and Ollama's `network_error` code are preserved.

The tools registry now exposes `tools.ErrToolNotFound`, and the retry documentation explicitly states that unknown errors are not retried by the default policy. Callers can supply a custom `RetryPolicy` when replaying additional error types is safe.

## Validation

- `go test -race -coverprofile=/tmp/iris-65-coverage.out -covermode=atomic ./...`
- Aggregate statement coverage: 80.2%
- `go vet ./...`
- `gofmt` check
- `git diff --check`

The local `golangci-lint` version reports seven findings that are already present on `main`; this change introduces none of them.
