### PR TITLE
[codex] add capability helpers and client embeddings

### DIFF
--- a/core/capability_helpers_test.go
+++ b/core/capability_helpers_test.go
@@ -1,0 +1,121 @@
+package core
+
+import (
+	"context"
+	"testing"
+)
+
+type capabilityBaseProvider struct {
+	id string
+}
+
+func (p *capabilityBaseProvider) ID() string          { return p.id }
+func (*capabilityBaseProvider) Models() []ModelInfo   { return nil }
+func (*capabilityBaseProvider) Supports(Feature) bool { return false }
+func (*capabilityBaseProvider) Chat(context.Context, *ChatRequest) (*ChatResponse, error) {
+	return nil, ErrNotSupported
+}
+func (*capabilityBaseProvider) StreamChat(context.Context, *ChatRequest) (*ChatStream, error) {
+	return nil, ErrNotSupported
+}
+
+type embeddingCapableProvider struct{ *capabilityBaseProvider }
+
+func (*embeddingCapableProvider) CreateEmbeddings(context.Context, *EmbeddingRequest) (*EmbeddingResponse, error) {
+	return &EmbeddingResponse{}, nil
+}
+
+type contextualizedEmbeddingCapableProvider struct{ *capabilityBaseProvider }
+
+func (*contextualizedEmbeddingCapableProvider) CreateContextualizedEmbeddings(context.Context, *ContextualizedEmbeddingRequest) (*ContextualizedEmbeddingResponse, error) {
+	return &ContextualizedEmbeddingResponse{}, nil
+}
+
+type rerankerCapableProvider struct{ *capabilityBaseProvider }
+
+func (*rerankerCapableProvider) Rerank(context.Context, *RerankRequest) (*RerankResponse, error) {
+	return &RerankResponse{}, nil
+}
+
+type imageCapableProvider struct{ *capabilityBaseProvider }
+
+func (*imageCapableProvider) GenerateImage(context.Context, *ImageGenerateRequest) (*ImageResponse, error) {
+	return &ImageResponse{}, nil
+}
+func (*imageCapableProvider) EditImage(context.Context, *ImageEditRequest) (*ImageResponse, error) {
+	return &ImageResponse{}, nil
+}
+func (*imageCapableProvider) StreamImage(context.Context, *ImageGenerateRequest) (*ImageStream, error) {
+	return &ImageStream{}, nil
+}
+
+type contentPartCapableProvider struct{ *capabilityBaseProvider }
+
+func (*contentPartCapableProvider) SupportsContentPart(ModelID, Role, ContentPart) bool {
+	return true
+}
+
+func TestAsEmbeddingProvider(t *testing.T) {
+	provider := &embeddingCapableProvider{capabilityBaseProvider: &capabilityBaseProvider{id: "embedding"}}
+	got, ok := AsEmbeddingProvider(provider)
+	if !ok || got != provider {
+		t.Fatalf("AsEmbeddingProvider() = (%v, %v), want provider, true", got, ok)
+	}
+
+	got, ok = AsEmbeddingProvider(&capabilityBaseProvider{id: "base"})
+	if ok || got != nil {
+		t.Fatalf("AsEmbeddingProvider(non-capable) = (%v, %v), want nil, false", got, ok)
+	}
+}
+
+func TestAsContextualizedEmbeddingProvider(t *testing.T) {
+	provider := &contextualizedEmbeddingCapableProvider{capabilityBaseProvider: &capabilityBaseProvider{id: "contextualized"}}
+	got, ok := AsContextualizedEmbeddingProvider(provider)
+	if !ok || got != provider {
+		t.Fatalf("AsContextualizedEmbeddingProvider() = (%v, %v), want provider, true", got, ok)
+	}
+
+	got, ok = AsContextualizedEmbeddingProvider(&capabilityBaseProvider{id: "base"})
+	if ok || got != nil {
+		t.Fatalf("AsContextualizedEmbeddingProvider(non-capable) = (%v, %v), want nil, false", got, ok)
+	}
+}
+
+func TestAsReranker(t *testing.T) {
+	provider := &rerankerCapableProvider{capabilityBaseProvider: &capabilityBaseProvider{id: "reranker"}}
+	got, ok := AsReranker(provider)
+	if !ok || got != provider {
+		t.Fatalf("AsReranker() = (%v, %v), want provider, true", got, ok)
+	}
+
+	got, ok = AsReranker(&capabilityBaseProvider{id: "base"})
+	if ok || got != nil {
+		t.Fatalf("AsReranker(non-capable) = (%v, %v), want nil, false", got, ok)
+	}
+}
+
+func TestAsImageGenerator(t *testing.T) {
+	provider := &imageCapableProvider{capabilityBaseProvider: &capabilityBaseProvider{id: "image"}}
+	got, ok := AsImageGenerator(provider)
+	if !ok || got != provider {
+		t.Fatalf("AsImageGenerator() = (%v, %v), want provider, true", got, ok)
+	}
+
+	got, ok = AsImageGenerator(&capabilityBaseProvider{id: "base"})
+	if ok || got != nil {
+		t.Fatalf("AsImageGenerator(non-capable) = (%v, %v), want nil, false", got, ok)
+	}
+}
+
+func TestAsContentPartSupporter(t *testing.T) {
+	provider := &contentPartCapableProvider{capabilityBaseProvider: &capabilityBaseProvider{id: "content"}}
+	got, ok := AsContentPartSupporter(provider)
+	if !ok || got != provider {
+		t.Fatalf("AsContentPartSupporter() = (%v, %v), want provider, true", got, ok)
+	}
+
+	got, ok = AsContentPartSupporter(&capabilityBaseProvider{id: "base"})
+	if ok || got != nil {
+		t.Fatalf("AsContentPartSupporter(non-capable) = (%v, %v), want nil, false", got, ok)
+	}
+}

--- a/core/client.go
+++ b/core/client.go
@@ -8,9 +8,9 @@ import (
 	"time"
 )
 
-// DefaultTimeout is the execution timeout applied to chat and streaming calls
-// when neither the caller's context nor a per-call Timeout() supplies one.
-// Disable it per client with WithTimeout(0).
+// DefaultTimeout is the execution timeout applied to calls routed through
+// Client, including chat, streaming, and embeddings, when the caller's
+// context does not already supply a deadline. Disable it with WithTimeout(0).
 const DefaultTimeout = 120 * time.Second
 
 // Provider is the interface that LLM providers must implement.
@@ -44,6 +44,13 @@ type ImageGenerator interface {
 	// StreamImage generates images with streaming partial results.
 	// Not all providers support streaming.
 	StreamImage(ctx context.Context, req *ImageGenerateRequest) (*ImageStream, error)
+}
+
+// AsImageGenerator attempts to cast a Provider to ImageGenerator. It returns
+// nil and false when the provider does not implement image operations.
+func AsImageGenerator(p Provider) (ImageGenerator, bool) {
+	generator, ok := p.(ImageGenerator)
+	return generator, ok
 }
 
 // Client is the main entry point for interacting with LLM providers.
@@ -107,9 +114,10 @@ func WithWarningHandler(h WarningHandler) ClientOption {
 	}
 }
 
-// WithTimeout sets the default execution timeout applied to chat and streaming
-// calls when the caller's context has no deadline of its own and no per-call
-// Timeout() is set. Pass 0 to disable the default and allow unbounded calls.
+// WithTimeout sets the default execution timeout applied to calls routed
+// through Client when the caller's context has no deadline of its own. Chat
+// builders can override it per call with Timeout(). Pass 0 to disable the
+// default and allow unbounded calls.
 func WithTimeout(d time.Duration) ClientOption {
 	return func(c *Client) {
 		c.timeout = d
@@ -1062,7 +1070,7 @@ func (c *Client) warnf(format string, args ...any) {
 }
 
 func (b *ChatBuilder) warnUnsupportedContentParts() {
-	supporter, declaresSupport := b.client.provider.(ContentPartSupporter)
+	supporter, declaresSupport := AsContentPartSupporter(b.client.provider)
 	for messageIndex, message := range b.req.Messages {
 		for partIndex, part := range message.Parts {
 			if declaresSupport && supporter.SupportsContentPart(b.req.Model, message.Role, part) {

--- a/core/client_embeddings_test.go
+++ b/core/client_embeddings_test.go
@@ -1,0 +1,245 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type clientEmbeddingProvider struct {
+	*capabilityBaseProvider
+	createEmbeddings func(context.Context, *EmbeddingRequest) (*EmbeddingResponse, error)
+	calls            int
+}
+
+func (p *clientEmbeddingProvider) CreateEmbeddings(ctx context.Context, req *EmbeddingRequest) (*EmbeddingResponse, error) {
+	p.calls++
+	return p.createEmbeddings(ctx, req)
+}
+
+type embeddingTelemetryHook struct {
+	starts []RequestStartEvent
+	ends   []RequestEndEvent
+}
+
+func (h *embeddingTelemetryHook) OnRequestStart(event RequestStartEvent) {
+	h.starts = append(h.starts, event)
+}
+
+func (h *embeddingTelemetryHook) OnRequestEnd(event RequestEndEvent) {
+	h.ends = append(h.ends, event)
+}
+
+type embeddingContextKey struct{}
+
+type contextualEmbeddingTelemetryHook struct {
+	embeddingTelemetryHook
+	endSawContext bool
+}
+
+func (h *contextualEmbeddingTelemetryHook) OnRequestStartWithContext(ctx context.Context, event RequestStartEvent) context.Context {
+	h.OnRequestStart(event)
+	return context.WithValue(ctx, embeddingContextKey{}, "telemetry")
+}
+
+func (h *contextualEmbeddingTelemetryHook) OnRequestEndWithContext(ctx context.Context, event RequestEndEvent) {
+	h.endSawContext = ctx.Value(embeddingContextKey{}) == "telemetry"
+	h.OnRequestEnd(event)
+}
+
+type embeddingNoRetryPolicy struct{}
+
+func (embeddingNoRetryPolicy) NextDelay(int, error) (time.Duration, bool) {
+	return 0, false
+}
+
+func TestClientEmbedDelegatesAndEmitsTelemetry(t *testing.T) {
+	request := &EmbeddingRequest{
+		Model: "embedding-model",
+		Input: []EmbeddingInput{{Text: "hello"}},
+	}
+	want := &EmbeddingResponse{
+		Model: "embedding-model",
+		Usage: EmbeddingUsage{PromptTokens: 7, TotalTokens: 7},
+	}
+	provider := &clientEmbeddingProvider{
+		capabilityBaseProvider: &capabilityBaseProvider{id: "embedding-provider"},
+		createEmbeddings: func(_ context.Context, got *EmbeddingRequest) (*EmbeddingResponse, error) {
+			if got != request {
+				t.Error("Client.Embed() did not pass the original request")
+			}
+			return want, nil
+		},
+	}
+	hook := &embeddingTelemetryHook{}
+	client := NewClient(provider, WithTelemetry(hook))
+
+	response, err := client.Embed(context.Background(), request)
+	if err != nil {
+		t.Fatalf("Embed() error = %v", err)
+	}
+	if response != want || provider.calls != 1 {
+		t.Fatalf("Embed() = (%v, calls=%d), want response and one call", response, provider.calls)
+	}
+	assertEmbeddingTelemetry(t, hook, "embedding-provider", "embedding-model", 7, nil)
+}
+
+func TestClientEmbedRejectsUnsupportedProvider(t *testing.T) {
+	hook := &embeddingTelemetryHook{}
+	client := NewClient(&capabilityBaseProvider{id: "chat-only"}, WithTelemetry(hook))
+
+	_, err := client.Embed(context.Background(), &EmbeddingRequest{Model: "model"})
+	if !errors.Is(err, ErrNotSupported) {
+		t.Fatalf("Embed() error = %v, want ErrNotSupported", err)
+	}
+	if len(hook.starts) != 0 || len(hook.ends) != 0 {
+		t.Fatal("unsupported capability should fail before telemetry")
+	}
+}
+
+func TestClientEmbedRejectsNilRequest(t *testing.T) {
+	provider := &clientEmbeddingProvider{
+		capabilityBaseProvider: &capabilityBaseProvider{id: "embedding-provider"},
+		createEmbeddings: func(context.Context, *EmbeddingRequest) (*EmbeddingResponse, error) {
+			t.Fatal("provider should not receive a nil request")
+			return nil, nil
+		},
+	}
+
+	_, err := NewClient(provider).Embed(context.Background(), nil)
+	if err == nil {
+		t.Fatal("Embed() should reject a nil request")
+	}
+}
+
+func TestClientEmbedEmitsTelemetryOnProviderError(t *testing.T) {
+	provider := &clientEmbeddingProvider{
+		capabilityBaseProvider: &capabilityBaseProvider{id: "embedding-provider"},
+		createEmbeddings: func(context.Context, *EmbeddingRequest) (*EmbeddingResponse, error) {
+			return nil, ErrBadRequest
+		},
+	}
+	hook := &embeddingTelemetryHook{}
+	client := NewClient(provider, WithTelemetry(hook), WithRetryPolicy(embeddingNoRetryPolicy{}))
+
+	_, err := client.Embed(context.Background(), &EmbeddingRequest{Model: "embedding-model"})
+	if !errors.Is(err, ErrBadRequest) {
+		t.Fatalf("Embed() error = %v, want ErrBadRequest", err)
+	}
+	assertEmbeddingTelemetry(t, hook, "embedding-provider", "embedding-model", 0, ErrBadRequest)
+}
+
+func TestClientEmbedPropagatesContextualTelemetryContext(t *testing.T) {
+	hook := &contextualEmbeddingTelemetryHook{}
+	provider := &clientEmbeddingProvider{
+		capabilityBaseProvider: &capabilityBaseProvider{id: "embedding-provider"},
+		createEmbeddings: func(ctx context.Context, _ *EmbeddingRequest) (*EmbeddingResponse, error) {
+			if ctx.Value(embeddingContextKey{}) != "telemetry" {
+				t.Error("provider did not receive telemetry context")
+			}
+			return &EmbeddingResponse{}, nil
+		},
+	}
+	client := NewClient(provider, WithTelemetry(hook))
+
+	_, err := client.Embed(context.Background(), &EmbeddingRequest{Model: "embedding-model"})
+	if err != nil {
+		t.Fatalf("Embed() error = %v", err)
+	}
+	if !hook.endSawContext {
+		t.Error("contextual telemetry end hook did not receive telemetry context")
+	}
+}
+
+func TestClientEmbedRetriesTransientErrors(t *testing.T) {
+	provider := &clientEmbeddingProvider{
+		capabilityBaseProvider: &capabilityBaseProvider{id: "embedding-provider"},
+	}
+	provider.createEmbeddings = func(context.Context, *EmbeddingRequest) (*EmbeddingResponse, error) {
+		if provider.calls == 1 {
+			return nil, ErrNetwork
+		}
+		return &EmbeddingResponse{}, nil
+	}
+	retry := NewRetryPolicy(RetryConfig{MaxRetries: 2, BaseDelay: time.Nanosecond, MaxDelay: time.Microsecond})
+	client := NewClient(provider, WithRetryPolicy(retry))
+
+	_, err := client.Embed(context.Background(), &EmbeddingRequest{Model: "embedding-model"})
+	if err != nil {
+		t.Fatalf("Embed() error = %v", err)
+	}
+	if provider.calls != 2 {
+		t.Fatalf("provider calls = %d, want 2", provider.calls)
+	}
+}
+
+func TestClientEmbedCanDisableClientTimeout(t *testing.T) {
+	provider := &clientEmbeddingProvider{
+		capabilityBaseProvider: &capabilityBaseProvider{id: "embedding-provider"},
+		createEmbeddings: func(ctx context.Context, _ *EmbeddingRequest) (*EmbeddingResponse, error) {
+			if _, hasDeadline := ctx.Deadline(); hasDeadline {
+				t.Error("WithTimeout(0) should not add a deadline")
+			}
+			return &EmbeddingResponse{}, nil
+		},
+	}
+	client := NewClient(provider, WithTimeout(0))
+
+	_, err := client.Embed(context.Background(), &EmbeddingRequest{Model: "embedding-model"})
+	if err != nil {
+		t.Fatalf("Embed() error = %v", err)
+	}
+}
+
+func TestClientEmbedAppliesClientTimeout(t *testing.T) {
+	provider := blockingEmbeddingProvider()
+	client := NewClient(provider, WithTimeout(20*time.Millisecond), WithRetryPolicy(embeddingNoRetryPolicy{}))
+
+	_, err := client.Embed(context.Background(), &EmbeddingRequest{Model: "embedding-model"})
+	if !errors.Is(err, ErrTimeout) || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Embed() error = %v, want ErrTimeout wrapping DeadlineExceeded", err)
+	}
+}
+
+func TestClientEmbedPreservesCallerDeadline(t *testing.T) {
+	provider := blockingEmbeddingProvider()
+	client := NewClient(provider, WithTimeout(time.Second), WithRetryPolicy(embeddingNoRetryPolicy{}))
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err := client.Embed(ctx, &EmbeddingRequest{Model: "embedding-model"})
+	if errors.Is(err, ErrTimeout) {
+		t.Fatalf("Embed() remapped caller deadline to ErrTimeout: %v", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Embed() error = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func blockingEmbeddingProvider() *clientEmbeddingProvider {
+	return &clientEmbeddingProvider{
+		capabilityBaseProvider: &capabilityBaseProvider{id: "blocking-embedding-provider"},
+		createEmbeddings: func(ctx context.Context, _ *EmbeddingRequest) (*EmbeddingResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+}
+
+func assertEmbeddingTelemetry(t *testing.T, hook *embeddingTelemetryHook, provider string, model ModelID, tokens int, wantErr error) {
+	t.Helper()
+	if len(hook.starts) != 1 || len(hook.ends) != 1 {
+		t.Fatalf("telemetry events = (%d starts, %d ends), want one each", len(hook.starts), len(hook.ends))
+	}
+	if hook.starts[0].Provider != provider || hook.starts[0].Model != model {
+		t.Errorf("start event = %+v, want provider=%s model=%s", hook.starts[0], provider, model)
+	}
+	end := hook.ends[0]
+	if end.Provider != provider || end.Model != model || end.Usage.PromptTokens != tokens || end.Usage.TotalTokens != tokens {
+		t.Errorf("end event = %+v, want provider=%s model=%s tokens=%d", end, provider, model, tokens)
+	}
+	if !errors.Is(end.Err, wantErr) {
+		t.Errorf("end error = %v, want %v", end.Err, wantErr)
+	}
+}

--- a/core/content.go
+++ b/core/content.go
@@ -16,6 +16,13 @@ type ContentPartSupporter interface {
 	SupportsContentPart(model ModelID, role Role, part ContentPart) bool
 }
 
+// AsContentPartSupporter attempts to cast a Provider to ContentPartSupporter.
+// It returns nil and false when the provider does not declare per-part support.
+func AsContentPartSupporter(p Provider) (ContentPartSupporter, bool) {
+	supporter, ok := p.(ContentPartSupporter)
+	return supporter, ok
+}
+
 // ImageDetail specifies the level of detail for image processing.
 type ImageDetail string
 

--- a/core/contextualized_embeddings.go
+++ b/core/contextualized_embeddings.go
@@ -11,6 +11,14 @@ type ContextualizedEmbeddingProvider interface {
 	CreateContextualizedEmbeddings(ctx context.Context, req *ContextualizedEmbeddingRequest) (*ContextualizedEmbeddingResponse, error)
 }
 
+// AsContextualizedEmbeddingProvider attempts to cast a Provider to
+// ContextualizedEmbeddingProvider. It returns nil and false when the provider
+// does not implement contextualized embeddings.
+func AsContextualizedEmbeddingProvider(p Provider) (ContextualizedEmbeddingProvider, bool) {
+	embedder, ok := p.(ContextualizedEmbeddingProvider)
+	return embedder, ok
+}
+
 // ContextualizedEmbeddingRequest represents a request to generate contextualized embeddings.
 type ContextualizedEmbeddingRequest struct {
 	// Model specifies the embedding model to use.

--- a/core/embeddings.go
+++ b/core/embeddings.go
@@ -1,6 +1,11 @@
 package core
 
-import "context"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
 
 // EncodingFormat specifies the embedding output format.
 type EncodingFormat string
@@ -85,4 +90,93 @@ type EmbeddingResponse struct {
 type EmbeddingProvider interface {
 	// CreateEmbeddings generates embeddings for the given input texts.
 	CreateEmbeddings(ctx context.Context, req *EmbeddingRequest) (*EmbeddingResponse, error)
+}
+
+// AsEmbeddingProvider attempts to cast a Provider to EmbeddingProvider.
+// It returns nil and false when the provider does not implement embeddings.
+func AsEmbeddingProvider(p Provider) (EmbeddingProvider, bool) {
+	embedder, ok := p.(EmbeddingProvider)
+	return embedder, ok
+}
+
+// Embed generates embeddings through the client's provider. It applies the
+// client timeout, telemetry, and retry policy to the optional embedding
+// capability just as GetResponse does for chat requests.
+func (c *Client) Embed(ctx context.Context, req *EmbeddingRequest) (*EmbeddingResponse, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("iris: embedding context cannot be nil")
+	}
+	if req == nil {
+		return nil, fmt.Errorf("iris: embedding request cannot be nil")
+	}
+	embedder, ok := AsEmbeddingProvider(c.provider)
+	if !ok {
+		return nil, fmt.Errorf("iris: provider %s does not support embeddings: %w", c.provider.ID(), ErrNotSupported)
+	}
+
+	var timeout time.Duration
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline && c.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.timeout)
+		defer cancel()
+		timeout = c.timeout
+	}
+
+	start := time.Now()
+	providerID := c.provider.ID()
+	ctx = c.startEmbeddingTelemetry(ctx, providerID, req.Model, start)
+	resp, err := c.createEmbeddingsWithRetry(ctx, embedder, req)
+	if timeout > 0 && err != nil && errors.Is(err, context.DeadlineExceeded) {
+		err = newTimeoutError(timeout, providerID, req.Model)
+	}
+	c.endEmbeddingTelemetry(ctx, providerID, req.Model, start, resp, err)
+	return resp, err
+}
+
+func (c *Client) createEmbeddingsWithRetry(ctx context.Context, provider EmbeddingProvider, req *EmbeddingRequest) (*EmbeddingResponse, error) {
+	for attempt := 0; ; attempt++ {
+		resp, err := provider.CreateEmbeddings(ctx, req)
+		if err == nil {
+			return resp, nil
+		}
+		delay, retry := c.retry.NextDelay(attempt, err)
+		if !retry {
+			return resp, err
+		}
+		select {
+		case <-ctx.Done():
+			return resp, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}
+
+func (c *Client) startEmbeddingTelemetry(ctx context.Context, provider string, model ModelID, start time.Time) context.Context {
+	event := RequestStartEvent{Provider: provider, Model: model, Start: start}
+	if hook, ok := c.telemetry.(ContextualTelemetryHook); ok {
+		return hook.OnRequestStartWithContext(ctx, event)
+	}
+	c.telemetry.OnRequestStart(event)
+	return ctx
+}
+
+func (c *Client) endEmbeddingTelemetry(ctx context.Context, provider string, model ModelID, start time.Time, resp *EmbeddingResponse, err error) {
+	usage := TokenUsage{}
+	if resp != nil {
+		usage.PromptTokens = resp.Usage.PromptTokens
+		usage.TotalTokens = resp.Usage.TotalTokens
+	}
+	event := RequestEndEvent{
+		Provider: provider,
+		Model:    model,
+		Start:    start,
+		End:      time.Now(),
+		Usage:    usage,
+		Err:      err,
+	}
+	if hook, ok := c.telemetry.(ContextualTelemetryHook); ok {
+		hook.OnRequestEndWithContext(ctx, event)
+		return
+	}
+	c.telemetry.OnRequestEnd(event)
 }

--- a/core/reranker.go
+++ b/core/reranker.go
@@ -10,6 +10,13 @@ type RerankerProvider interface {
 	Rerank(ctx context.Context, req *RerankRequest) (*RerankResponse, error)
 }
 
+// AsReranker attempts to cast a Provider to RerankerProvider. It returns nil
+// and false when the provider does not implement reranking.
+func AsReranker(p Provider) (RerankerProvider, bool) {
+	reranker, ok := p.(RerankerProvider)
+	return reranker, ok
+}
+
 // RerankRequest represents a request to rerank documents.
 type RerankRequest struct {
 	// Model specifies the reranker model to use.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,19 +82,61 @@ type Provider interface {
 - `Chat()`: Synchronous request for simple use cases
 - `StreamChat()`: Streaming request for real-time output
 
-### Optional Interfaces
+### Optional Provider Capability Interfaces
 
-Additional capabilities use separate interfaces:
+Additional operations use small optional interfaces so providers can opt into
+capabilities without polluting the required `Provider` contract. Capability
+discovery has two complementary layers:
+
+1. `provider.Supports(feature)` answers whether the provider family advertises
+   a feature. Model catalogs can narrow that support per model.
+2. `core.As*` helpers answer whether the concrete provider exposes the Go
+   operation needed to call that capability.
+
+Use the helper before calling a raw optional interface:
 
 ```go
-type ImageGenerator interface {
-    GenerateImage(ctx context.Context, req *ImageGenerateRequest) (*ImageResponse, error)
-    EditImage(ctx context.Context, req *ImageEditRequest) (*ImageResponse, error)
-    StreamImage(ctx context.Context, req *ImageGenerateRequest) (*ImageStream, error)
+embedder, ok := core.AsEmbeddingProvider(provider)
+if !ok {
+    return core.ErrNotSupported
 }
+
+response, err := embedder.CreateEmbeddings(ctx, request)
 ```
 
-This allows providers to opt into capabilities without polluting the core interface.
+The helper returns `(nil, false)` when the operation is unavailable. The
+current optional interfaces and built-in implementers are:
+
+| Interface | Discovery helper | Feature | Built-in implementers |
+|-----------|------------------|---------|-----------------------|
+| `BatchProvider` | `AsBatchProvider` | `FeatureBatch` | OpenAI |
+| `EmbeddingProvider` | `AsEmbeddingProvider` | `FeatureEmbeddings` | Azure AI Foundry, Gemini, Ollama, OpenAI, Voyage AI |
+| `ContextualizedEmbeddingProvider` | `AsContextualizedEmbeddingProvider` | `FeatureContextualizedEmbeddings` | Voyage AI |
+| `RerankerProvider` | `AsReranker` | `FeatureReranking` | Voyage AI |
+| `ImageGenerator` | `AsImageGenerator` | `FeatureImageGeneration` | Gemini, OpenAI |
+| `ContentPartSupporter` | `AsContentPartSupporter` | Per-content-part declaration | Anthropic, Azure AI Foundry, Gemini, OpenAI |
+
+Third-party providers can implement the same interfaces; this table describes
+only the implementations shipped with Iris.
+
+For the common embedding path, prefer `client.Embed(ctx, request)`. It performs
+the same interface discovery and delegates to `EmbeddingProvider` while also
+applying the client's retry policy, telemetry hooks, and default timeout. A
+caller-supplied context deadline takes precedence over the client timeout.
+
+```go
+response, err := client.Embed(ctx, &core.EmbeddingRequest{
+    Model: "text-embedding-3-small",
+    Input: []core.EmbeddingInput{{Text: "Text to index"}},
+})
+```
+
+Image operations intentionally remain on `ImageGenerator` for now. The image
+capability has three distinct lifecycles—generation, editing with multipart
+inputs, and streaming partial images—and image token usage does not map cleanly
+to the chat-oriented telemetry event. Until a client API can cover all three
+consistently, callers should use `AsImageGenerator` and bound raw image calls
+with their own context deadline.
 
 ### Alternatives Considered
 

--- a/docs/changes/2026-08-19_v0.18.0_capability-discovery-client-embeddings.md
+++ b/docs/changes/2026-08-19_v0.18.0_capability-discovery-client-embeddings.md
@@ -1,0 +1,163 @@
+---
+date: 2026-08-19
+version: v0.18.0
+feature: Symmetric capability discovery and client embeddings
+product: iris
+change_type: feature
+affected_components:
+  - core/capability_helpers_test.go
+  - core/client.go
+  - core/client_embeddings_test.go
+  - core/content.go
+  - core/contextualized_embeddings.go
+  - core/embeddings.go
+  - core/reranker.go
+  - docs/ARCHITECTURE.md
+  - examples/image/gemini/main.go
+  - docs/changes/2026-08-19_v0.18.0_capability-discovery-client-embeddings.md
+related_frds: []
+---
+
+## Summary
+
+Every optional provider capability now has a symmetric `As*` discovery helper, removing the need for callers to write raw type assertions. `Client.Embed` adds a first-class embedding path with the client's timeout, retry, and telemetry lifecycle. The architecture guide documents the optional-interface pattern, current built-in implementers, and why image operations remain on their raw interface for now.
+
+## Motivation
+
+Only `BatchProvider` previously had an official discovery helper. Embeddings, contextualized embeddings, reranking, images, and content-part declarations required hand-written assertions, and embedding calls bypassed the lifecycle behavior configured on `core.Client`. This made capability discovery inconsistent and meant client telemetry, retry policies, and default timeouts did not apply to a common non-chat operation.
+
+## What Changed
+
+### New Additions
+
+- `core.AsEmbeddingProvider` discovers `EmbeddingProvider` implementations.
+- `core.AsContextualizedEmbeddingProvider` discovers `ContextualizedEmbeddingProvider` implementations.
+- `core.AsReranker` discovers `RerankerProvider` implementations.
+- `core.AsImageGenerator` discovers `ImageGenerator` implementations.
+- `core.AsContentPartSupporter` discovers `ContentPartSupporter` implementations.
+- `(*core.Client).Embed` delegates embedding requests with client-level timeout, retry, and telemetry behavior.
+- `core/capability_helpers_test.go` covers successful and unsuccessful discovery for every new helper.
+- `core/client_embeddings_test.go` covers delegation, error paths, retries, telemetry, contextual telemetry, timeout precedence, and disabled timeouts.
+
+### Modifications
+
+- The chat client's content-part warning path now uses `AsContentPartSupporter` instead of a raw type assertion.
+- The Gemini image example now uses `AsImageGenerator` instead of a raw type assertion.
+- `DefaultTimeout` and `WithTimeout` documentation now state that the default applies to client-routed embedding calls as well as chat and streaming setup.
+- `docs/ARCHITECTURE.md` now describes optional capability discovery and lists the built-in provider implementations.
+
+### Removals
+
+N/A. No interfaces, methods, or behaviors were removed.
+
+## Technical Specification
+
+### Data Schemas / Types
+
+N/A. This change uses the existing embedding request, response, usage, telemetry, and provider interface types without changing their fields.
+
+### API Endpoints
+
+N/A. `Client.Embed` delegates to the selected provider's existing `CreateEmbeddings` implementation and does not introduce a new network endpoint.
+
+### CLI Interface
+
+N/A. No CLI commands or flags changed.
+
+### Go Package API
+
+The new discovery helpers mirror `AsBatchProvider` and return `(nil, false)` when the concrete provider does not implement the optional interface:
+
+```go
+func AsEmbeddingProvider(p Provider) (EmbeddingProvider, bool)
+func AsContextualizedEmbeddingProvider(p Provider) (ContextualizedEmbeddingProvider, bool)
+func AsReranker(p Provider) (RerankerProvider, bool)
+func AsImageGenerator(p Provider) (ImageGenerator, bool)
+func AsContentPartSupporter(p Provider) (ContentPartSupporter, bool)
+```
+
+The client-level embedding method is:
+
+```go
+func (c *Client) Embed(
+    ctx context.Context,
+    req *EmbeddingRequest,
+) (*EmbeddingResponse, error)
+```
+
+`Embed` rejects nil contexts and requests before dispatch. It returns an error wrapping `core.ErrNotSupported` when the client's provider does not implement `EmbeddingProvider`. Unsupported capability errors occur before telemetry starts.
+
+When the caller's context has no deadline and the client timeout is positive, `Embed` applies `WithTimeout`'s duration. An Iris-applied deadline returns an error matching both `core.ErrTimeout` and `context.DeadlineExceeded`; a caller-supplied deadline remains a raw context deadline error. Transient provider failures use the configured `RetryPolicy`.
+
+The method emits base or contextual telemetry hooks using only provider ID, model ID, timestamps, token counts, and the classified error. `EmbeddingUsage.PromptTokens` and `EmbeddingUsage.TotalTokens` map to the corresponding `TokenUsage` fields; completion tokens remain zero.
+
+### Configuration
+
+No new options were added. `WithTelemetry`, `WithRetryPolicy`, and `WithTimeout` now also govern `Client.Embed` calls.
+
+## Usage Examples
+
+### Example: Discover and call a raw optional capability
+
+```go
+embedder, ok := core.AsEmbeddingProvider(provider)
+if !ok {
+    return core.ErrNotSupported
+}
+
+response, err := embedder.CreateEmbeddings(ctx, &core.EmbeddingRequest{
+    Model: "text-embedding-3-small",
+    Input: []core.EmbeddingInput{{Text: "Text to index"}},
+})
+```
+
+### Example: Use client-managed embeddings
+
+```go
+client := core.NewClient(
+    provider,
+    core.WithTimeout(30*time.Second),
+    core.WithTelemetry(telemetryHook),
+)
+
+response, err := client.Embed(ctx, &core.EmbeddingRequest{
+    Model: "text-embedding-3-small",
+    Input: []core.EmbeddingInput{
+        {ID: "doc-1", Text: "Refunds are available for 30 days."},
+        {ID: "doc-2", Text: "Shipping takes three business days."},
+    },
+    InputType: core.InputTypeDocument,
+})
+if err != nil {
+    return err
+}
+```
+
+### Example: Handle a provider without embeddings
+
+```go
+_, err := client.Embed(ctx, request)
+if errors.Is(err, core.ErrNotSupported) {
+    return fmt.Errorf("choose an embedding-capable provider: %w", err)
+}
+```
+
+## Integration Notes
+
+PetalFlow, Cortex, and other Iris consumers can replace raw type assertions with the exported helpers without changing provider selection. Consumers that call embeddings through `Client.Embed` gain the same retry, telemetry, and default-timeout configuration already used for chat. Direct `EmbeddingProvider.CreateEmbeddings` calls remain supported and continue to use only provider-level behavior.
+
+The built-in implementer matrix is: OpenAI for batch; Azure AI Foundry, Gemini, Ollama, OpenAI, and Voyage AI for embeddings; Voyage AI for contextualized embeddings and reranking; Gemini and OpenAI for images; and Anthropic, Azure AI Foundry, Gemini, and OpenAI for per-content-part declarations. Third-party providers can implement any optional interface without registering in core.
+
+## Breaking Changes & Migration
+
+None. Existing type assertions and direct provider calls continue to compile. Callers may migrate incrementally to the helpers or `Client.Embed`.
+
+## Deferred / Out of Scope
+
+Client-level image conveniences are deferred. `ImageGenerator` covers generation, multipart editing, and partial-image streaming with different lifecycles, and `ImageUsage` does not map directly to the chat-oriented telemetry event. Until a client API handles all three consistently, callers should use `AsImageGenerator` and set a context deadline on direct image operations.
+
+Client-level methods for contextualized embeddings, reranking, and batch processing are also outside this change; their symmetric discovery helpers are available.
+
+## Testing Notes
+
+The full race-enabled Go test suite, `go vet ./...`, CI-matched golangci-lint v2.1.6, formatting checks, and diff checks passed. Aggregate statement coverage was 81.0%, with the core package at 91.6%. The new tests exercise helper success/failure, embedding delegation, unsupported and nil requests, telemetry on success and failure, contextual hook propagation, transient retries, Iris-owned timeout mapping, disabled client timeouts, and preservation of caller-owned deadlines.

--- a/examples/image/gemini/main.go
+++ b/examples/image/gemini/main.go
@@ -27,12 +27,10 @@ func main() {
 	}
 
 	provider := gemini.New(apiKey)
-	client := core.NewClient(provider)
 
 	fmt.Println("Generating image with Gemini...")
 
-	// Type assert to ImageGenerator
-	imageGen, ok := client.Provider().(core.ImageGenerator)
+	imageGen, ok := core.AsImageGenerator(provider)
 	if !ok {
 		fmt.Fprintln(os.Stderr, "Provider does not support image generation")
 		os.Exit(1)


### PR DESCRIPTION
## Summary

- add symmetric `As*Provider` helpers for every optional provider capability
- add `Client.Embed` with retry, timeout, telemetry, and contextual embedding support
- document the optional capability matrix and the rationale for deferring client-level image generation
- update the Gemini image example to use capability discovery

## Context

Only batch generation previously had a capability-discovery helper, so consumers used raw type assertions for embeddings, reranking, images, and content-part support. Embedding calls also bypassed the client lifecycle used by generation requests.

## Implementation

- return `ErrNotSupported` when the configured provider has no embedding capability
- preserve caller deadlines while mapping Iris-owned timeouts to `ErrTimeout`
- apply the configured retry policy and base/contextual telemetry lifecycle
- propagate contextual embedding metadata and map embedding usage to `TokenUsage`
- leave image generation provider-level for now because its request/response lifecycle differs enough to require a separately designed client API

## Testing

- `go test -race -coverprofile=/tmp/iris-issue68-coverage.out -covermode=atomic ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run`
- `go vet ./...`
- aggregate coverage: 81.0%; `core`: 91.6%
- formatting and diff checks

Closes #68
