### PR TITLE
feat: add Gemini embeddings and fix reasoning capabilities

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -11,7 +11,7 @@ Cells reflect each provider's `Supports()` implementation. For chat-based featur
 |----------|------|-----------|--------------|-----------|----------------|----------------|--------------------|------------|-----------|--------|
 | OpenAI | Yes | Yes | Yes | Yes* | Yes* | Yes* | Yes | Yes | No | Yes |
 | Anthropic | Yes | Yes | Yes | Yes | No | No | No† | No | No | No |
-| Gemini | Yes | Yes | Yes | Yes | No | No | Yes | No | No | Yes |
+| Gemini | Yes | Yes | Yes | Yes | No | No | Yes | Yes | No | Yes |
 | xAI (Grok) | Yes | Yes | Yes | Yes | No | No | No† | No | No | No |
 | Perplexity | Yes | Yes | Yes | Yes | No | No | No† | No | No | No |
 | Z.ai (GLM) | Yes | Yes | Yes | Yes | No | No | No† | No | No | No |
@@ -30,9 +30,9 @@ Perplexity additionally supports web-search grounding (`core.SearchOptions`, res
 
 | Provider | Status | Features |
 |----------|--------|----------|
-| OpenAI | Supported | Chat, Streaming, Tools, Batch API, Structured Output, Embeddings, Images, Responses API (GPT-5+) |
+| OpenAI | Supported | Chat, Streaming, Tools, Reasoning, Batch API, Structured Output, Embeddings, Images, Responses API (GPT-5+) |
 | Anthropic | Supported | Chat, Streaming, Tools, Reasoning |
-| Google Gemini | Supported | Chat, Streaming, Tools, Reasoning, Structured Output, Images |
+| Google Gemini | Supported | Chat, Streaming, Tools, Reasoning, Structured Output, Embeddings, Images |
 | xAI Grok | Supported | Chat, Streaming, Tools, Reasoning |
 | Z.ai GLM | Supported | Chat, Streaming, Tools, Thinking |
 | Perplexity | Supported | Chat, Streaming, Tools, Reasoning, Web Search + Citations |
@@ -196,10 +196,17 @@ resp, err := client.Chat(anthropic.ModelClaudeSonnet46).
 
 **Image Generation Models**: gemini-3.1-flash-image-preview, gemini-3-pro-image-preview, gemini-2.5-flash-image (Nano Banana)
 
+**Embedding Models**:
+
+| Model | Display Name | Input Types | Notes |
+|-------|--------------|-------------|-------|
+| gemini-embedding-001 | Gemini Embedding 001 | Query, Document | Configurable output dimensions |
+
 **Special Features**:
 - Native multimodal support
 - Long context windows
 - Grounding with Google Search
+- Batch text embeddings with query/document retrieval optimization
 
 **Usage Example**:
 ```go
@@ -209,6 +216,13 @@ client := core.NewClient(provider)
 resp, err := client.Chat(gemini.ModelGemini25Flash).
     User("Summarize this document.").
     GetResponse(ctx)
+
+embeddingProvider := gemini.New(os.Getenv("GEMINI_API_KEY"))
+embeddingResp, err := embeddingProvider.CreateEmbeddings(ctx, &core.EmbeddingRequest{
+    Model:     gemini.ModelGeminiEmbedding001,
+    Input:     []core.EmbeddingInput{{Text: "A document to index"}},
+    InputType: core.InputTypeDocument,
+})
 ```
 
 ---
@@ -517,7 +531,7 @@ resp, err := client.Chat("gpt-5.6"). // any deployed model
 | Web search integration | Perplexity |
 | Local/private deployment | Ollama |
 | Cost-sensitive applications | HuggingFace (routing), Ollama (local) |
-| Embeddings and RAG | VoyageAI |
+| Embeddings and RAG | Gemini, VoyageAI |
 | Code generation | OpenAI (Codex models), Anthropic |
 | Multimodal (vision) | OpenAI (GPT-4o), Anthropic (Claude), Gemini, Azure AI Foundry vision deployments |
 | Image generation | OpenAI (DALL-E, GPT-Image), Gemini (Nano Banana) |

--- a/docs/changes/2026-08-19_v0.18.0_gemini-embeddings-openai-reasoning.md
+++ b/docs/changes/2026-08-19_v0.18.0_gemini-embeddings-openai-reasoning.md
@@ -1,0 +1,151 @@
+---
+date: 2026-08-19
+version: v0.18.0
+feature: Gemini embeddings and OpenAI reasoning capabilities
+product: iris
+change_type: feature
+affected_components:
+  - providers/gemini/embeddings.go
+  - providers/gemini/embeddings_test.go
+  - providers/gemini/models.go
+  - providers/gemini/provider.go
+  - providers/gemini/provider_test.go
+  - providers/openai/provider.go
+  - providers/openai/provider_test.go
+  - tests/integration/gemini_test.go
+  - docs/PROVIDERS.md
+  - docs/changes/2026-08-19_v0.18.0_gemini-embeddings-openai-reasoning.md
+related_frds: []
+---
+
+## Summary
+
+The Gemini provider now implements `core.EmbeddingProvider` through Google's synchronous `batchEmbedContents` API and exposes `gemini-embedding-001` in its model catalog. The OpenAI provider now reports provider-level reasoning support, while model-level capability declarations continue to identify which OpenAI models accept reasoning options. The provider comparison matrix and Gemini usage documentation reflect both capability corrections.
+
+## Motivation
+
+Gemini's upstream API supports text embeddings, but Iris previously exposed neither an embedding operation nor an embedding model for the provider. OpenAI already routed reasoning-capable models through the Responses API, but its provider-level `Supports(core.FeatureReasoning)` response incorrectly returned `false`; capability discovery could therefore reject functionality that was already implemented.
+
+## What Changed
+
+### New Additions
+
+- `(*gemini.Gemini).CreateEmbeddings(context.Context, *core.EmbeddingRequest) (*core.EmbeddingResponse, error)` sends one or more text inputs to Gemini's synchronous batch embedding endpoint and preserves input order, IDs, and metadata.
+- `gemini.ModelGeminiEmbedding001` identifies the `gemini-embedding-001` embedding model.
+- Gemini embedding tests cover request mapping, output mapping, validation, authentication, normalized provider errors, malformed responses, mismatched output counts, and timeouts.
+- A tagged Gemini integration test exercises a two-input embedding request when `GEMINI_API_KEY` is available.
+
+### Modifications
+
+- `(*gemini.Gemini).Supports(core.FeatureEmbeddings)` now returns `true`, and the Gemini model catalog declares embedding support only for `gemini-embedding-001`.
+- `(*openai.OpenAI).Supports(core.FeatureReasoning)` now returns `true`. Model-specific support is unchanged: reasoning-capable Responses models such as `gpt-5.6` report reasoning support, while models such as `gpt-4.1` do not.
+- `docs/PROVIDERS.md` now lists Gemini embeddings and explicitly includes reasoning in the OpenAI feature summary.
+
+### Removals
+
+N/A. No APIs, models, or capabilities were removed.
+
+## Technical Specification
+
+### Data Schemas / Types
+
+Gemini batch requests use the following internal JSON shape. Every item uses the same model resource and carries one input string:
+
+```go
+type geminiBatchEmbeddingRequest struct {
+    Requests []geminiEmbeddingRequest `json:"requests"`
+}
+
+type geminiEmbeddingRequest struct {
+    Model                string        `json:"model"`
+    Content              geminiContent `json:"content"`
+    TaskType             string        `json:"taskType,omitempty"`
+    OutputDimensionality *int          `json:"outputDimensionality,omitempty"`
+}
+```
+
+`core.InputTypeQuery` maps to `RETRIEVAL_QUERY`, and `core.InputTypeDocument` maps to `RETRIEVAL_DOCUMENT`. `Dimensions` maps to `outputDimensionality`. The deployed v1beta batch endpoint currently applies these legacy top-level fields; live validation showed that its newer nested `embedContentConfig` shape is accepted but ignored. Gemini returns float vectors only; explicit user identifiers, truncation settings, base64 encodings, or quantized output types fail with `core.ErrNotSupported` before any HTTP request.
+
+### API Endpoints
+
+`POST /v1beta/models/{model}:batchEmbedContents`
+
+The provider authenticates with `x-goog-api-key`, sends one `requests` entry per `core.EmbeddingInput`, and reads ordered vectors from `embeddings`. HTTP errors are converted through Gemini's existing normalized error mapping. When the API supplies aggregate `usageMetadata.promptTokenCount`, that value populates both `PromptTokens` and `TotalTokens`; the deployed endpoint may omit this optional metadata, leaving both values at zero.
+
+### CLI Interface
+
+N/A. This change does not add or modify CLI commands.
+
+### Go Package API
+
+```go
+func (p *Gemini) CreateEmbeddings(
+    ctx context.Context,
+    req *core.EmbeddingRequest,
+) (*core.EmbeddingResponse, error)
+```
+
+The request requires a non-empty safe model identifier and at least one non-blank text input. Optional IDs and metadata are copied to the corresponding response vectors without aliasing request metadata. Provider timeouts and earlier caller deadlines are enforced by the shared timeout helper.
+
+```go
+const ModelGeminiEmbedding001 core.ModelID = "gemini-embedding-001"
+```
+
+This is the Gemini model catalog entry that advertises `core.FeatureEmbeddings`.
+
+### Configuration
+
+No new configuration fields were introduced. Gemini embeddings use the existing API key, base URL, HTTP client, and timeout provider options.
+
+## Usage Examples
+
+### Example: Embed documents for retrieval
+
+```go
+provider := gemini.New(os.Getenv("GEMINI_API_KEY"))
+dimensions := 768
+
+response, err := provider.CreateEmbeddings(ctx, &core.EmbeddingRequest{
+    Model: gemini.ModelGeminiEmbedding001,
+    Input: []core.EmbeddingInput{
+        {ID: "policy-1", Text: "Refunds are available for 30 days."},
+        {ID: "policy-2", Text: "Shipping normally takes three business days."},
+    },
+    InputType:  core.InputTypeDocument,
+    Dimensions: &dimensions,
+})
+if err != nil {
+    return err
+}
+
+fmt.Printf("embedded %d documents\n", len(response.Vectors))
+```
+
+### Example: Reject an unsupported encoding
+
+```go
+_, err := provider.CreateEmbeddings(ctx, &core.EmbeddingRequest{
+    Model:          gemini.ModelGeminiEmbedding001,
+    Input:          []core.EmbeddingInput{{Text: "example"}},
+    EncodingFormat: core.EncodingFormatBase64,
+})
+if !errors.Is(err, core.ErrNotSupported) {
+    return fmt.Errorf("expected unsupported encoding error: %w", err)
+}
+```
+
+## Integration Notes
+
+Any Iris consumer that discovers optional operations through `core.Provider.Supports` can now select Gemini for embeddings and OpenAI for reasoning. Consumers should still inspect `core.ModelInfo.Capabilities` before sending reasoning options to a specific OpenAI model. No PetalFlow, Cortex, PetalTrace, graph IR, or MCP adapter contract changes are required because this implementation uses Iris's existing embedding and capability interfaces.
+
+## Breaking Changes & Migration
+
+None. Provider capability discovery becomes more accurate, and the added Gemini operation is backward compatible.
+
+## Deferred / Out of Scope
+
+Adding embeddings for Z.ai or Hugging Face is outside the issue's acceptance criteria and remains deferred. Gemini media embeddings, asynchronous batches, title parameters, truncation control, custom task types beyond query/document retrieval, and non-float output encodings are also outside this change.
+
+## Testing Notes
+
+`providers/gemini/embeddings_test.go` validates the HTTP boundary and all supported option mappings, rejects invalid and unsupported requests before network access, normalizes rate-limit responses, detects invalid payloads and vector-count mismatches, and confirms provider timeout cancellation. `providers/gemini/provider_test.go` and `providers/openai/provider_test.go` verify provider- and model-level capability declarations. `tests/integration/gemini_test.go` exercises live batch embeddings when credentials are supplied; it skips without `GEMINI_API_KEY`.

--- a/providers/gemini/embeddings.go
+++ b/providers/gemini/embeddings.go
@@ -1,0 +1,199 @@
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
+	"github.com/petal-labs/iris/providers/internal/timeoutx"
+)
+
+const (
+	geminiBatchEmbeddingPathFormat = "%s/v1beta/models/%s:batchEmbedContents"
+	geminiEmbeddingTaskQuery       = "RETRIEVAL_QUERY"
+	geminiEmbeddingTaskDocument    = "RETRIEVAL_DOCUMENT"
+)
+
+type geminiBatchEmbeddingRequest struct {
+	Requests []geminiEmbeddingRequest `json:"requests"`
+}
+
+type geminiEmbeddingRequest struct {
+	Model                string        `json:"model"`
+	Content              geminiContent `json:"content"`
+	TaskType             string        `json:"taskType,omitempty"`
+	OutputDimensionality *int          `json:"outputDimensionality,omitempty"`
+}
+
+type geminiBatchEmbeddingResponse struct {
+	Embeddings    []geminiContentEmbedding `json:"embeddings"`
+	UsageMetadata geminiEmbeddingUsage     `json:"usageMetadata"`
+}
+
+type geminiContentEmbedding struct {
+	Values []float32 `json:"values"`
+}
+
+type geminiEmbeddingUsage struct {
+	PromptTokenCount int `json:"promptTokenCount"`
+}
+
+var geminiEmbeddingModelPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+// CreateEmbeddings generates embeddings for one or more text inputs through
+// Gemini's synchronous batchEmbedContents endpoint.
+func (p *Gemini) CreateEmbeddings(ctx context.Context, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	if err := normalize.RequireAPIKey("gemini", p.config.APIKey); err != nil {
+		return nil, err
+	}
+	if err := validateGeminiEmbeddingRequest(ctx, req); err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := timeoutx.Apply(ctx, p.config.Timeout)
+	defer cancel()
+
+	body, err := json.Marshal(buildGeminiEmbeddingRequest(req))
+	if err != nil {
+		return nil, newDecodeError(err)
+	}
+
+	response, err := p.sendEmbeddingRequest(ctx, req.Model, body)
+	if err != nil {
+		return nil, err
+	}
+	return mapGeminiEmbeddingResponse(response, req)
+}
+
+func (p *Gemini) sendEmbeddingRequest(ctx context.Context, model core.ModelID, body []byte) (*geminiBatchEmbeddingResponse, error) {
+	endpoint := fmt.Sprintf(geminiBatchEmbeddingPathFormat, strings.TrimRight(p.config.BaseURL, "/"), model)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+	for key, values := range p.buildHeaders() {
+		for _, value := range values {
+			httpReq.Header.Add(key, value)
+		}
+	}
+
+	resp, err := p.config.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+	defer resp.Body.Close()
+	return decodeGeminiEmbeddingResponse(resp)
+}
+
+func decodeGeminiEmbeddingResponse(resp *http.Response) (*geminiBatchEmbeddingResponse, error) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, normalizeError(resp.StatusCode, body)
+	}
+
+	var response geminiBatchEmbeddingResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, newDecodeError(err)
+	}
+	return &response, nil
+}
+
+func validateGeminiEmbeddingRequest(ctx context.Context, req *core.EmbeddingRequest) error {
+	if ctx == nil {
+		return fmt.Errorf("gemini: embedding context cannot be nil")
+	}
+	if req == nil {
+		return fmt.Errorf("gemini: embedding request cannot be nil")
+	}
+	if !geminiEmbeddingModelPattern.MatchString(string(req.Model)) {
+		return fmt.Errorf("gemini: invalid embedding model %q", req.Model)
+	}
+	if len(req.Input) == 0 {
+		return fmt.Errorf("gemini: embedding input cannot be empty")
+	}
+	for i, input := range req.Input {
+		if strings.TrimSpace(input.Text) == "" {
+			return fmt.Errorf("gemini: embedding input %d cannot be blank", i)
+		}
+	}
+	if req.Dimensions != nil && *req.Dimensions <= 0 {
+		return fmt.Errorf("gemini: embedding dimensions must be positive")
+	}
+	if req.User != "" {
+		return fmt.Errorf("gemini: embedding user identifier: %w", core.ErrNotSupported)
+	}
+	if req.Truncation != nil {
+		return fmt.Errorf("gemini: embedding truncation: %w", core.ErrNotSupported)
+	}
+	if req.InputType != core.InputTypeNone && req.InputType != core.InputTypeQuery && req.InputType != core.InputTypeDocument {
+		return fmt.Errorf("gemini: unsupported embedding input type %q", req.InputType)
+	}
+	if req.EncodingFormat != "" && req.EncodingFormat != core.EncodingFormatFloat {
+		return fmt.Errorf("gemini: embedding encoding format %q: %w", req.EncodingFormat, core.ErrNotSupported)
+	}
+	if req.OutputDType != "" && req.OutputDType != core.OutputDTypeFloat {
+		return fmt.Errorf("gemini: embedding output type %q: %w", req.OutputDType, core.ErrNotSupported)
+	}
+	return nil
+}
+
+func buildGeminiEmbeddingRequest(req *core.EmbeddingRequest) *geminiBatchEmbeddingRequest {
+	requests := make([]geminiEmbeddingRequest, len(req.Input))
+	taskType := mapGeminiEmbeddingTaskType(req.InputType)
+	for i, input := range req.Input {
+		requests[i] = geminiEmbeddingRequest{
+			Model:                "models/" + string(req.Model),
+			Content:              geminiContent{Parts: []geminiPart{{Text: input.Text}}},
+			TaskType:             taskType,
+			OutputDimensionality: req.Dimensions,
+		}
+	}
+	return &geminiBatchEmbeddingRequest{Requests: requests}
+}
+
+func mapGeminiEmbeddingTaskType(inputType core.InputType) string {
+	switch inputType {
+	case core.InputTypeQuery:
+		return geminiEmbeddingTaskQuery
+	case core.InputTypeDocument:
+		return geminiEmbeddingTaskDocument
+	default:
+		return ""
+	}
+}
+
+func mapGeminiEmbeddingResponse(resp *geminiBatchEmbeddingResponse, req *core.EmbeddingRequest) (*core.EmbeddingResponse, error) {
+	if len(resp.Embeddings) != len(req.Input) {
+		return nil, fmt.Errorf("gemini: embedding response count %d does not match input count %d", len(resp.Embeddings), len(req.Input))
+	}
+
+	vectors := make([]core.EmbeddingVector, len(resp.Embeddings))
+	for i, embedding := range resp.Embeddings {
+		vectors[i] = core.EmbeddingVector{
+			Index:    i,
+			ID:       req.Input[i].ID,
+			Metadata: maps.Clone(req.Input[i].Metadata),
+			Vector:   embedding.Values,
+		}
+	}
+	tokens := resp.UsageMetadata.PromptTokenCount
+	return &core.EmbeddingResponse{
+		Vectors: vectors,
+		Model:   req.Model,
+		Usage: core.EmbeddingUsage{
+			PromptTokens: tokens,
+			TotalTokens:  tokens,
+		},
+	}, nil
+}

--- a/providers/gemini/embeddings_test.go
+++ b/providers/gemini/embeddings_test.go
@@ -1,0 +1,272 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestCreateEmbeddings(t *testing.T) {
+	dimensions := 3
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertEmbeddingRequest(t, r, dimensions)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"embeddings": []any{
+				map[string]any{"values": []float32{0.1, 0.2, 0.3}},
+				map[string]any{"values": []float32{0.4, 0.5, 0.6}},
+			},
+			"usageMetadata": map[string]any{"promptTokenCount": 7},
+		})
+	}))
+	defer server.Close()
+
+	metadata := map[string]string{"source": "test"}
+	request := &core.EmbeddingRequest{
+		Model:      ModelGeminiEmbedding001,
+		Input:      []core.EmbeddingInput{{Text: "hello", ID: "first", Metadata: metadata}, {Text: "world", ID: "second"}},
+		Dimensions: &dimensions,
+		InputType:  core.InputTypeQuery,
+	}
+	provider := New("test-key", WithBaseURL(server.URL))
+	response, err := provider.CreateEmbeddings(context.Background(), request)
+	if err != nil {
+		t.Fatalf("CreateEmbeddings() error = %v", err)
+	}
+
+	if response.Model != ModelGeminiEmbedding001 {
+		t.Errorf("Model = %q, want %q", response.Model, ModelGeminiEmbedding001)
+	}
+	if len(response.Vectors) != 2 {
+		t.Fatalf("len(Vectors) = %d, want 2", len(response.Vectors))
+	}
+	if response.Vectors[0].Index != 0 || response.Vectors[0].ID != "first" {
+		t.Errorf("Vectors[0] identity = (%d, %q), want (0, first)", response.Vectors[0].Index, response.Vectors[0].ID)
+	}
+	if got := response.Vectors[1].Vector; len(got) != 3 || got[2] != 0.6 {
+		t.Errorf("Vectors[1].Vector = %v, want [0.4 0.5 0.6]", got)
+	}
+	if response.Usage.PromptTokens != 7 || response.Usage.TotalTokens != 7 {
+		t.Errorf("Usage = %+v, want prompt/total tokens 7", response.Usage)
+	}
+
+	response.Vectors[0].Metadata["source"] = "changed"
+	if metadata["source"] != "test" {
+		t.Error("response metadata aliases request metadata")
+	}
+}
+
+func TestCreateEmbeddingsOmitsUnsetOptions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Requests []map[string]json.RawMessage `json:"requests"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if len(body.Requests) != 1 {
+			t.Fatalf("len(requests) = %d, want 1", len(body.Requests))
+		}
+		if _, ok := body.Requests[0]["taskType"]; ok {
+			t.Error("taskType should be omitted when no input type is set")
+		}
+		if _, ok := body.Requests[0]["outputDimensionality"]; ok {
+			t.Error("outputDimensionality should be omitted when dimensions are unset")
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"embeddings":    []any{map[string]any{"values": []float32{0.1}}},
+			"usageMetadata": map[string]any{"promptTokenCount": 1},
+		})
+	}))
+	defer server.Close()
+
+	provider := New("test-key", WithBaseURL(server.URL))
+	_, err := provider.CreateEmbeddings(context.Background(), validGeminiEmbeddingRequest())
+	if err != nil {
+		t.Fatalf("CreateEmbeddings() error = %v", err)
+	}
+}
+
+func TestCreateEmbeddingsValidatesRequest(t *testing.T) {
+	dimensions := 0
+	truncate := true
+	tests := []struct {
+		name            string
+		request         *core.EmbeddingRequest
+		wantUnsupported bool
+	}{
+		{name: "nil request", request: nil},
+		{name: "missing model", request: &core.EmbeddingRequest{Input: []core.EmbeddingInput{{Text: "hello"}}}},
+		{name: "unsafe model", request: &core.EmbeddingRequest{Model: "models/../unsafe", Input: []core.EmbeddingInput{{Text: "hello"}}}},
+		{name: "missing input", request: &core.EmbeddingRequest{Model: ModelGeminiEmbedding001}},
+		{name: "blank input", request: &core.EmbeddingRequest{Model: ModelGeminiEmbedding001, Input: []core.EmbeddingInput{{Text: "  "}}}},
+		{name: "invalid dimensions", request: &core.EmbeddingRequest{Model: ModelGeminiEmbedding001, Input: []core.EmbeddingInput{{Text: "hello"}}, Dimensions: &dimensions}},
+		{name: "invalid input type", request: &core.EmbeddingRequest{Model: ModelGeminiEmbedding001, Input: []core.EmbeddingInput{{Text: "hello"}}, InputType: core.InputType("invalid")}},
+		{name: "user identifier", request: &core.EmbeddingRequest{Model: ModelGeminiEmbedding001, Input: []core.EmbeddingInput{{Text: "hello"}}, User: "user-123"}, wantUnsupported: true},
+		{name: "truncation", request: &core.EmbeddingRequest{Model: ModelGeminiEmbedding001, Input: []core.EmbeddingInput{{Text: "hello"}}, Truncation: &truncate}, wantUnsupported: true},
+		{name: "base64 encoding", request: &core.EmbeddingRequest{Model: ModelGeminiEmbedding001, Input: []core.EmbeddingInput{{Text: "hello"}}, EncodingFormat: core.EncodingFormatBase64}, wantUnsupported: true},
+		{name: "int8 output", request: &core.EmbeddingRequest{Model: ModelGeminiEmbedding001, Input: []core.EmbeddingInput{{Text: "hello"}}, OutputDType: core.OutputDTypeInt8}, wantUnsupported: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hit := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+			defer server.Close()
+
+			provider := New("test-key", WithBaseURL(server.URL))
+			_, err := provider.CreateEmbeddings(context.Background(), tt.request)
+			if err == nil {
+				t.Fatal("CreateEmbeddings() should reject invalid request")
+			}
+			if tt.wantUnsupported && !errors.Is(err, core.ErrNotSupported) {
+				t.Errorf("error = %v, want ErrNotSupported", err)
+			}
+			if hit {
+				t.Error("invalid request should fail before HTTP")
+			}
+		})
+	}
+}
+
+func TestCreateEmbeddingsRejectsNilContext(t *testing.T) {
+	provider := New("test-key")
+	_, err := provider.CreateEmbeddings(nil, validGeminiEmbeddingRequest())
+	if err == nil || !strings.Contains(err.Error(), "context cannot be nil") {
+		t.Fatalf("error = %v, want nil context error", err)
+	}
+}
+
+func TestCreateEmbeddingsEmptyKeyFailsBeforeHTTP(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hit = true }))
+	defer server.Close()
+
+	provider := New("", WithBaseURL(server.URL))
+	_, err := provider.CreateEmbeddings(context.Background(), validGeminiEmbeddingRequest())
+	if !errors.Is(err, core.ErrUnauthorized) {
+		t.Fatalf("error = %v, want ErrUnauthorized", err)
+	}
+	if hit {
+		t.Error("empty key should fail before HTTP")
+	}
+}
+
+func TestCreateEmbeddingsNormalizesHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"code": 429, "message": "quota exhausted", "status": "RESOURCE_EXHAUSTED"},
+		})
+	}))
+	defer server.Close()
+
+	provider := New("test-key", WithBaseURL(server.URL))
+	_, err := provider.CreateEmbeddings(context.Background(), validGeminiEmbeddingRequest())
+	if !errors.Is(err, core.ErrRateLimited) {
+		t.Fatalf("error = %v, want ErrRateLimited", err)
+	}
+}
+
+func TestCreateEmbeddingsRejectsMalformedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"embeddings":`))
+	}))
+	defer server.Close()
+
+	provider := New("test-key", WithBaseURL(server.URL))
+	_, err := provider.CreateEmbeddings(context.Background(), validGeminiEmbeddingRequest())
+	if !errors.Is(err, core.ErrDecode) {
+		t.Fatalf("error = %v, want ErrDecode", err)
+	}
+}
+
+func TestCreateEmbeddingsRejectsMismatchedResponseCount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"embeddings": []any{}})
+	}))
+	defer server.Close()
+
+	provider := New("test-key", WithBaseURL(server.URL))
+	_, err := provider.CreateEmbeddings(context.Background(), validGeminiEmbeddingRequest())
+	if err == nil || !strings.Contains(err.Error(), "response count") {
+		t.Fatalf("error = %v, want response count mismatch", err)
+	}
+}
+
+func TestCreateEmbeddingsHonorsProviderTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(func() { go server.Close() })
+
+	provider := New("test-key", WithBaseURL(server.URL), WithTimeout(20*time.Millisecond))
+	_, err := provider.CreateEmbeddings(context.Background(), validGeminiEmbeddingRequest())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func validGeminiEmbeddingRequest() *core.EmbeddingRequest {
+	return &core.EmbeddingRequest{
+		Model: ModelGeminiEmbedding001,
+		Input: []core.EmbeddingInput{{Text: "hello"}},
+	}
+}
+
+func assertEmbeddingRequest(t *testing.T, r *http.Request, dimensions int) {
+	t.Helper()
+	if r.Method != http.MethodPost {
+		t.Errorf("method = %q, want POST", r.Method)
+	}
+	if r.URL.Path != "/v1beta/models/gemini-embedding-001:batchEmbedContents" {
+		t.Errorf("path = %q, want Gemini batch embeddings path", r.URL.Path)
+	}
+	if got := r.Header.Get("x-goog-api-key"); got != "test-key" {
+		t.Errorf("x-goog-api-key = %q, want test-key", got)
+	}
+	if got := r.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+
+	var body struct {
+		Requests []struct {
+			Model   string `json:"model"`
+			Content struct {
+				Parts []struct {
+					Text string `json:"text"`
+				} `json:"parts"`
+			} `json:"content"`
+			TaskType             string `json:"taskType"`
+			OutputDimensionality int    `json:"outputDimensionality"`
+		} `json:"requests"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if len(body.Requests) != 2 {
+		t.Fatalf("len(requests) = %d, want 2", len(body.Requests))
+	}
+	for i, request := range body.Requests {
+		if request.Model != "models/gemini-embedding-001" {
+			t.Errorf("requests[%d].model = %q", i, request.Model)
+		}
+		if request.TaskType != "RETRIEVAL_QUERY" {
+			t.Errorf("requests[%d].taskType = %q, want RETRIEVAL_QUERY", i, request.TaskType)
+		}
+		if request.OutputDimensionality != dimensions {
+			t.Errorf("requests[%d].outputDimensionality = %d, want %d", i, request.OutputDimensionality, dimensions)
+		}
+	}
+	if got := body.Requests[0].Content.Parts[0].Text; got != "hello" {
+		t.Errorf("first input = %q, want hello", got)
+	}
+}

--- a/providers/gemini/embeddings_test.go
+++ b/providers/gemini/embeddings_test.go
@@ -138,6 +138,7 @@ func TestCreateEmbeddingsValidatesRequest(t *testing.T) {
 
 func TestCreateEmbeddingsRejectsNilContext(t *testing.T) {
 	provider := New("test-key")
+	//nolint:staticcheck // Intentionally verify that the public API rejects a nil context.
 	_, err := provider.CreateEmbeddings(nil, validGeminiEmbeddingRequest())
 	if err == nil || !strings.Contains(err.Error(), "context cannot be nil") {
 		t.Fatalf("error = %v, want nil context error", err)

--- a/providers/gemini/models.go
+++ b/providers/gemini/models.go
@@ -36,6 +36,9 @@ const (
 
 	// Image generation models (Nano Banana)
 	ModelGemini25FlashImage core.ModelID = "gemini-2.5-flash-image"
+
+	// Embedding models
+	ModelGeminiEmbedding001 core.ModelID = "gemini-embedding-001"
 )
 
 // models is the static list of supported models.
@@ -176,6 +179,13 @@ var models = []core.ModelInfo{
 		DisplayName: "Gemini 2.5 Flash Image (Nano Banana)",
 		Capabilities: []core.Feature{
 			core.FeatureImageGeneration,
+		},
+	},
+	{
+		ID:          ModelGeminiEmbedding001,
+		DisplayName: "Gemini Embedding 001",
+		Capabilities: []core.Feature{
+			core.FeatureEmbeddings,
 		},
 	},
 }

--- a/providers/gemini/provider.go
+++ b/providers/gemini/provider.go
@@ -79,7 +79,8 @@ func (p *Gemini) Models() []core.ModelInfo {
 // Supports reports whether the provider supports the given feature.
 func (p *Gemini) Supports(feature core.Feature) bool {
 	switch feature {
-	case core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling, core.FeatureReasoning, core.FeatureImageGeneration, core.FeatureStructuredOutput:
+	case core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling, core.FeatureReasoning,
+		core.FeatureImageGeneration, core.FeatureStructuredOutput, core.FeatureEmbeddings:
 		return true
 	default:
 		return false
@@ -133,6 +134,8 @@ func (p *Gemini) StreamChat(ctx context.Context, req *core.ChatRequest) (*core.C
 var _ core.Provider = (*Gemini)(nil)
 
 var _ core.ContentPartSupporter = (*Gemini)(nil)
+
+var _ core.EmbeddingProvider = (*Gemini)(nil)
 
 // Compile-time check that Gemini implements ImageGenerator.
 var _ core.ImageGenerator = (*Gemini)(nil)

--- a/providers/gemini/provider_test.go
+++ b/providers/gemini/provider_test.go
@@ -63,8 +63,8 @@ func TestModels(t *testing.T) {
 	p := New("test-key")
 	models := p.Models()
 
-	if len(models) != 14 {
-		t.Errorf("Models() count = %d, want 14", len(models))
+	if len(models) != 15 {
+		t.Errorf("Models() count = %d, want 15", len(models))
 	}
 
 	// Verify model IDs
@@ -88,6 +88,7 @@ func TestModels(t *testing.T) {
 		ModelGemini25Pro,
 		ModelGemini20FlashLite,
 		ModelGemini25FlashImage,
+		ModelGeminiEmbedding001,
 	}
 
 	for _, id := range expected {
@@ -124,6 +125,7 @@ func TestSupports(t *testing.T) {
 		{core.FeatureToolCalling, true},
 		{core.FeatureReasoning, true},
 		{core.FeatureImageGeneration, true},
+		{core.FeatureEmbeddings, true},
 		{core.FeatureBuiltInTools, false},
 		{core.FeatureResponseChain, false},
 		{core.Feature("unknown"), false},
@@ -255,6 +257,20 @@ func TestModelCapabilities(t *testing.T) {
 
 func TestProviderImplementsInterface(t *testing.T) {
 	var _ core.Provider = (*Gemini)(nil)
+	var _ core.EmbeddingProvider = (*Gemini)(nil)
+}
+
+func TestEmbeddingModelCapabilities(t *testing.T) {
+	info := GetModelInfo(ModelGeminiEmbedding001)
+	if info == nil {
+		t.Fatal("GetModelInfo(gemini-embedding-001) = nil")
+	}
+	if !info.HasCapability(core.FeatureEmbeddings) {
+		t.Error("gemini-embedding-001 missing FeatureEmbeddings")
+	}
+	if info.HasCapability(core.FeatureChat) {
+		t.Error("gemini-embedding-001 should not declare FeatureChat")
+	}
 }
 
 func TestNewWithEmptyAPIKey(t *testing.T) {

--- a/providers/openai/provider.go
+++ b/providers/openai/provider.go
@@ -77,7 +77,7 @@ func (p *OpenAI) Supports(feature core.Feature) bool {
 	switch feature {
 	case core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling,
 		core.FeatureImageGeneration, core.FeatureEmbeddings, core.FeatureStructuredOutput,
-		core.FeatureBatch:
+		core.FeatureBatch, core.FeatureReasoning:
 		return true
 	default:
 		return false

--- a/providers/openai/provider_test.go
+++ b/providers/openai/provider_test.go
@@ -133,6 +133,22 @@ func TestSupportsEmbeddings(t *testing.T) {
 	}
 }
 
+func TestSupportsReasoning(t *testing.T) {
+	p := New("test-key")
+	if !p.Supports(core.FeatureReasoning) {
+		t.Error("Supports(FeatureReasoning) = false, want true")
+	}
+
+	reasoningModel := GetModelInfo(ModelGPT56)
+	if reasoningModel == nil || !reasoningModel.HasCapability(core.FeatureReasoning) {
+		t.Error("GPT-5.6 should declare model-level reasoning support")
+	}
+	nonReasoningModel := GetModelInfo(ModelGPT41)
+	if nonReasoningModel == nil || nonReasoningModel.HasCapability(core.FeatureReasoning) {
+		t.Error("GPT-4.1 should remain model-level non-reasoning")
+	}
+}
+
 func TestImplementsImageGenerator(t *testing.T) {
 	var _ core.ImageGenerator = (*OpenAI)(nil)
 }

--- a/tests/integration/gemini_test.go
+++ b/tests/integration/gemini_test.go
@@ -71,6 +71,36 @@ func TestGemini_ChatCompletion_Flash(t *testing.T) {
 	t.Logf("Model: %s", gemini.ModelGemini25Flash)
 }
 
+func TestGemini_Embeddings(t *testing.T) {
+	skipIfNoGeminiKey(t)
+
+	provider := gemini.New(getGeminiKey(t))
+	dimensions := 128
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := provider.CreateEmbeddings(ctx, &core.EmbeddingRequest{
+		Model:      gemini.ModelGeminiEmbedding001,
+		Input:      []core.EmbeddingInput{{Text: "Iris is a multi-provider Go SDK."}, {Text: "Gemini supports embeddings."}},
+		Dimensions: &dimensions,
+		InputType:  core.InputTypeDocument,
+	})
+	if err != nil {
+		t.Fatalf("CreateEmbeddings() error = %v", err)
+	}
+	if len(resp.Vectors) != 2 {
+		t.Fatalf("len(Vectors) = %d, want 2", len(resp.Vectors))
+	}
+	for i, vector := range resp.Vectors {
+		if len(vector.Vector) != dimensions {
+			t.Errorf("len(Vectors[%d].Vector) = %d, want %d", i, len(vector.Vector), dimensions)
+		}
+	}
+	if resp.Usage.TotalTokens != resp.Usage.PromptTokens {
+		t.Errorf("Usage = %+v, want matching total and prompt tokens", resp.Usage)
+	}
+}
+
 func TestGemini_ImageGeneration(t *testing.T) {
 	skipIfNoGeminiKey(t)
 


### PR DESCRIPTION
## Summary

- implement Gemini `core.EmbeddingProvider` support with synchronous `batchEmbedContents` requests
- add `gemini-embedding-001` to the model catalog and advertise Gemini embedding capabilities
- map query/document input types and configurable dimensions while validating unsupported options before network access
- report OpenAI provider-level reasoning support while preserving model-specific capability checks
- regenerate the provider matrix and add the required v0.18.0 change record

## Implementation notes

The Gemini integration preserves input ordering, IDs, and cloned metadata, normalizes provider errors, and applies existing provider timeout behavior. Model identifiers are validated before being interpolated into the API path. The request shape uses the top-level task and dimension fields because the deployed v1beta batch endpoint currently ignores the newer nested config despite advertising it in discovery metadata.

## Testing

- `go test -race -coverprofile=/tmp/iris-issue67-coverage.out -covermode=atomic ./...`
- `go vet ./...`
- `go test -tags=integration ./tests/integration/... -run '^TestGemini_Embeddings$' -count=1` (credential-backed live test)
- aggregate coverage: 80.9%
- formatting and `git diff --check`

Closes #67
