### PR TITLE
[codex] fix CLI provider and init scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ iris keys set anthropic
 iris keys set gemini
 iris keys set xai
 iris keys set zai
+iris keys set huggingface
+iris keys set perplexity
+iris keys set voyageai
+iris keys set azurefoundry
 iris keys set ollama  # Only needed for Ollama Cloud
 
 # Upgrade the keystore to master-key encryption (V2)
@@ -199,8 +203,11 @@ iris chat --provider anthropic --model claude-sonnet-5 --prompt "Tell me a story
 # Get JSON output
 iris chat --provider openai --model gpt-5.6 --prompt "Hello" --json
 
-# Initialize a new project
-iris init myproject
+# Initialize a standalone project (creates main.go, go.mod, and tools/)
+iris init myproject --provider perplexity
+cd myproject
+export PERPLEXITY_API_KEY=<your-key>
+go run .
 ```
 
 ## 📚 Documentation
@@ -233,6 +240,10 @@ Iris looks for configuration at `~/.iris/config.yaml`. The schema is:
 | `default_provider` | Provider used when `--provider` is omitted |
 | `default_model` | Model used when `--model` is omitted |
 | `providers.<id>.base_url` | Override a provider's API base URL |
+| `providers.azurefoundry.endpoint` | Azure AI Foundry resource endpoint |
+| `providers.azurefoundry.deployment_id` | Optional Azure deployment ID |
+| `providers.azurefoundry.api_version` | Optional Azure API version override |
+| `providers.azurefoundry.use_openai_endpoint` | Use Azure OpenAI deployment-style request paths |
 
 ```yaml
 default_provider: openai
@@ -242,9 +253,13 @@ providers:
   ollama:
     # Custom base URL for a remote/local Ollama instance (default: http://localhost:11434)
     base_url: http://remote-host:11434
+  azurefoundry:
+    endpoint: https://my-resource.openai.azure.com
+    deployment_id: production-chat
+    use_openai_endpoint: true
 ```
 
-API keys are **not** configured here. The CLI reads provider keys from the encrypted keystore (`iris keys set <provider>`, see [Security](#-security)); the SDK reads them from environment variables when you use the provider packages directly.
+API keys are **not** configured here. The CLI reads provider keys from the encrypted keystore (`iris keys set <provider>`, see [Security](#-security)); the SDK reads them from environment variables when you use the provider packages directly. For Azure AI Foundry, `AZURE_AI_ENDPOINT` and `AZURE_AI_DEPLOYMENT_ID` are also accepted when their corresponding config fields are omitted. `base_url` remains a backward-compatible alias for the Azure endpoint.
 
 ## 🔒 Security
 

--- a/cli/commands/app.go
+++ b/cli/commands/app.go
@@ -130,7 +130,7 @@ Use Iris to manage API keys, chat with models, and scaffold projects.`,
 
 	// Global flags available to all commands.
 	root.PersistentFlags().StringVar(&a.cfgFile, "config", "", "config file (default is ~/.iris/config.yaml)")
-	root.PersistentFlags().StringVar(&a.provider, "provider", "", "provider ID (openai, anthropic, ollama)")
+	root.PersistentFlags().StringVar(&a.provider, "provider", "", "provider ID (for example: openai, anthropic, perplexity, ollama)")
 	root.PersistentFlags().StringVar(&a.model, "model", "", "model ID (e.g. gpt-4o)")
 	root.PersistentFlags().BoolVar(&a.jsonOutput, "json", false, "emit JSON output")
 	root.PersistentFlags().BoolVar(&a.verbose, "verbose", false, "print token usage summary after each response")

--- a/cli/commands/chat_test.go
+++ b/cli/commands/chat_test.go
@@ -73,6 +73,8 @@ func TestCreateProviderAllProviders(t *testing.T) {
 		{"ollama", "", "ollama"},         // ollama works without API key
 		{"ollama", "test-key", "ollama"}, // ollama also works with API key
 		{"huggingface", "test-key", "huggingface"},
+		{"perplexity", "test-key", "perplexity"},
+		{"voyageai", "test-key", "voyageai"},
 	}
 
 	for _, tt := range tests {
@@ -86,6 +88,201 @@ func TestCreateProviderAllProviders(t *testing.T) {
 				t.Errorf("provider.ID() = %q, want %q", provider.ID(), tt.wantID)
 			}
 		})
+	}
+}
+
+func TestCreateProviderUsesPerplexityBaseURL(t *testing.T) {
+	var gotRequest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRequest = true
+		if r.URL.Path != "/chat/completions" {
+			t.Errorf("path = %q, want /chat/completions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"resp-1","model":"sonar","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	}))
+	defer server.Close()
+
+	app := NewApp()
+	provider, err := app.createProvider("perplexity", "test-key", &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"perplexity": {BaseURL: server.URL},
+		},
+	})
+	if err != nil {
+		t.Fatalf("createProvider(perplexity) error = %v", err)
+	}
+
+	_, err = provider.Chat(context.Background(), &core.ChatRequest{
+		Model:    "sonar",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("perplexity.Chat() error = %v", err)
+	}
+	if !gotRequest {
+		t.Error("perplexity request did not use the configured base URL")
+	}
+}
+
+func TestCreateProviderUsesVoyageAIBaseURL(t *testing.T) {
+	var gotRequest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotRequest = true
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("path = %q, want /embeddings", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"object":"list","data":[{"object":"embedding","index":0,"embedding":[0.1]}],"model":"voyage-4-large","usage":{"total_tokens":1}}`)
+	}))
+	defer server.Close()
+
+	app := NewApp()
+	provider, err := app.createProvider("voyageai", "test-key", &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"voyageai": {BaseURL: server.URL},
+		},
+	})
+	if err != nil {
+		t.Fatalf("createProvider(voyageai) error = %v", err)
+	}
+
+	embedder, ok := provider.(core.EmbeddingProvider)
+	if !ok {
+		t.Fatal("voyageai provider does not implement core.EmbeddingProvider")
+	}
+	_, err = embedder.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "voyage-4-large",
+		Input: []core.EmbeddingInput{{Text: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("voyageai.CreateEmbeddings() error = %v", err)
+	}
+	if !gotRequest {
+		t.Error("voyageai request did not use the configured base URL")
+	}
+}
+
+func TestCreateAzureFoundryProviderFromConfig(t *testing.T) {
+	server := newAzureChatServer(t, "/openai/deployments/chat-prod/chat/completions", "2025-01-01-preview")
+	defer server.Close()
+
+	app := NewApp()
+	provider, err := app.createProvider("azurefoundry", "test-key", &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"azurefoundry": {
+				Endpoint:          server.URL,
+				DeploymentID:      "chat-prod",
+				APIVersion:        "2025-01-01-preview",
+				UseOpenAIEndpoint: true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("createProvider(azurefoundry) error = %v", err)
+	}
+
+	assertAzureChatSucceeds(t, provider)
+}
+
+func TestCreateAzureFoundryProviderFromEnvironment(t *testing.T) {
+	server := newAzureChatServer(t, "/openai/deployments/env-deployment/chat/completions", "2024-10-21")
+	defer server.Close()
+	t.Setenv("AZURE_AI_ENDPOINT", server.URL)
+	t.Setenv("AZURE_AI_DEPLOYMENT_ID", "env-deployment")
+
+	app := NewApp()
+	provider, err := app.createProvider("azurefoundry", "test-key", &config.Config{
+		Providers: map[string]config.ProviderConfig{
+			"azurefoundry": {UseOpenAIEndpoint: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("createProvider(azurefoundry) error = %v", err)
+	}
+
+	assertAzureChatSucceeds(t, provider)
+}
+
+func TestCreateAzureFoundryProviderRequiresEndpoint(t *testing.T) {
+	t.Setenv("AZURE_AI_ENDPOINT", "")
+	app := NewApp()
+	_, err := app.createProvider("azurefoundry", "test-key", nil)
+	if err == nil {
+		t.Fatal("createProvider(azurefoundry) should require an endpoint")
+	}
+	if !strings.Contains(err.Error(), "endpoint") || !strings.Contains(err.Error(), "AZURE_AI_ENDPOINT") {
+		t.Errorf("error = %q, want endpoint configuration guidance", err)
+	}
+}
+
+func TestCreateAzureFoundryProviderRejectsInvalidConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  config.ProviderConfig
+	}{
+		{
+			name: "non HTTP endpoint",
+			cfg:  config.ProviderConfig{Endpoint: "file:///tmp/azure"},
+		},
+		{
+			name: "endpoint credentials",
+			cfg:  config.ProviderConfig{Endpoint: "https://user:secret@example.com"},
+		},
+		{
+			name: "unsafe deployment ID",
+			cfg: config.ProviderConfig{
+				Endpoint:     "https://example.openai.azure.com",
+				DeploymentID: "chat/prod",
+			},
+		},
+		{
+			name: "unsafe API version",
+			cfg: config.ProviderConfig{
+				Endpoint:   "https://example.openai.azure.com",
+				APIVersion: "2025-01-01&mode=unsafe",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := NewApp()
+			_, err := app.createProvider("azurefoundry", "test-key", &config.Config{
+				Providers: map[string]config.ProviderConfig{"azurefoundry": tt.cfg},
+			})
+			if err == nil {
+				t.Fatal("createProvider(azurefoundry) should reject invalid config")
+			}
+		})
+	}
+}
+
+func newAzureChatServer(t *testing.T, wantPath, wantAPIVersion string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != wantPath {
+			t.Errorf("path = %q, want %q", r.URL.Path, wantPath)
+		}
+		if got := r.URL.Query().Get("api-version"); got != wantAPIVersion {
+			t.Errorf("api-version = %q, want %q", got, wantAPIVersion)
+		}
+		if got := r.Header.Get("api-key"); got != "test-key" {
+			t.Errorf("api-key = %q, want test-key", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"resp-1","model":"gpt-4o","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	}))
+}
+
+func assertAzureChatSucceeds(t *testing.T, provider core.Provider) {
+	t.Helper()
+	_, err := provider.Chat(context.Background(), &core.ChatRequest{
+		Model:    "gpt-4o",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("azurefoundry.Chat() error = %v", err)
 	}
 }
 
@@ -227,6 +424,91 @@ func TestRunChatKeylessOllama(t *testing.T) {
 	if !gotRequest {
 		t.Error("no request reached the ollama server; keyless path did not proceed")
 	}
+}
+
+func TestRunChatPerplexityWithStoredKey(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want stored key", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"resp-1","model":"sonar","choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+	}))
+	defer server.Close()
+
+	app, stdout := appWithStoredKey(t, "perplexity")
+	app.cfg = &config.Config{Providers: map[string]config.ProviderConfig{
+		"perplexity": {BaseURL: server.URL},
+	}}
+	app.provider = "perplexity"
+	app.model = "sonar"
+	app.chatPrompt = "hi"
+
+	if err := app.runChat(nil, nil); err != nil {
+		t.Fatalf("runChat() error = %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "hello") {
+		t.Errorf("stdout = %q, want provider response", got)
+	}
+}
+
+func TestRunChatAzureFoundryWithStoredKeyAndEnvironment(t *testing.T) {
+	server := newAzureChatServer(t, "/models/chat/completions", "2024-05-01-preview")
+	defer server.Close()
+	t.Setenv("AZURE_AI_ENDPOINT", server.URL)
+
+	app, stdout := appWithStoredKey(t, "azurefoundry")
+	app.cfg = &config.Config{Providers: map[string]config.ProviderConfig{}}
+	app.provider = "azurefoundry"
+	app.model = "gpt-4o"
+	app.chatPrompt = "hi"
+
+	if err := app.runChat(nil, nil); err != nil {
+		t.Fatalf("runChat() error = %v", err)
+	}
+	if got := stdout.String(); !strings.Contains(got, "hello") {
+		t.Errorf("stdout = %q, want provider response", got)
+	}
+}
+
+func TestRunChatVoyageAIReportsUnsupportedCapability(t *testing.T) {
+	app, _ := appWithStoredKey(t, "voyageai")
+	app.cfg = &config.Config{Providers: map[string]config.ProviderConfig{}}
+	app.provider = "voyageai"
+	app.model = "voyage-4-large"
+	app.chatPrompt = "hi"
+
+	err := app.runChat(nil, nil)
+	if err == nil {
+		t.Fatal("runChat() should report Voyage AI's unsupported chat capability")
+	}
+	if !strings.Contains(err.Error(), "chat is not supported by Voyage AI") {
+		t.Errorf("error = %q, want Voyage AI capability error", err)
+	}
+	if strings.Contains(err.Error(), "unsupported provider") {
+		t.Errorf("error = %q, provider should be constructed before capability validation", err)
+	}
+}
+
+func appWithStoredKey(t *testing.T, providerID string) (*App, *bytes.Buffer) {
+	t.Helper()
+	keyPath := filepath.Join(t.TempDir(), "keys.enc")
+	store, err := keystore.NewKeystoreAtPath(keyPath)
+	if err != nil {
+		t.Fatalf("create keystore: %v", err)
+	}
+	if err := store.Set(providerID, "test-key"); err != nil {
+		t.Fatalf("store %s key: %v", providerID, err)
+	}
+
+	stdout := &bytes.Buffer{}
+	app := NewApp(
+		WithKeystoreFactory(func() (keystore.Keystore, error) {
+			return keystore.NewKeystoreAtPath(keyPath)
+		}),
+		WithIO(strings.NewReader(""), stdout, &bytes.Buffer{}),
+	)
+	return app, stdout
 }
 
 // TestRunChatMissingKeyFailsForKeyedProviders verifies the actionable

--- a/cli/commands/init.go
+++ b/cli/commands/init.go
@@ -19,7 +19,7 @@ func (a *App) newInitCommand() *cobra.Command {
 
 Creates a project directory with:
   - main.go: A starter Go file using the Iris SDK
-  - iris.yaml: Project configuration
+  - go.mod: A standalone Go module with the Iris dependency
   - tools/: Directory for custom tools
 
 Example:
@@ -37,62 +37,72 @@ func (a *App) runInit(cmd *cobra.Command, args []string) error {
 	projectPath := args[0]
 	projectName := filepath.Base(projectPath)
 
-	// Validate project name (just the base name, not full path).
 	if err := validateProjectName(projectName); err != nil {
 		return err
 	}
+	if err := validateInitProvider(a.initProvider); err != nil {
+		return err
+	}
+	if err := ensureProjectPathAvailable(projectPath); err != nil {
+		return err
+	}
+	if err := createProject(projectPath, projectName, a.initProvider); err != nil {
+		return err
+	}
 
-	// Check if directory already exists.
-	if _, err := os.Stat(projectPath); err == nil {
+	printInitSuccess(a, projectName, projectPath)
+	return nil
+}
+
+func ensureProjectPathAvailable(projectPath string) error {
+	_, err := os.Stat(projectPath)
+	if err == nil {
 		return fmt.Errorf("directory %q already exists", projectPath)
 	}
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to inspect project path %q: %w", projectPath, err)
+	}
+	return nil
+}
 
-	// Create directory structure.
-	dirs := []string{
-		projectPath,
-		filepath.Join(projectPath, "tools"),
+func createProject(projectPath, projectName, provider string) error {
+	toolsPath := filepath.Join(projectPath, "tools")
+	if err := os.MkdirAll(toolsPath, 0755); err != nil {
+		return fmt.Errorf("failed to create project directories: %w", err)
 	}
-	for _, dir := range dirs {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return fmt.Errorf("failed to create directory %s: %w", dir, err)
-		}
-	}
-
-	// Create .gitkeep files in empty directories.
-	gitkeepDirs := []string{
-		filepath.Join(projectPath, "tools"),
-	}
-	for _, dir := range gitkeepDirs {
-		path := filepath.Join(dir, ".gitkeep")
-		if err := os.WriteFile(path, []byte{}, 0644); err != nil {
-			return fmt.Errorf("failed to create %s: %w", path, err)
-		}
+	if err := os.WriteFile(filepath.Join(toolsPath, ".gitkeep"), []byte{}, 0644); err != nil {
+		return fmt.Errorf("failed to create tools/.gitkeep: %w", err)
 	}
 
-	// Generate main.go.
-	mainPath := filepath.Join(projectPath, "main.go")
-	if err := generateFile(mainPath, mainGoTemplate, templateData{
-		Provider: a.initProvider,
-	}); err != nil {
+	data := templateData{
+		ProjectName: projectName,
+		Provider:    provider,
+		GoVersion:   scaffoldGoVersion,
+		SDKVersion:  scaffoldSDKVersion,
+	}
+	if err := generateFile(filepath.Join(projectPath, "main.go"), mainTemplateForProvider(provider), data); err != nil {
 		return fmt.Errorf("failed to create main.go: %w", err)
 	}
-
-	// Generate iris.yaml.
-	configPath := filepath.Join(projectPath, "iris.yaml")
-	if err := generateFile(configPath, irisYamlTemplate, templateData{
-		Provider: a.initProvider,
-	}); err != nil {
-		return fmt.Errorf("failed to create iris.yaml: %w", err)
+	if err := generateFile(filepath.Join(projectPath, "go.mod"), goModTemplate, data); err != nil {
+		return fmt.Errorf("failed to create go.mod: %w", err)
 	}
+	return nil
+}
 
-	// Print success message.
+func printInitSuccess(a *App, projectName, projectPath string) {
 	fmt.Fprintf(a.stdout, "Created Iris project: %s\n\n", projectName)
 	fmt.Fprintln(a.stdout, "Next steps:")
 	fmt.Fprintf(a.stdout, "  cd %s\n", projectPath)
-	fmt.Fprintf(a.stdout, "  export %s=<your-key>\n", envVarForProvider(a.initProvider))
-	fmt.Fprintln(a.stdout, "  go run main.go")
-
-	return nil
+	if a.initProvider == "azurefoundry" {
+		fmt.Fprintln(a.stdout, "  export AZURE_AI_ENDPOINT=<your-endpoint>")
+	}
+	if a.initProvider != "ollama" {
+		fmt.Fprintf(a.stdout, "  export %s=<your-key>\n", envVarForProvider(a.initProvider))
+	}
+	if a.initProvider == "ollama" {
+		fmt.Fprintln(a.stdout, "  # Ensure Ollama is running and llama3.2 is available")
+	}
+	fmt.Fprintln(a.stdout, "  go run .")
 }
 
 func validateProjectName(name string) error {
@@ -118,8 +128,16 @@ func validateProjectName(name string) error {
 }
 
 type templateData struct {
-	Provider string
+	ProjectName string
+	Provider    string
+	GoVersion   string
+	SDKVersion  string
 }
+
+const (
+	scaffoldGoVersion  = "1.24.0"
+	scaffoldSDKVersion = "v0.17.0"
+)
 
 var templateFuncs = template.FuncMap{
 	"envVar":       envVarForProvider,
@@ -136,13 +154,24 @@ func generateFile(path string, tmplContent string, data templateData) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-
-	return tmpl.Execute(f, data)
+	if err := tmpl.Execute(f, data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 func envVarForProvider(provider string) string {
-	return strings.ToUpper(provider) + "_API_KEY"
+	switch provider {
+	case "huggingface":
+		return "HF_TOKEN"
+	case "voyageai":
+		return "VOYAGE_API_KEY"
+	case "azurefoundry":
+		return "AZURE_AI_API_KEY"
+	default:
+		return strings.ToUpper(provider) + "_API_KEY"
+	}
 }
 
 func defaultModel(provider string) string {
@@ -159,8 +188,39 @@ func defaultModel(provider string) string {
 		return "glm-4.7-flash"
 	case "ollama":
 		return "llama3.2"
+	case "perplexity":
+		return "sonar"
+	case "huggingface":
+		return "meta-llama/Llama-3-8B-Instruct"
+	case "azurefoundry":
+		return "gpt-4o"
+	case "voyageai":
+		return "voyage-4-large"
 	default:
-		return "default"
+		return ""
+	}
+}
+
+func validateInitProvider(provider string) error {
+	switch provider {
+	case "openai", "anthropic", "gemini", "xai", "zai", "ollama",
+		"huggingface", "perplexity", "voyageai", "azurefoundry":
+		return nil
+	default:
+		return fmt.Errorf("unsupported provider %q for project scaffold", provider)
+	}
+}
+
+func mainTemplateForProvider(provider string) string {
+	switch provider {
+	case "ollama":
+		return ollamaMainGoTemplate
+	case "voyageai":
+		return voyageAIMainGoTemplate
+	case "azurefoundry":
+		return azureFoundryMainGoTemplate
+	default:
+		return mainGoTemplate
 	}
 }
 
@@ -199,13 +259,101 @@ func main() {
 }
 `
 
-var irisYamlTemplate = `# Iris project configuration
-default_provider: {{.Provider}}
-default_model: {{.Provider | defaultModel}}
+var ollamaMainGoTemplate = `package main
 
-# Provider configurations
-# API keys should be set via 'iris keys set <provider>' or environment variables
-providers:
-  {{.Provider}}:
-    api_key_env: {{.Provider | envVar}}
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/ollama"
+)
+
+func main() {
+	p := ollama.NewLocal()
+	c := core.NewClient(p)
+
+	resp, err := c.Chat("{{.Provider | defaultModel}}").
+		User("Hello, world!").
+		GetResponse(context.Background())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(resp.Output)
+}
+`
+
+var voyageAIMainGoTemplate = `package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/voyageai"
+)
+
+func main() {
+	apiKey := os.Getenv("{{.Provider | envVar}}")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "{{.Provider | envVar}} not set")
+		os.Exit(1)
+	}
+
+	p := voyageai.New(apiKey)
+	resp, err := p.CreateEmbeddings(context.Background(), &core.EmbeddingRequest{
+		Model: "{{.Provider | defaultModel}}",
+		Input: []core.EmbeddingInput{
+			{Text: "Hello, world!"},
+		},
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Generated %d embedding(s)\n", len(resp.Vectors))
+}
+`
+
+var azureFoundryMainGoTemplate = `package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/azurefoundry"
+)
+
+func main() {
+	p, err := azurefoundry.NewFromEnv()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(1)
+	}
+	c := core.NewClient(p)
+
+	resp, err := c.Chat("{{.Provider | defaultModel}}").
+		User("Hello, world!").
+		GetResponse(context.Background())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(1)
+	}
+
+	fmt.Println(resp.Output)
+}
+`
+
+var goModTemplate = `module {{.ProjectName}}
+
+go {{.GoVersion}}
+
+require github.com/petal-labs/iris {{.SDKVersion}}
 `

--- a/cli/commands/init_test.go
+++ b/cli/commands/init_test.go
@@ -1,7 +1,9 @@
 package commands
 
 import (
+	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -45,6 +47,9 @@ func TestEnvVarForProvider(t *testing.T) {
 		{"openai", "OPENAI_API_KEY"},
 		{"anthropic", "ANTHROPIC_API_KEY"},
 		{"ollama", "OLLAMA_API_KEY"},
+		{"huggingface", "HF_TOKEN"},
+		{"voyageai", "VOYAGE_API_KEY"},
+		{"azurefoundry", "AZURE_AI_API_KEY"},
 	}
 
 	for _, tt := range tests {
@@ -65,7 +70,14 @@ func TestDefaultModel(t *testing.T) {
 		{"openai", "gpt-4o"},
 		{"anthropic", "claude-sonnet-4-5"},
 		{"gemini", "gemini-2.5-flash"},
-		{"unknown", "default"},
+		{"xai", "grok-4-1-fast-non-reasoning"},
+		{"zai", "glm-4.7-flash"},
+		{"ollama", "llama3.2"},
+		{"perplexity", "sonar"},
+		{"huggingface", "meta-llama/Llama-3-8B-Instruct"},
+		{"azurefoundry", "gpt-4o"},
+		{"voyageai", "voyage-4-large"},
+		{"unknown", ""},
 	}
 
 	for _, tt := range tests {
@@ -83,7 +95,7 @@ func TestGenerateFile(t *testing.T) {
 	path := filepath.Join(tmpDir, "test.txt")
 
 	tmpl := "Hello {{.Provider}}!"
-	data := templateData{Provider: "world"}
+	data := templateData{ProjectName: "testproject", Provider: "world"}
 
 	err := generateFile(path, tmpl, data)
 	if err != nil {
@@ -105,7 +117,7 @@ func TestGenerateFileWithFuncs(t *testing.T) {
 	path := filepath.Join(tmpDir, "test.txt")
 
 	tmpl := "Provider: {{.Provider}}, Env: {{.Provider | envVar}}, Model: {{.Provider | defaultModel}}"
-	data := templateData{Provider: "openai"}
+	data := templateData{ProjectName: "testproject", Provider: "openai"}
 
 	err := generateFile(path, tmpl, data)
 	if err != nil {
@@ -175,15 +187,53 @@ func TestInitCreatesProjectStructure(t *testing.T) {
 		t.Error("main.go missing 'openai.New'")
 	}
 
-	// Verify iris.yaml exists and contains expected content
-	configPath := filepath.Join(projectPath, "iris.yaml")
-	configContent, err := os.ReadFile(configPath)
+	// Verify go.mod exists and declares a runnable module with Iris.
+	goModPath := filepath.Join(projectPath, "go.mod")
+	goModContent, err := os.ReadFile(goModPath)
 	if err != nil {
-		t.Fatalf("iris.yaml not created: %v", err)
+		t.Fatalf("go.mod not created: %v", err)
+	}
+	if !strings.Contains(string(goModContent), "module testproject") {
+		t.Error("go.mod missing generated module name")
+	}
+	if !strings.Contains(string(goModContent), "github.com/petal-labs/iris") {
+		t.Error("go.mod missing Iris dependency")
 	}
 
-	if !strings.Contains(string(configContent), "default_provider: openai") {
-		t.Error("iris.yaml missing 'default_provider: openai'")
+	if _, err := os.Stat(filepath.Join(projectPath, "iris.yaml")); !os.IsNotExist(err) {
+		t.Errorf("unused iris.yaml should not be generated, stat error = %v", err)
+	}
+}
+
+func TestInitRejectsUnsupportedProvider(t *testing.T) {
+	projectPath := filepath.Join(t.TempDir(), "badprovider")
+
+	err := runInitWithPath(projectPath, "not-a-provider")
+	if err == nil {
+		t.Fatal("runInit() should reject an unsupported provider")
+	}
+	if !strings.Contains(err.Error(), "unsupported provider") {
+		t.Errorf("error = %q, want unsupported provider guidance", err)
+	}
+	if _, statErr := os.Stat(projectPath); !os.IsNotExist(statErr) {
+		t.Errorf("project directory should not be created, stat error = %v", statErr)
+	}
+}
+
+func TestGeneratedProjectsCompile(t *testing.T) {
+	providers := []string{
+		"openai", "anthropic", "gemini", "xai", "zai",
+		"ollama", "huggingface", "perplexity", "voyageai", "azurefoundry",
+	}
+
+	for _, provider := range providers {
+		t.Run(provider, func(t *testing.T) {
+			projectPath := filepath.Join(t.TempDir(), "scaffold")
+			if err := runInitWithPath(projectPath, provider); err != nil {
+				t.Fatalf("runInitWithPath(%q) error = %v", provider, err)
+			}
+			compileGeneratedProject(t, projectPath)
+		})
 	}
 }
 
@@ -206,49 +256,30 @@ func TestInitErrorOnExistingDirectory(t *testing.T) {
 	}
 }
 
-// Helper function to run init with a specific path
 func runInitWithPath(projectPath, provider string) error {
-	projectName := filepath.Base(projectPath)
+	app := NewApp(WithIO(strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{}))
+	app.initProvider = provider
+	return app.runInit(nil, []string{projectPath})
+}
 
-	if err := validateProjectName(projectName); err != nil {
-		return err
+func compileGeneratedProject(t *testing.T, projectPath string) {
+	t.Helper()
+	repoRoot, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
 	}
 
-	if _, err := os.Stat(projectPath); err == nil {
-		return os.ErrExist
-	}
+	runGoCommand(t, projectPath, "mod", "edit", "-replace=github.com/petal-labs/iris="+repoRoot)
+	runGoCommand(t, projectPath, "test", "./...")
+}
 
-	dirs := []string{
-		projectPath,
-		filepath.Join(projectPath, "tools"),
+func runGoCommand(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("go", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go %s failed: %v\n%s", strings.Join(args, " "), err, output)
 	}
-
-	for _, dir := range dirs {
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return err
-		}
-	}
-
-	gitkeepDirs := []string{
-		filepath.Join(projectPath, "tools"),
-	}
-
-	for _, dir := range gitkeepDirs {
-		path := filepath.Join(dir, ".gitkeep")
-		if err := os.WriteFile(path, []byte{}, 0644); err != nil {
-			return err
-		}
-	}
-
-	mainPath := filepath.Join(projectPath, "main.go")
-	if err := generateFile(mainPath, mainGoTemplate, templateData{Provider: provider}); err != nil {
-		return err
-	}
-
-	configPath := filepath.Join(projectPath, "iris.yaml")
-	if err := generateFile(configPath, irisYamlTemplate, templateData{Provider: provider}); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/cli/commands/provider_factory.go
+++ b/cli/commands/provider_factory.go
@@ -2,20 +2,25 @@ package commands
 
 import (
 	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
 
 	"github.com/petal-labs/iris/cli/config"
 	"github.com/petal-labs/iris/core"
 	"github.com/petal-labs/iris/providers"
 	"github.com/petal-labs/iris/providers/anthropic"
+	"github.com/petal-labs/iris/providers/azurefoundry"
 	"github.com/petal-labs/iris/providers/gemini"
 	"github.com/petal-labs/iris/providers/huggingface"
 	"github.com/petal-labs/iris/providers/ollama"
 	"github.com/petal-labs/iris/providers/openai"
+	"github.com/petal-labs/iris/providers/perplexity"
+	"github.com/petal-labs/iris/providers/voyageai"
 	"github.com/petal-labs/iris/providers/xai"
 	"github.com/petal-labs/iris/providers/zai"
 )
-
-type providerConstructor func(apiKey, baseURL string) (core.Provider, error)
 
 // keylessProviders lists providers that can operate without an API key
 // (local inference). For these, a missing keystore entry is not an error:
@@ -33,65 +38,10 @@ func providerAllowsEmptyAPIKey(providerID string) bool {
 }
 
 func defaultProviderFactory() ProviderFactory {
-	constructors := map[string]providerConstructor{
-		"openai": func(apiKey, baseURL string) (core.Provider, error) {
-			var opts []openai.Option
-			if baseURL != "" {
-				opts = append(opts, openai.WithBaseURL(baseURL))
-			}
-			return openai.New(apiKey, opts...), nil
-		},
-		"anthropic": func(apiKey, baseURL string) (core.Provider, error) {
-			var opts []anthropic.Option
-			if baseURL != "" {
-				opts = append(opts, anthropic.WithBaseURL(baseURL))
-			}
-			return anthropic.New(apiKey, opts...), nil
-		},
-		"gemini": func(apiKey, baseURL string) (core.Provider, error) {
-			var opts []gemini.Option
-			if baseURL != "" {
-				opts = append(opts, gemini.WithBaseURL(baseURL))
-			}
-			return gemini.New(apiKey, opts...), nil
-		},
-		"xai": func(apiKey, baseURL string) (core.Provider, error) {
-			var opts []xai.Option
-			if baseURL != "" {
-				opts = append(opts, xai.WithBaseURL(baseURL))
-			}
-			return xai.New(apiKey, opts...), nil
-		},
-		"zai": func(apiKey, baseURL string) (core.Provider, error) {
-			var opts []zai.Option
-			if baseURL != "" {
-				opts = append(opts, zai.WithBaseURL(baseURL))
-			}
-			return zai.New(apiKey, opts...), nil
-		},
-		"ollama": func(apiKey, baseURL string) (core.Provider, error) {
-			var opts []ollama.Option
-			if baseURL != "" {
-				opts = append(opts, ollama.WithBaseURL(baseURL))
-			}
-			if apiKey != "" {
-				opts = append(opts, ollama.WithAPIKey(apiKey))
-			}
-			return ollama.New(opts...), nil
-		},
-		"huggingface": func(apiKey, baseURL string) (core.Provider, error) {
-			var opts []huggingface.Option
-			if baseURL != "" {
-				opts = append(opts, huggingface.WithBaseURL(baseURL))
-			}
-			return huggingface.New(apiKey, opts...), nil
-		},
-	}
-
 	return func(providerID, apiKey string, cfg *config.Config) (core.Provider, error) {
-		baseURL := providerBaseURL(cfg, providerID)
-		if ctor, ok := constructors[providerID]; ok {
-			return ctor(apiKey, baseURL)
+		provider, handled, err := createBuiltInProvider(providerID, apiKey, providerConfig(cfg, providerID))
+		if handled {
+			return provider, err
 		}
 
 		// Fall back to registry for externally-registered providers.
@@ -103,13 +53,175 @@ func defaultProviderFactory() ProviderFactory {
 	}
 }
 
-func providerBaseURL(cfg *config.Config, providerID string) string {
+func providerConfig(cfg *config.Config, providerID string) config.ProviderConfig {
 	if cfg == nil {
-		return ""
+		return config.ProviderConfig{}
 	}
 	pc := cfg.GetProvider(providerID)
 	if pc == nil {
-		return ""
+		return config.ProviderConfig{}
 	}
-	return pc.BaseURL
+	return *pc
+}
+
+func createBuiltInProvider(providerID, apiKey string, cfg config.ProviderConfig) (core.Provider, bool, error) {
+	switch providerID {
+	case "openai":
+		return newOpenAIProvider(apiKey, cfg.BaseURL), true, nil
+	case "anthropic":
+		return newAnthropicProvider(apiKey, cfg.BaseURL), true, nil
+	case "gemini":
+		return newGeminiProvider(apiKey, cfg.BaseURL), true, nil
+	case "xai":
+		return newXAIProvider(apiKey, cfg.BaseURL), true, nil
+	case "zai":
+		return newZAIProvider(apiKey, cfg.BaseURL), true, nil
+	case "ollama":
+		return newOllamaProvider(apiKey, cfg.BaseURL), true, nil
+	case "huggingface":
+		return newHuggingFaceProvider(apiKey, cfg.BaseURL), true, nil
+	case "perplexity":
+		return newPerplexityProvider(apiKey, cfg.BaseURL), true, nil
+	case "voyageai":
+		return newVoyageAIProvider(apiKey, cfg.BaseURL), true, nil
+	case "azurefoundry":
+		provider, err := newAzureFoundryProvider(apiKey, cfg)
+		return provider, true, err
+	default:
+		return nil, false, nil
+	}
+}
+
+func newOpenAIProvider(apiKey, baseURL string) core.Provider {
+	var opts []openai.Option
+	if baseURL != "" {
+		opts = append(opts, openai.WithBaseURL(baseURL))
+	}
+	return openai.New(apiKey, opts...)
+}
+
+func newAnthropicProvider(apiKey, baseURL string) core.Provider {
+	var opts []anthropic.Option
+	if baseURL != "" {
+		opts = append(opts, anthropic.WithBaseURL(baseURL))
+	}
+	return anthropic.New(apiKey, opts...)
+}
+
+func newGeminiProvider(apiKey, baseURL string) core.Provider {
+	var opts []gemini.Option
+	if baseURL != "" {
+		opts = append(opts, gemini.WithBaseURL(baseURL))
+	}
+	return gemini.New(apiKey, opts...)
+}
+
+func newXAIProvider(apiKey, baseURL string) core.Provider {
+	var opts []xai.Option
+	if baseURL != "" {
+		opts = append(opts, xai.WithBaseURL(baseURL))
+	}
+	return xai.New(apiKey, opts...)
+}
+
+func newZAIProvider(apiKey, baseURL string) core.Provider {
+	var opts []zai.Option
+	if baseURL != "" {
+		opts = append(opts, zai.WithBaseURL(baseURL))
+	}
+	return zai.New(apiKey, opts...)
+}
+
+func newOllamaProvider(apiKey, baseURL string) core.Provider {
+	var opts []ollama.Option
+	if baseURL != "" {
+		opts = append(opts, ollama.WithBaseURL(baseURL))
+	}
+	if apiKey != "" {
+		opts = append(opts, ollama.WithAPIKey(apiKey))
+	}
+	return ollama.New(opts...)
+}
+
+func newHuggingFaceProvider(apiKey, baseURL string) core.Provider {
+	var opts []huggingface.Option
+	if baseURL != "" {
+		opts = append(opts, huggingface.WithBaseURL(baseURL))
+	}
+	return huggingface.New(apiKey, opts...)
+}
+
+func newPerplexityProvider(apiKey, baseURL string) core.Provider {
+	var opts []perplexity.Option
+	if baseURL != "" {
+		opts = append(opts, perplexity.WithBaseURL(baseURL))
+	}
+	return perplexity.New(apiKey, opts...)
+}
+
+func newVoyageAIProvider(apiKey, baseURL string) core.Provider {
+	var opts []voyageai.Option
+	if baseURL != "" {
+		opts = append(opts, voyageai.WithBaseURL(baseURL))
+	}
+	return voyageai.New(apiKey, opts...)
+}
+
+func newAzureFoundryProvider(apiKey string, cfg config.ProviderConfig) (core.Provider, error) {
+	endpoint := strings.TrimSpace(cfg.Endpoint)
+	if endpoint == "" {
+		endpoint = strings.TrimSpace(cfg.BaseURL)
+	}
+	if endpoint == "" {
+		endpoint = strings.TrimSpace(os.Getenv(azurefoundry.EnvEndpoint))
+	}
+	if endpoint == "" {
+		return nil, fmt.Errorf("azurefoundry endpoint required: set providers.azurefoundry.endpoint or %s", azurefoundry.EnvEndpoint)
+	}
+	cfg.DeploymentID = strings.TrimSpace(cfg.DeploymentID)
+	if cfg.DeploymentID == "" {
+		cfg.DeploymentID = strings.TrimSpace(os.Getenv(azurefoundry.EnvDeploymentID))
+	}
+	cfg.APIVersion = strings.TrimSpace(cfg.APIVersion)
+	if err := validateAzureFoundryConfig(endpoint, cfg); err != nil {
+		return nil, err
+	}
+
+	return azurefoundry.New(endpoint, apiKey, azureFoundryOptions(cfg)...), nil
+}
+
+func azureFoundryOptions(cfg config.ProviderConfig) []azurefoundry.Option {
+	opts := make([]azurefoundry.Option, 0, 3)
+	if cfg.DeploymentID != "" {
+		opts = append(opts, azurefoundry.WithDeploymentID(cfg.DeploymentID))
+	}
+	if cfg.APIVersion != "" {
+		opts = append(opts, azurefoundry.WithAPIVersion(cfg.APIVersion))
+	}
+	if cfg.UseOpenAIEndpoint {
+		opts = append(opts, azurefoundry.WithOpenAIEndpoint())
+	}
+	return opts
+}
+
+var azureConfigValuePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+func validateAzureFoundryConfig(endpoint string, cfg config.ProviderConfig) error {
+	parsed, err := url.ParseRequestURI(endpoint)
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return fmt.Errorf("invalid azurefoundry endpoint %q: must be an absolute HTTP(S) URL", endpoint)
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
+		return fmt.Errorf("invalid azurefoundry endpoint %q: credentials, queries, and fragments are not allowed", endpoint)
+	}
+	if parsed.EscapedPath() != "" && parsed.EscapedPath() != "/" {
+		return fmt.Errorf("invalid azurefoundry endpoint %q: path must be empty", endpoint)
+	}
+	if cfg.DeploymentID != "" && !azureConfigValuePattern.MatchString(cfg.DeploymentID) {
+		return fmt.Errorf("invalid azurefoundry deployment_id %q", cfg.DeploymentID)
+	}
+	if cfg.APIVersion != "" && !azureConfigValuePattern.MatchString(cfg.APIVersion) {
+		return fmt.Errorf("invalid azurefoundry api_version %q", cfg.APIVersion)
+	}
+	return nil
 }

--- a/cli/config/config.go
+++ b/cli/config/config.go
@@ -18,7 +18,11 @@ type Config struct {
 
 // ProviderConfig holds configuration for a specific provider.
 type ProviderConfig struct {
-	BaseURL string `yaml:"base_url,omitempty"`
+	BaseURL           string `yaml:"base_url,omitempty"`
+	Endpoint          string `yaml:"endpoint,omitempty"`
+	DeploymentID      string `yaml:"deployment_id,omitempty"`
+	APIVersion        string `yaml:"api_version,omitempty"`
+	UseOpenAIEndpoint bool   `yaml:"use_openai_endpoint,omitempty"`
 }
 
 // DefaultConfigPath returns the default configuration file path for the current platform.

--- a/cli/config/config_test.go
+++ b/cli/config/config_test.go
@@ -77,6 +77,11 @@ default_model: gpt-4o
 providers:
   openai:
     base_url: https://api.openai.com/v1
+  azurefoundry:
+    endpoint: https://example.openai.azure.com
+    deployment_id: production-chat
+    api_version: 2025-01-01-preview
+    use_openai_endpoint: true
   anthropic:
 `
 	tmpDir := t.TempDir()
@@ -96,13 +101,27 @@ providers:
 	if cfg.DefaultModel != "gpt-4o" {
 		t.Errorf("DefaultModel = %q, want gpt-4o", cfg.DefaultModel)
 	}
-	if len(cfg.Providers) != 2 {
-		t.Errorf("len(Providers) = %d, want 2", len(cfg.Providers))
+	if len(cfg.Providers) != 3 {
+		t.Errorf("len(Providers) = %d, want 3", len(cfg.Providers))
 	}
 
 	openai := cfg.Providers["openai"]
 	if openai.BaseURL != "https://api.openai.com/v1" {
 		t.Errorf("openai.BaseURL = %q, want https://api.openai.com/v1", openai.BaseURL)
+	}
+
+	azure := cfg.Providers["azurefoundry"]
+	if azure.Endpoint != "https://example.openai.azure.com" {
+		t.Errorf("azurefoundry.Endpoint = %q, want Azure endpoint", azure.Endpoint)
+	}
+	if azure.DeploymentID != "production-chat" {
+		t.Errorf("azurefoundry.DeploymentID = %q, want production-chat", azure.DeploymentID)
+	}
+	if azure.APIVersion != "2025-01-01-preview" {
+		t.Errorf("azurefoundry.APIVersion = %q, want 2025-01-01-preview", azure.APIVersion)
+	}
+	if !azure.UseOpenAIEndpoint {
+		t.Error("azurefoundry.UseOpenAIEndpoint = false, want true")
 	}
 }
 

--- a/docs/changes/2026-08-19_v0.18.0_cli-provider-init-reliability.md
+++ b/docs/changes/2026-08-19_v0.18.0_cli-provider-init-reliability.md
@@ -1,0 +1,199 @@
+---
+date: 2026-08-19
+version: v0.18.0
+feature: CLI provider and init scaffold reliability
+product: iris
+change_type: bugfix
+affected_components: [cli/config/config.go, cli/config/config_test.go, cli/commands/app.go, cli/commands/provider_factory.go, cli/commands/chat_test.go, cli/commands/init.go, cli/commands/init_test.go, tests/integration/cli_test.go, README.md, docs/changes/2026-08-19_v0.18.0_cli-provider-init-reliability.md]
+related_frds: [GitHub issue #66]
+---
+
+## Summary
+
+The CLI can now construct every built-in provider, including Perplexity,
+Voyage AI, and Azure AI Foundry, without losing provider-specific configuration.
+`iris init` now validates its provider, emits a standalone Go module, selects a
+real model for all ten providers, and generates provider-appropriate starter code
+that compiles without hand-editing.
+
+## Motivation
+
+The provider registry fallback accepted Perplexity and Voyage AI identifiers but
+discarded their configured `base_url`. Azure AI Foundry could not be constructed
+by the CLI because its endpoint, deployment, API version, and endpoint mode were
+not expressible in `~/.iris/config.yaml`. Separately, `iris init` emitted an unused
+`iris.yaml`, omitted `go.mod`, used `"default"` for four providers, and generated
+constructor calls that did not compile for Azure AI Foundry.
+
+## What Changed
+
+### New Additions
+
+- `ProviderConfig.Endpoint string` (`endpoint`) supplies the Azure resource URL.
+- `ProviderConfig.DeploymentID string` (`deployment_id`) supplies an optional
+  Azure deployment name.
+- `ProviderConfig.APIVersion string` (`api_version`) overrides Azure's selected
+  API version.
+- `ProviderConfig.UseOpenAIEndpoint bool` (`use_openai_endpoint`) selects Azure
+  OpenAI deployment-style routes.
+- Explicit CLI constructors for `perplexity`, `voyageai`, and `azurefoundry`.
+- Provider-specific project templates for local Ollama, Voyage AI embeddings,
+  and Azure AI Foundry environment configuration.
+- Generated `go.mod` files using Go 1.24.0 and Iris v0.17.0, the latest released
+  SDK available while this v0.18.0 change was developed.
+
+### Modifications
+
+- Every built-in provider now receives `providers.<id>.base_url` through its
+  typed `WithBaseURL` option instead of relying on the registry fallback.
+- Azure endpoint resolution uses `providers.azurefoundry.endpoint`, then the
+  backward-compatible `base_url`, then `AZURE_AI_ENDPOINT`. Deployment resolution
+  uses `deployment_id`, then `AZURE_AI_DEPLOYMENT_ID`.
+- Azure API keys continue to come from the encrypted CLI keystore; endpoint and
+  deployment environment variables never contain credentials.
+- `defaultModel()` now returns concrete models for Perplexity (`sonar`),
+  Hugging Face (`meta-llama/Llama-3-8B-Instruct`), Azure AI Foundry (`gpt-4o`),
+  and Voyage AI (`voyage-4-large`). Unknown providers return an empty model and
+  are rejected before project files are created.
+- `envVarForProvider()` now emits the provider-defined names `HF_TOKEN`,
+  `VOYAGE_API_KEY`, and `AZURE_AI_API_KEY`.
+- `iris init` instructions now end with `go run .`; local Ollama does not request
+  an API key, while Azure includes its required endpoint environment variable.
+- Global provider flag help no longer implies that only three providers exist.
+
+### Removals
+
+- `iris init` no longer generates `iris.yaml`. No Iris runtime consumed that file,
+  and its `api_key_env` shape was not part of the real CLI config schema.
+
+## Technical Specification
+
+### Data Schemas / Types
+
+The CLI provider configuration shape is now:
+
+```go
+type ProviderConfig struct {
+    BaseURL           string `yaml:"base_url,omitempty"`
+    Endpoint          string `yaml:"endpoint,omitempty"`
+    DeploymentID      string `yaml:"deployment_id,omitempty"`
+    APIVersion        string `yaml:"api_version,omitempty"`
+    UseOpenAIEndpoint bool   `yaml:"use_openai_endpoint,omitempty"`
+}
+```
+
+The four Azure-specific fields are ignored by other providers. Existing
+`base_url` configurations retain their behavior.
+
+### API Endpoints
+
+N/A — Iris is an SDK and CLI; this change adds no daemon endpoint. Azure requests
+use the provider's existing Model Inference or Azure OpenAI URL builders.
+
+### CLI Interface
+
+The command signature remains:
+
+```text
+iris init <project-name> [--provider <provider-id>]
+```
+
+Supported scaffold provider IDs are `openai`, `anthropic`, `gemini`, `xai`,
+`zai`, `ollama`, `huggingface`, `perplexity`, `voyageai`, and `azurefoundry`.
+The generated layout is:
+
+```text
+<project-name>/
+├── go.mod
+├── main.go
+└── tools/
+    └── .gitkeep
+```
+
+### Go Package API
+
+N/A — no exported SDK identifier changed. The CLI uses existing provider
+constructors and options.
+
+### Configuration
+
+```yaml
+providers:
+  azurefoundry:
+    endpoint: https://my-resource.openai.azure.com
+    deployment_id: production-chat
+    api_version: 2025-01-01-preview
+    use_openai_endpoint: true
+```
+
+`endpoint` is required unless `base_url` or `AZURE_AI_ENDPOINT` is set.
+`deployment_id` is optional and falls back to `AZURE_AI_DEPLOYMENT_ID`.
+`api_version` is optional; the Azure provider's endpoint-mode default applies
+when omitted. `use_openai_endpoint` defaults to `false`.
+
+## Usage Examples
+
+### Example: Azure AI Foundry CLI chat
+
+```bash
+iris keys set azurefoundry
+export AZURE_AI_ENDPOINT=https://my-resource.services.ai.azure.com
+iris chat --provider azurefoundry --model gpt-4o --prompt "Hello"
+```
+
+For an Azure OpenAI deployment, set `deployment_id` and
+`use_openai_endpoint: true` in `~/.iris/config.yaml`.
+
+### Example: Generate and run a Perplexity project
+
+```bash
+iris init search-app --provider perplexity
+cd search-app
+export PERPLEXITY_API_KEY=<your-key>
+go run .
+```
+
+An unsupported provider fails before creating the destination directory:
+
+```text
+unsupported provider "not-a-provider" for project scaffold
+```
+
+## Integration Notes
+
+This changes only the Iris CLI and generated standalone Iris SDK projects. It
+does not change PetalFlow, Cortex, PetalTrace, graph compilation, or MCP adapter
+contracts. CLI API keys remain isolated in the existing encrypted keystore.
+
+## Breaking Changes & Migration
+
+Projects generated by older CLI versions included `iris.yaml`; new projects do
+not. That file was never consumed, so existing projects do not need to remove it.
+Scripts that assert the old generated file list must instead expect `go.mod`.
+
+## Deferred / Out of Scope
+
+- Voyage AI remains an embeddings, contextualized-embeddings, and reranking
+  provider. `iris chat --provider voyageai` now resolves the provider and returns
+  its precise `chat is not supported` capability error; this change does not add
+  a chat API that Voyage AI itself does not offer.
+- The generated SDK dependency is pinned to the latest published release rather
+  than resolving an unbounded version at generation time.
+- Entra ID credential construction is not exposed through the CLI config; the
+  Azure SDK provider continues to support it directly.
+
+## Testing Notes
+
+- `cli/config/config_test.go` parses and asserts every Azure YAML field.
+- `cli/commands/chat_test.go` exercises Perplexity and Voyage AI base URLs at
+  fake HTTP servers, both Azure endpoint modes/config sources, stored keystore
+  keys, the missing-endpoint error, and Voyage AI's capability error.
+- `cli/commands/init_test.go` generates and compiles projects for all ten providers
+  using the current checkout as a local module replacement. It also covers model
+  and environment mappings, unsupported providers, the generated `go.mod`, and
+  removal of unused `iris.yaml`.
+- `go test -race -coverprofile=/tmp/iris-issue66-coverage.out -covermode=atomic ./...`
+  passed with 80.8% total statement coverage.
+- `go vet ./...` passed.
+- `go test -tags=integration ./tests/integration/... -run '^TestCLI_Init' -count=1`
+  passed against a built CLI binary.

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -120,7 +120,7 @@ func TestCLI_Init(t *testing.T) {
 	// Verify files exist
 	files := []string{
 		"main.go",
-		"iris.yaml",
+		"go.mod",
 		"tools/.gitkeep",
 	}
 


### PR DESCRIPTION
Closes #66.

## Issue and user impact

The CLI provider factory only had typed constructors for seven providers. Perplexity and Voyage AI could fall through to the registry, but that path discarded configured base URLs, while Azure AI Foundry could not be configured with its required endpoint or optional deployment settings at all. In addition, `iris init` generated an unused `iris.yaml`, omitted `go.mod`, fell back to a fake `default` model for several providers, and emitted constructor calls that did not compile for Azure.

Users could therefore select provider identifiers that the SDK advertised but the CLI could not use correctly, and newly scaffolded projects required manual repair before they could build.

## Root cause

- The CLI factory treated provider construction as a uniform `(apiKey, baseURL)` operation even though Azure needs endpoint-specific options.
- Registry fallback accepts only the API key, so provider configuration was silently lost.
- The init generator used one chat template for providers with different constructor and capability contracts.
- The scaffold did not generate module metadata and emitted a configuration file that no runtime consumed.

## Fix

- Add explicit typed factory paths for all ten built-in providers.
- Preserve `base_url` for Perplexity and Voyage AI.
- Extend CLI provider configuration with validated Azure `endpoint`, `deployment_id`, `api_version`, and `use_openai_endpoint` fields.
- Support `AZURE_AI_ENDPOINT` and `AZURE_AI_DEPLOYMENT_ID` fallbacks while keeping API keys in the encrypted keystore.
- Reject malformed Azure endpoints and unsafe path/query configuration before constructing requests.
- Generate standalone `go.mod` files and provider-specific starters for Ollama, Voyage AI embeddings, and Azure AI Foundry.
- Add concrete default models and correct environment-variable names for every supported scaffold provider.
- Stop generating unused `iris.yaml` files and reject unsupported providers before creating a project directory.
- Update CLI help, README configuration guidance, tagged integration expectations, and the required change record.

Voyage AI remains an embeddings and reranking provider. `iris chat --provider voyageai` now resolves the provider and returns its precise unsupported-chat capability error instead of an unsupported-provider error; its generated starter demonstrates embeddings.

## Verification

- `go test -race -coverprofile=/tmp/iris-issue66-coverage.out -covermode=atomic ./...`
- 80.8% total statement coverage
- `go vet ./...`
- `go test -tags=integration ./tests/integration/... -run '^TestCLI_Init' -count=1`
- Generated and compiled standalone projects for all ten providers using the current checkout as a local module replacement
- HTTP-boundary tests for Perplexity, Voyage AI, Azure config/environment routing, stored keystore keys, and invalid Azure input
