### PR TITLE
[P2] Improve client resilience

### DIFF
--- a/core/client.go
+++ b/core/client.go
@@ -52,6 +52,7 @@ type Client struct {
 	provider          Provider
 	telemetry         TelemetryHook
 	retry             RetryPolicy
+	rateLimiter       RateLimiter
 	warningHandler    WarningHandler
 	timeout           time.Duration
 	streamIdleTimeout time.Duration
@@ -93,6 +94,16 @@ func WithRetryPolicy(r RetryPolicy) ClientOption {
 	return func(c *Client) {
 		if r != nil {
 			c.retry = r
+		}
+	}
+}
+
+// WithRateLimiter configures a limiter used before every provider attempt,
+// including retries. Pass nil to leave rate limiting disabled.
+func WithRateLimiter(l RateLimiter) ClientOption {
+	return func(c *Client) {
+		if l != nil {
+			c.rateLimiter = l
 		}
 	}
 }
@@ -668,6 +679,9 @@ func (b *ChatBuilder) GetResponse(ctx context.Context) (*ChatResponse, error) {
 	// Execute with retry logic
 retryLoop:
 	for attempt := 0; ; attempt++ {
+		if err = b.client.waitForRateLimit(ctx); err != nil {
+			break
+		}
 		resp, err = b.client.provider.Chat(ctx, &b.req)
 		if err == nil {
 			break
@@ -778,7 +792,30 @@ func (b *ChatBuilder) Stream(ctx context.Context) (*ChatStream, error) {
 		ctx, idleCancel = context.WithCancel(ctx)
 	}
 
-	stream, err := b.client.provider.StreamChat(ctx, &b.req)
+	var stream *ChatStream
+	var err error
+
+retryLoop:
+	for attempt := 0; ; attempt++ {
+		if err = b.client.waitForRateLimit(ctx); err != nil {
+			break
+		}
+		stream, err = b.client.provider.StreamChat(ctx, &b.req)
+		if err == nil {
+			break
+		}
+
+		delay, shouldRetry := b.client.retry.NextDelay(attempt, err)
+		if !shouldRetry {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+			break retryLoop
+		case <-time.After(delay):
+		}
+	}
 	if err != nil {
 		if idleCancel != nil {
 			idleCancel()
@@ -847,6 +884,13 @@ func (b *ChatBuilder) Stream(ctx context.Context) (*ChatStream, error) {
 
 	// Wrap the stream to emit telemetry when it completes
 	return wrapStreamWithTelemetry(ctx, stream, b.client.telemetry, providerID, b.req.Model, start, onDone, mapErr), nil
+}
+
+func (c *Client) waitForRateLimit(ctx context.Context) error {
+	if c.rateLimiter == nil {
+		return contextError(ctx)
+	}
+	return c.rateLimiter.Wait(ctx)
 }
 
 // MessageBuilder provides a fluent API for building multimodal messages.

--- a/core/client_test.go
+++ b/core/client_test.go
@@ -402,6 +402,100 @@ func TestStreamValidation(t *testing.T) {
 	}
 }
 
+func TestStreamRetriesSetupErrors(t *testing.T) {
+	callCount := 0
+	p := &mockProvider{
+		id: "test",
+		streamFunc: func(_ context.Context, req *ChatRequest) (*ChatStream, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, ErrServer
+			}
+
+			ch := make(chan ChatChunk, 1)
+			errCh := make(chan error)
+			finalCh := make(chan *ChatResponse, 1)
+			ch <- ChatChunk{Delta: "ok"}
+			close(ch)
+			finalCh <- &ChatResponse{Output: "ok"}
+			close(finalCh)
+			close(errCh)
+			return &ChatStream{Ch: ch, Err: errCh, Final: finalCh}, nil
+		},
+	}
+
+	retry := NewRetryPolicy(RetryConfig{
+		MaxRetries: 1,
+		BaseDelay:  time.Millisecond,
+		MaxDelay:   time.Millisecond,
+		Jitter:     0,
+	})
+	client := NewClient(p, WithRetryPolicy(retry), WithTimeout(0))
+	stream, err := client.Chat("model").User("hello").Stream(context.Background())
+	if err != nil {
+		t.Fatalf("Stream() error = %v", err)
+	}
+	if callCount != 2 {
+		t.Fatalf("provider call count = %d, want 2", callCount)
+	}
+	response, err := DrainStream(context.Background(), stream)
+	if err != nil {
+		t.Fatalf("DrainStream() error = %v", err)
+	}
+	if response.Output != "ok" {
+		t.Fatalf("response output = %q, want ok", response.Output)
+	}
+}
+
+func TestClientRateLimiterRunsForEachAttempt(t *testing.T) {
+	rateLimitCalls := 0
+	providerCalls := 0
+	p := &mockProvider{
+		id: "test",
+		chatFunc: func(_ context.Context, _ *ChatRequest) (*ChatResponse, error) {
+			providerCalls++
+			if providerCalls == 1 {
+				return nil, ErrNetwork
+			}
+			return &ChatResponse{Output: "ok"}, nil
+		},
+	}
+	retry := NewRetryPolicy(RetryConfig{
+		MaxRetries: 1,
+		BaseDelay:  time.Millisecond,
+		MaxDelay:   time.Millisecond,
+		Jitter:     0,
+	})
+	client := NewClient(p,
+		WithTimeout(0),
+		WithRetryPolicy(retry),
+		WithRateLimiter(RateLimiterFunc(func(context.Context) error {
+			rateLimitCalls++
+			return nil
+		})),
+	)
+
+	if _, err := client.Chat("model").User("hello").GetResponse(context.Background()); err != nil {
+		t.Fatalf("GetResponse() error = %v", err)
+	}
+	if rateLimitCalls != 2 {
+		t.Fatalf("rate limiter calls = %d, want 2", rateLimitCalls)
+	}
+}
+
+func TestIntervalRateLimiterRespectsContext(t *testing.T) {
+	limiter := NewIntervalRateLimiter(100 * time.Millisecond)
+	if err := limiter.Wait(context.Background()); err != nil {
+		t.Fatalf("first Wait() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	if err := limiter.Wait(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("second Wait() error = %v, want context deadline", err)
+	}
+}
+
 func TestStreamSuccess(t *testing.T) {
 	p := &mockProvider{id: "test"}
 	c := NewClient(p)

--- a/core/errors.go
+++ b/core/errors.go
@@ -9,13 +9,14 @@ import (
 
 // ProviderError represents an error returned by a provider with full context.
 type ProviderError struct {
-	Provider  string
-	Status    int
-	RequestID string
-	Code      string
-	Message   string
-	Body      string // raw response body (truncated); preserved when Message lacks detail
-	Err       error
+	Provider   string
+	Status     int
+	RequestID  string
+	Code       string
+	Message    string
+	Body       string        // raw response body (truncated); preserved when Message lacks detail
+	RetryAfter time.Duration // server-advised minimum delay before retrying
+	Err        error
 }
 
 // Error implements the error interface.

--- a/core/rate_limit.go
+++ b/core/rate_limit.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// RateLimiter controls when the client may start an outgoing provider attempt.
+// Wait must return context cancellation or deadline errors promptly when ctx is
+// done. The client calls Wait for the initial request and every retry attempt.
+type RateLimiter interface {
+	Wait(ctx context.Context) error
+}
+
+// RateLimiterFunc adapts a function into a RateLimiter.
+type RateLimiterFunc func(context.Context) error
+
+// Wait implements RateLimiter.
+func (f RateLimiterFunc) Wait(ctx context.Context) error {
+	if f == nil {
+		return contextError(ctx)
+	}
+	return f(ctx)
+}
+
+// IntervalRateLimiter spaces request starts by a fixed interval. It is safe
+// for concurrent use and does not queue requests after their contexts expire.
+type IntervalRateLimiter struct {
+	mu       sync.Mutex
+	interval time.Duration
+	next     time.Time
+}
+
+// NewIntervalRateLimiter creates a limiter that permits one request every
+// interval. A non-positive interval disables waiting.
+func NewIntervalRateLimiter(interval time.Duration) *IntervalRateLimiter {
+	if interval < 0 {
+		interval = 0
+	}
+	return &IntervalRateLimiter{interval: interval}
+}
+
+// Wait blocks until the next request slot is available or ctx is done.
+func (l *IntervalRateLimiter) Wait(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if l == nil || l.interval <= 0 {
+		return ctx.Err()
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if err := contextError(ctx); err != nil {
+		return err
+	}
+
+	now := time.Now()
+	readyAt := l.next
+	if readyAt.Before(now) {
+		readyAt = now
+	}
+	if wait := time.Until(readyAt); wait > 0 {
+		timer := time.NewTimer(wait)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+
+	l.next = time.Now().Add(l.interval)
+	return nil
+}
+
+func contextError(ctx context.Context) error {
+	if ctx == nil {
+		return nil
+	}
+	return ctx.Err()
+}

--- a/core/retry.go
+++ b/core/retry.go
@@ -91,6 +91,14 @@ func (e *exponentialBackoff) NextDelay(attempt int, err error) (time.Duration, b
 		delay = 0
 	}
 
+	// A server-provided delay is a minimum. It is intentionally applied after
+	// jitter and the local cap so Retry-After is never shortened by client-side
+	// backoff configuration.
+	var pe *ProviderError
+	if errors.As(err, &pe) && pe.RetryAfter > time.Duration(delay) {
+		delay = float64(pe.RetryAfter)
+	}
+
 	return time.Duration(delay), true
 }
 

--- a/core/retry_test.go
+++ b/core/retry_test.go
@@ -242,6 +242,27 @@ func TestRetryPolicyProviderErrorStatusCodes(t *testing.T) {
 	}
 }
 
+func TestRetryPolicyHonorsProviderRetryAfter(t *testing.T) {
+	policy := NewRetryPolicy(RetryConfig{
+		MaxRetries: 3,
+		BaseDelay:  time.Second,
+		MaxDelay:   5 * time.Second,
+		Jitter:     0,
+	})
+
+	delay, ok := policy.NextDelay(0, &ProviderError{
+		Provider:   "test",
+		Status:     429,
+		RetryAfter: 30 * time.Second,
+	})
+	if !ok {
+		t.Fatal("Retry-After error should be retryable")
+	}
+	if delay < 30*time.Second {
+		t.Fatalf("delay = %v, want at least 30s", delay)
+	}
+}
+
 func TestIsRetryable(t *testing.T) {
 	tests := []struct {
 		name string

--- a/docs/changes/2026-08-28_v0.0.0-dev_issue-69-resilience.md
+++ b/docs/changes/2026-08-28_v0.0.0-dev_issue-69-resilience.md
@@ -1,0 +1,183 @@
+---
+date: 2026-08-28
+version: v0.0.0-dev
+feature: Client resilience improvements
+product: iris
+change_type: api
+affected_components: [
+  core/client.go,
+  core/client_test.go,
+  core/errors.go,
+  core/rate_limit.go,
+  core/retry.go,
+  core/retry_test.go,
+  providers/internal/normalize/errors.go,
+  providers/internal/normalize/errors_test.go,
+  providers/openai/client.go,
+  providers/openai/client_embeddings.go,
+  providers/openai/client_responses.go,
+  providers/openai/errors.go,
+  providers/openai/errors_test.go,
+  providers/openai/streaming.go,
+  providers/openai/streaming_responses.go,
+  providers/anthropic/client.go,
+  providers/anthropic/client_files.go,
+  providers/anthropic/errors.go,
+  providers/anthropic/streaming.go,
+  providers/azurefoundry/client_chat.go,
+  providers/azurefoundry/embeddings.go,
+  providers/azurefoundry/errors.go,
+  providers/gemini/client.go,
+  providers/gemini/client_files.go,
+  providers/gemini/client_image.go,
+  providers/gemini/embeddings.go,
+  providers/gemini/errors.go,
+  providers/gemini/streaming.go,
+  providers/huggingface/client.go,
+  providers/huggingface/discovery.go,
+  providers/huggingface/errors.go,
+  providers/huggingface/streaming.go,
+  providers/ollama/errors.go,
+  providers/perplexity/client.go,
+  providers/perplexity/errors.go,
+  providers/perplexity/streaming.go,
+  providers/voyageai/client_contextualized.go,
+  providers/voyageai/client_embeddings.go,
+  providers/voyageai/client_rerank.go,
+  providers/voyageai/errors.go,
+  providers/xai/client.go,
+  providers/xai/errors.go,
+  providers/xai/streaming.go,
+  providers/zai/client.go,
+  providers/zai/errors.go,
+  providers/zai/streaming.go
+]
+related_frds: []
+---
+
+## Summary
+
+Issue #69 adds resilience behavior at the shared client layer. Stream setup failures now use the configured retry policy, provider `Retry-After` hints are preserved and honored, and clients can enforce a request-start rate limit across initial attempts and retries. Mid-stream reconnection, HTTP middleware interception, and multi-provider fallback routing remain out of scope.
+
+## Motivation
+
+Before this change, retry behavior covered unary chat calls but not stream setup, and provider response headers were discarded before the retry policy saw the error. This caused clients to retry too quickly after server-advised rate limits and made it impossible to centrally pace outgoing attempts.
+
+## What Changed
+
+### New Additions
+
+- `core.ProviderError.RetryAfter time.Duration` stores a positive server-advised minimum retry delay.
+- `core.RateLimiter` defines `Wait(context.Context) error` for client-side request pacing.
+- `core.RateLimiterFunc` adapts a function to `core.RateLimiter`.
+- `core.IntervalRateLimiter` and `core.NewIntervalRateLimiter(interval time.Duration)` provide a concurrency-safe fixed-interval limiter.
+- `core.WithRateLimiter(l RateLimiter) ClientOption` installs a limiter on a client. The limiter runs before every chat and stream setup attempt, including retries.
+- `providers/internal/normalize.WithRetryAfter(err error, headers ...http.Header) error` extracts standard `Retry-After`, Azure millisecond, and common reset headers into normalized provider errors.
+
+### Modifications
+
+- `RetryPolicy.NextDelay` treats `ProviderError.RetryAfter` as a minimum. The server hint is applied after jitter and the configured local cap, so client configuration cannot shorten a server-required wait.
+- `ChatBuilder.Stream` retries only failures returned while establishing the stream. Once a `ChatStream` is returned, its body is not reconnected or replayed.
+- Chat and streaming provider error paths—and the existing embedding, file, image, discovery, and rerank paths that use the shared normalizers—now pass response headers through normalization.
+
+### Removals
+
+N/A. Existing retry policy and provider APIs remain source-compatible; the new provider error field is additive.
+
+## Technical Specification
+
+### Data Schemas / Types
+
+```go
+type ProviderError struct {
+	Provider   string
+	Status     int
+	RequestID  string
+	Code       string
+	Message    string
+	Body       string
+	RetryAfter time.Duration
+	Err        error
+}
+```
+
+`RetryAfter <= 0` means that no usable server delay was supplied. The field is populated from response headers by shared provider normalization and is not included in the human-readable error string.
+
+### Go Package API
+
+```go
+type RateLimiter interface {
+	Wait(ctx context.Context) error
+}
+
+type RateLimiterFunc func(context.Context) error
+
+func NewIntervalRateLimiter(interval time.Duration) *IntervalRateLimiter
+
+func WithRateLimiter(l RateLimiter) ClientOption
+```
+
+`IntervalRateLimiter` permits the first request immediately and spaces subsequent request starts by `interval`. Calls waiting for a slot return `ctx.Err()` if the context is canceled or reaches its deadline. A non-positive interval disables waiting.
+
+## Usage Examples
+
+### Example: Pace chat attempts and honor a server rate limit
+
+```go
+limiter := core.NewIntervalRateLimiter(250 * time.Millisecond)
+client := core.NewClient(provider, core.WithRateLimiter(limiter))
+
+response, err := client.Chat("gpt-5.6").
+	User("Summarize this report").
+	GetResponse(ctx)
+if err != nil {
+	// A 429 Retry-After response is retried no earlier than its hint.
+	return err
+}
+fmt.Println(response.Output)
+```
+
+### Example: Supply a custom limiter
+
+```go
+client := core.NewClient(provider, core.WithRateLimiter(
+	core.RateLimiterFunc(func(ctx context.Context) error {
+		return acquireSharedQuota(ctx)
+	}),
+))
+```
+
+### Example: Stream setup retries
+
+```go
+stream, err := client.Chat("gpt-5.6").User("Hello").Stream(ctx)
+if err != nil {
+	// Only setup failures are retried. Errors after stream creation arrive on
+	// stream.Err and are not automatically replayed.
+	return err
+}
+response, err := core.DrainStream(ctx, stream)
+```
+
+## Integration Notes
+
+The change is confined to Iris core retry and stream paths plus provider error normalization. Provider-specific HTTP clients remain responsible for issuing requests; the shared client only controls attempt timing and does not intercept or rewrite HTTP requests. No PetalFlow, Cortex, or PetalTrace contract changes are required.
+
+## Breaking Changes & Migration
+
+None. Existing clients retain the default behavior with no rate limiter configured. Existing custom `RetryPolicy` implementations continue to use the unchanged `NextDelay(attempt, err)` signature.
+
+## Deferred / Out of Scope
+
+- Mid-stream reconnection or response resumption is deferred because replaying a partially consumed stream requires provider-specific request IDs and semantics.
+- `core.WithHTTPMiddleware(...)` is deferred; providers currently own their `http.Client` and transport configuration, so a correct cross-provider interception API needs a separate design.
+- Fallback providers and cost/latency model routing are deferred for a separate package/design discussion.
+
+## Testing Notes
+
+- Added core tests for server delay minima, stream setup retries, per-attempt rate-limiter invocation, and context-aware interval limiting.
+- Added normalization tests for numeric and HTTP-date `Retry-After` values plus an OpenAI provider normalization test.
+- `go test -race ./core` passed.
+- `go test ./...` passed across all packages and providers.
+- `go test -race ./...` passed across all packages and providers.
+- Focused tests for core, shared normalization, and OpenAI passed.

--- a/providers/anthropic/client.go
+++ b/providers/anthropic/client.go
@@ -56,7 +56,7 @@ func (p *Anthropic) doChat(ctx context.Context, req *core.ChatRequest) (*core.Ch
 
 	// Check for error status
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Parse response

--- a/providers/anthropic/client_files.go
+++ b/providers/anthropic/client_files.go
@@ -76,7 +76,7 @@ func (p *Anthropic) UploadFile(ctx context.Context, req *FileUploadRequest) (*Fi
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, normalizeError(resp.StatusCode, body, resp.Header.Get("request-id"))
+		return nil, normalizeError(resp.StatusCode, body, resp.Header.Get("request-id"), resp.Header)
 	}
 
 	var file File
@@ -117,7 +117,7 @@ func (p *Anthropic) GetFile(ctx context.Context, fileID string) (*File, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, normalizeError(resp.StatusCode, body, resp.Header.Get("request-id"))
+		return nil, normalizeError(resp.StatusCode, body, resp.Header.Get("request-id"), resp.Header)
 	}
 
 	var file File
@@ -174,7 +174,7 @@ func (p *Anthropic) ListFiles(ctx context.Context, req *FileListRequest) (*FileL
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, normalizeError(resp.StatusCode, body, resp.Header.Get("request-id"))
+		return nil, normalizeError(resp.StatusCode, body, resp.Header.Get("request-id"), resp.Header)
 	}
 
 	var result FileListResponse
@@ -256,7 +256,7 @@ func (p *Anthropic) DownloadFile(ctx context.Context, fileID string) (io.ReadClo
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
 		body, _ := io.ReadAll(resp.Body)
-		return nil, normalizeError(resp.StatusCode, body, resp.Header.Get("request-id"))
+		return nil, normalizeError(resp.StatusCode, body, resp.Header.Get("request-id"), resp.Header)
 	}
 
 	return resp.Body, nil
@@ -292,7 +292,7 @@ func (p *Anthropic) DeleteFile(ctx context.Context, fileID string) error {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return normalizeError(resp.StatusCode, body, resp.Header.Get("request-id"))
+		return normalizeError(resp.StatusCode, body, resp.Header.Get("request-id"), resp.Header)
 	}
 
 	return nil

--- a/providers/anthropic/errors.go
+++ b/providers/anthropic/errors.go
@@ -31,7 +31,7 @@ var ErrToolArgsInvalidJSON = errors.New("tool args invalid json")
 var ErrFileNotDownloadable = errors.New("file not downloadable")
 
 // normalizeError converts an HTTP error response to a ProviderError with the appropriate sentinel.
-func normalizeError(status int, body []byte, requestID string) error {
+func normalizeError(status int, body []byte, requestID string, headers ...http.Header) error {
 	// Parse error response if possible
 	var errResp anthropicErrorResponse
 	_ = json.Unmarshal(body, &errResp)
@@ -53,7 +53,7 @@ func normalizeError(status int, body []byte, requestID string) error {
 
 	pe := normalize.ProviderError("anthropic", status, requestID, code, message, normalize.SentinelForStatus(status))
 	pe.(*core.ProviderError).Body = bodyStr
-	return pe
+	return normalize.WithRetryAfter(pe, headers...)
 }
 
 // newNetworkError creates a ProviderError for network-related failures.

--- a/providers/anthropic/streaming.go
+++ b/providers/anthropic/streaming.go
@@ -89,7 +89,7 @@ func (p *Anthropic) doStreamChat(ctx context.Context, req *core.ChatRequest) (*c
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()
 		respBody, _ := io.ReadAll(resp.Body)
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Create channels

--- a/providers/azurefoundry/client_chat.go
+++ b/providers/azurefoundry/client_chat.go
@@ -67,7 +67,7 @@ func (p *AzureFoundry) doChat(ctx context.Context, req *core.ChatRequest) (*core
 
 	// Check for error status
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Parse response
@@ -143,7 +143,7 @@ func (p *AzureFoundry) doStreamChat(ctx context.Context, req *core.ChatRequest) 
 		if err != nil {
 			return nil, newNetworkError(err)
 		}
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Process SSE stream using the passed-in ctx; the reader goroutine

--- a/providers/azurefoundry/embeddings.go
+++ b/providers/azurefoundry/embeddings.go
@@ -108,7 +108,7 @@ func (p *AzureFoundry) CreateEmbeddings(ctx context.Context, req *core.Embedding
 
 	// Check for error status
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Parse response

--- a/providers/azurefoundry/errors.go
+++ b/providers/azurefoundry/errors.go
@@ -88,11 +88,13 @@ type azureInnerError struct {
 }
 
 // normalizeError converts an HTTP error response to a ProviderError with the appropriate sentinel.
-func normalizeError(status int, body []byte, requestID string) error {
+func normalizeError(status int, body []byte, requestID string, headers ...http.Header) error {
 	var errResp azureErrorResponse
 	if err := json.Unmarshal(body, &errResp); err != nil {
 		// Could not parse error response, use generic handling
-		return normalize.OpenAIStyleProviderError("azurefoundry", status, body, requestID)
+		return normalize.WithRetryAfter(
+			normalize.OpenAIStyleProviderError("azurefoundry", status, body, requestID), headers...,
+		)
 	}
 
 	detail := errResp.Error
@@ -111,14 +113,14 @@ func normalizeError(status int, body []byte, requestID string) error {
 	// Classify error based on code
 	sentinel := classifyErrorCode(code, innerCode, status)
 
-	return &core.ProviderError{
+	return normalize.WithRetryAfter(&core.ProviderError{
 		Provider:  "azurefoundry",
 		Status:    status,
 		RequestID: requestID,
 		Code:      code,
 		Message:   message,
 		Err:       sentinel,
-	}
+	}, headers...)
 }
 
 // classifyErrorCode maps Azure error codes to sentinel errors.

--- a/providers/gemini/client.go
+++ b/providers/gemini/client.go
@@ -51,7 +51,7 @@ func (p *Gemini) doChat(ctx context.Context, req *core.ChatRequest) (*core.ChatR
 
 	// Check for error status
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody)
+		return nil, normalizeError(resp.StatusCode, respBody, resp.Header)
 	}
 
 	// Parse response

--- a/providers/gemini/client_files.go
+++ b/providers/gemini/client_files.go
@@ -70,7 +70,7 @@ func (p *Gemini) initiateResumableUpload(ctx context.Context, req *FileUploadReq
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)
-		return "", normalizeError(resp.StatusCode, respBody)
+		return "", normalizeError(resp.StatusCode, respBody, resp.Header)
 	}
 
 	uploadURL := resp.Header.Get("X-Goog-Upload-URL")
@@ -109,7 +109,7 @@ func (p *Gemini) uploadFileContent(ctx context.Context, uploadURL string, req *F
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, normalizeError(resp.StatusCode, body)
+		return nil, normalizeError(resp.StatusCode, body, resp.Header)
 	}
 
 	var result fileUploadResponse
@@ -146,7 +146,7 @@ func (p *Gemini) GetFile(ctx context.Context, name string) (*File, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, normalizeError(resp.StatusCode, body)
+		return nil, normalizeError(resp.StatusCode, body, resp.Header)
 	}
 
 	var file File
@@ -196,7 +196,7 @@ func (p *Gemini) ListFiles(ctx context.Context, req *FileListRequest) (*FileList
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, normalizeError(resp.StatusCode, body)
+		return nil, normalizeError(resp.StatusCode, body, resp.Header)
 	}
 
 	var result FileListResponse
@@ -259,7 +259,7 @@ func (p *Gemini) DeleteFile(ctx context.Context, name string) error {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return normalizeError(resp.StatusCode, body)
+		return normalizeError(resp.StatusCode, body, resp.Header)
 	}
 
 	return nil

--- a/providers/gemini/client_image.go
+++ b/providers/gemini/client_image.go
@@ -48,7 +48,7 @@ func (p *Gemini) GenerateImage(ctx context.Context, req *core.ImageGenerateReque
 	}
 
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody)
+		return nil, normalizeError(resp.StatusCode, respBody, resp.Header)
 	}
 
 	var gemResp geminiResponse
@@ -95,7 +95,7 @@ func (p *Gemini) EditImage(ctx context.Context, req *core.ImageEditRequest) (*co
 	}
 
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody)
+		return nil, normalizeError(resp.StatusCode, respBody, resp.Header)
 	}
 
 	var gemResp geminiResponse

--- a/providers/gemini/embeddings.go
+++ b/providers/gemini/embeddings.go
@@ -99,7 +99,7 @@ func decodeGeminiEmbeddingResponse(resp *http.Response) (*geminiBatchEmbeddingRe
 		return nil, newNetworkError(err)
 	}
 	if resp.StatusCode >= http.StatusBadRequest {
-		return nil, normalizeError(resp.StatusCode, body)
+		return nil, normalizeError(resp.StatusCode, body, resp.Header)
 	}
 
 	var response geminiBatchEmbeddingResponse

--- a/providers/gemini/errors.go
+++ b/providers/gemini/errors.go
@@ -34,7 +34,7 @@ var (
 )
 
 // normalizeError converts an HTTP error response to a ProviderError with the appropriate sentinel.
-func normalizeError(status int, body []byte) error {
+func normalizeError(status int, body []byte, headers ...http.Header) error {
 	// Parse error response if possible
 	var errResp geminiErrorResponse
 	_ = json.Unmarshal(body, &errResp)
@@ -56,7 +56,7 @@ func normalizeError(status int, body []byte) error {
 
 	pe := normalize.ProviderError("gemini", status, "", code, message, normalize.SentinelForStatus(status))
 	pe.(*core.ProviderError).Body = bodyStr
-	return pe
+	return normalize.WithRetryAfter(pe, headers...)
 }
 
 // newNetworkError creates a ProviderError for network-related failures.

--- a/providers/gemini/streaming.go
+++ b/providers/gemini/streaming.go
@@ -48,7 +48,7 @@ func (p *Gemini) doStreamChat(ctx context.Context, req *core.ChatRequest) (*core
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()
 		respBody, _ := io.ReadAll(resp.Body)
-		return nil, normalizeError(resp.StatusCode, respBody)
+		return nil, normalizeError(resp.StatusCode, respBody, resp.Header)
 	}
 
 	// Create channels

--- a/providers/huggingface/client.go
+++ b/providers/huggingface/client.go
@@ -83,7 +83,7 @@ func (p *HuggingFace) doChat(ctx context.Context, req *core.ChatRequest) (*core.
 
 	// Check for error status
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Parse response

--- a/providers/huggingface/discovery.go
+++ b/providers/huggingface/discovery.go
@@ -117,7 +117,7 @@ func (p *HuggingFace) GetModelStatus(ctx context.Context, modelID string) (Model
 
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(resp.Body)
-		return ModelStatusUnknown, normalizeError(resp.StatusCode, body, "")
+		return ModelStatusUnknown, normalizeError(resp.StatusCode, body, "", resp.Header)
 	}
 
 	var result hubModelDetailResponse
@@ -158,7 +158,7 @@ func (p *HuggingFace) GetModelProviders(ctx context.Context, modelID string) ([]
 
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, normalizeError(resp.StatusCode, body, "")
+		return nil, normalizeError(resp.StatusCode, body, "", resp.Header)
 	}
 
 	var result hubModelDetailResponse
@@ -222,7 +222,7 @@ func (p *HuggingFace) ListModels(ctx context.Context, opts ListModelsOptions) ([
 
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, normalizeError(resp.StatusCode, body, "")
+		return nil, normalizeError(resp.StatusCode, body, "", resp.Header)
 	}
 
 	var results []hubModelInfoResponse

--- a/providers/huggingface/errors.go
+++ b/providers/huggingface/errors.go
@@ -2,6 +2,7 @@ package huggingface
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/petal-labs/iris/providers/internal/normalize"
 )
@@ -10,8 +11,10 @@ import (
 var ErrToolArgsInvalidJSON = errors.New("tool args invalid json")
 
 // normalizeError converts an HTTP error response to a ProviderError with the appropriate sentinel.
-func normalizeError(status int, body []byte, requestID string) error {
-	return normalize.OpenAIStyleProviderError("huggingface", status, body, requestID)
+func normalizeError(status int, body []byte, requestID string, headers ...http.Header) error {
+	return normalize.WithRetryAfter(
+		normalize.OpenAIStyleProviderError("huggingface", status, body, requestID), headers...,
+	)
 }
 
 // newNetworkError creates a ProviderError for network-related failures.

--- a/providers/huggingface/streaming.go
+++ b/providers/huggingface/streaming.go
@@ -87,7 +87,7 @@ func (p *HuggingFace) doStreamChat(ctx context.Context, req *core.ChatRequest) (
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()
 		respBody, _ := io.ReadAll(resp.Body)
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Create channels

--- a/providers/internal/normalize/errors.go
+++ b/providers/internal/normalize/errors.go
@@ -3,12 +3,68 @@ package normalize
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/petal-labs/iris/core"
 )
+
+// WithRetryAfter attaches a server-advised retry delay to a normalized
+// ProviderError. It accepts the standard Retry-After header plus common
+// provider-specific millisecond and reset headers.
+func WithRetryAfter(err error, headers ...http.Header) error {
+	if err == nil || len(headers) == 0 {
+		return err
+	}
+
+	var providerErr *core.ProviderError
+	if !errors.As(err, &providerErr) {
+		return err
+	}
+	providerErr.RetryAfter = retryAfterDuration(headers[0])
+	return err
+}
+
+func retryAfterDuration(headers http.Header) time.Duration {
+	if value := headers.Get("Retry-After"); value != "" {
+		if delay := parseRetryAfterValue(value); delay > 0 {
+			return delay
+		}
+	}
+	if value := headers.Get("x-ms-retry-after-ms"); value != "" {
+		if milliseconds, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64); err == nil && milliseconds > 0 {
+			return time.Duration(milliseconds) * time.Millisecond
+		}
+	}
+	for _, name := range []string{"x-ratelimit-reset-requests", "x-ratelimit-reset-tokens"} {
+		if value := headers.Get(name); value != "" {
+			if delay := parseRetryAfterValue(value); delay > 0 {
+				return delay
+			}
+		}
+	}
+	return 0
+}
+
+func parseRetryAfterValue(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil && seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	if date, err := http.ParseTime(value); err == nil {
+		if delay := time.Until(date); delay > 0 {
+			return delay
+		}
+	}
+	if duration, err := time.ParseDuration(value); err == nil && duration > 0 {
+		return duration
+	}
+	return 0
+}
 
 // maxBodyLen caps how much of a raw response body is retained on
 // ProviderError.Body so oversized error pages don't bloat logs.

--- a/providers/internal/normalize/errors_test.go
+++ b/providers/internal/normalize/errors_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/petal-labs/iris/core"
 )
@@ -142,6 +143,102 @@ func TestProviderErrorDefaults(t *testing.T) {
 	}
 	if !errors.Is(err, core.ErrServer) {
 		t.Error("error should wrap core.ErrServer")
+	}
+}
+
+func TestWithRetryAfterAttachesServerDelay(t *testing.T) {
+	err := ProviderError("test-provider", http.StatusTooManyRequests, "", "", "busy", core.ErrRateLimited)
+	wrapped := WithRetryAfter(err, http.Header{"Retry-After": []string{"30"}})
+
+	var providerErr *core.ProviderError
+	if !errors.As(wrapped, &providerErr) {
+		t.Fatal("expected *core.ProviderError")
+	}
+	if providerErr.RetryAfter != 30*time.Second {
+		t.Fatalf("RetryAfter = %v, want 30s", providerErr.RetryAfter)
+	}
+}
+
+func TestWithRetryAfterSupportsHTTPDate(t *testing.T) {
+	err := ProviderError("test-provider", http.StatusTooManyRequests, "", "", "busy", core.ErrRateLimited)
+	when := time.Now().Add(2 * time.Second).UTC().Format(http.TimeFormat)
+	wrapped := WithRetryAfter(err, http.Header{"Retry-After": []string{when}})
+
+	var providerErr *core.ProviderError
+	if !errors.As(wrapped, &providerErr) {
+		t.Fatal("expected *core.ProviderError")
+	}
+	if providerErr.RetryAfter <= 0 || providerErr.RetryAfter > 2*time.Second {
+		t.Fatalf("RetryAfter = %v, want a positive delay no greater than 2s", providerErr.RetryAfter)
+	}
+}
+
+func TestWithRetryAfterNoopCases(t *testing.T) {
+	if WithRetryAfter(nil, http.Header{"Retry-After": []string{"30"}}) != nil {
+		t.Fatal("nil error should remain nil")
+	}
+
+	original := errors.New("not a provider error")
+	if got := WithRetryAfter(original, http.Header{"Retry-After": []string{"30"}}); got != original {
+		t.Fatal("non-provider error should remain unchanged")
+	}
+
+	providerErr := ProviderError("test-provider", http.StatusTooManyRequests, "", "", "busy", core.ErrRateLimited)
+	if got := WithRetryAfter(providerErr); got != providerErr {
+		t.Fatal("provider error without headers should remain unchanged")
+	}
+}
+
+func TestWithRetryAfterSupportsProviderHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  string
+		value   string
+		wantMin time.Duration
+	}{
+		{name: "azure milliseconds", header: "x-ms-retry-after-ms", value: "1500", wantMin: 1500 * time.Millisecond},
+		{name: "reset duration", header: "x-ratelimit-reset-requests", value: "2s", wantMin: 2 * time.Second},
+		{name: "token reset duration", header: "x-ratelimit-reset-tokens", value: "3s", wantMin: 3 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ProviderError("test-provider", http.StatusTooManyRequests, "", "", "busy", core.ErrRateLimited)
+			headers := http.Header{}
+			headers.Set(tt.header, tt.value)
+			WithRetryAfter(err, headers)
+
+			var providerErr *core.ProviderError
+			if !errors.As(err, &providerErr) {
+				t.Fatal("expected *core.ProviderError")
+			}
+			if providerErr.RetryAfter != tt.wantMin {
+				t.Fatalf("RetryAfter = %v, want %v", providerErr.RetryAfter, tt.wantMin)
+			}
+		})
+	}
+}
+
+func TestWithRetryAfterIgnoresInvalidHints(t *testing.T) {
+	err := ProviderError("test-provider", http.StatusTooManyRequests, "", "", "busy", core.ErrRateLimited)
+	WithRetryAfter(err, http.Header{"Retry-After": []string{"not-a-delay"}})
+
+	var providerErr *core.ProviderError
+	if !errors.As(err, &providerErr) {
+		t.Fatal("expected *core.ProviderError")
+	}
+	if providerErr.RetryAfter != 0 {
+		t.Fatalf("RetryAfter = %v, want 0", providerErr.RetryAfter)
+	}
+
+	WithRetryAfter(err, http.Header{"Retry-After": []string{"1.5s"}})
+	if providerErr.RetryAfter != 1500*time.Millisecond {
+		t.Fatalf("duration RetryAfter = %v, want 1.5s", providerErr.RetryAfter)
+	}
+
+	WithRetryAfter(err, http.Header{"Retry-After": []string{time.Unix(1, 0).UTC().Format(http.TimeFormat)}})
+	if providerErr.RetryAfter != 0 {
+		t.Fatalf("expired RetryAfter = %v, want 0", providerErr.RetryAfter)
 	}
 }
 

--- a/providers/ollama/errors.go
+++ b/providers/ollama/errors.go
@@ -14,27 +14,27 @@ import (
 func parseErrorResponse(resp *http.Response) error {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return normalize.ProviderError(
+		return normalize.WithRetryAfter(normalize.ProviderError(
 			"ollama",
 			resp.StatusCode,
 			"",
 			"read_error",
 			fmt.Sprintf("failed to read error response: %v", err),
 			fmt.Errorf("%w: %w", core.ErrNetwork, err),
-		)
+		), resp.Header)
 	}
 
 	var errResp ollamaErrorResponse
 	if err := json.Unmarshal(body, &errResp); err != nil {
 		// If we can't parse JSON, use the raw body
-		return mapOllamaError(resp.StatusCode, string(body))
+		return normalize.WithRetryAfter(mapOllamaError(resp.StatusCode, string(body)), resp.Header)
 	}
 
 	if errResp.Error != "" {
-		return mapOllamaError(resp.StatusCode, errResp.Error)
+		return normalize.WithRetryAfter(mapOllamaError(resp.StatusCode, errResp.Error), resp.Header)
 	}
 
-	return mapOllamaError(resp.StatusCode, "unknown error")
+	return normalize.WithRetryAfter(mapOllamaError(resp.StatusCode, "unknown error"), resp.Header)
 }
 
 // mapOllamaError converts an Ollama error to a core.ProviderError.

--- a/providers/openai/client.go
+++ b/providers/openai/client.go
@@ -56,7 +56,7 @@ func (p *OpenAI) doChat(ctx context.Context, req *core.ChatRequest) (*core.ChatR
 
 	// Check for error status
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Parse response

--- a/providers/openai/client_embeddings.go
+++ b/providers/openai/client_embeddings.go
@@ -60,7 +60,7 @@ func (p *OpenAI) CreateEmbeddings(ctx context.Context, req *core.EmbeddingReques
 	requestID := resp.Header.Get("x-request-id")
 
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	var oaiResp openAIEmbeddingResponse

--- a/providers/openai/client_responses.go
+++ b/providers/openai/client_responses.go
@@ -56,7 +56,7 @@ func (p *OpenAI) doResponsesChat(ctx context.Context, req *core.ChatRequest) (*c
 
 	// Check for error status
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Parse response

--- a/providers/openai/errors.go
+++ b/providers/openai/errors.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/petal-labs/iris/providers/internal/normalize"
 )
@@ -20,8 +21,10 @@ type openAIErrorResponse struct {
 }
 
 // normalizeError converts an HTTP error response to a ProviderError with the appropriate sentinel.
-func normalizeError(status int, body []byte, requestID string) error {
-	return normalize.OpenAIStyleProviderError("openai", status, body, requestID)
+func normalizeError(status int, body []byte, requestID string, headers ...http.Header) error {
+	return normalize.WithRetryAfter(
+		normalize.OpenAIStyleProviderError("openai", status, body, requestID), headers...,
+	)
 }
 
 // newNetworkError creates a ProviderError for network-related failures.

--- a/providers/openai/errors_test.go
+++ b/providers/openai/errors_test.go
@@ -2,7 +2,9 @@ package openai
 
 import (
 	"errors"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/petal-labs/iris/core"
 )
@@ -66,6 +68,20 @@ func TestNormalizeError429(t *testing.T) {
 
 	if pErr.RequestID != "req-456" {
 		t.Errorf("RequestID = %q, want %q", pErr.RequestID, "req-456")
+	}
+}
+
+func TestNormalizeError429CapturesRetryAfter(t *testing.T) {
+	err := normalizeError(429, []byte(`{"error":{"message":"Rate limit exceeded"}}`), "req-456", http.Header{
+		"Retry-After": []string{"30"},
+	})
+
+	var providerErr *core.ProviderError
+	if !errors.As(err, &providerErr) {
+		t.Fatal("expected ProviderError")
+	}
+	if providerErr.RetryAfter != 30*time.Second {
+		t.Fatalf("RetryAfter = %v, want 30s", providerErr.RetryAfter)
 	}
 }
 

--- a/providers/openai/streaming.go
+++ b/providers/openai/streaming.go
@@ -118,7 +118,7 @@ func (p *OpenAI) doStreamChat(ctx context.Context, req *core.ChatRequest) (*core
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()
 		respBody, _ := io.ReadAll(resp.Body)
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Create channels

--- a/providers/openai/streaming_responses.go
+++ b/providers/openai/streaming_responses.go
@@ -52,7 +52,7 @@ func (p *OpenAI) doResponsesStreamChat(ctx context.Context, req *core.ChatReques
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()
 		respBody, _ := io.ReadAll(resp.Body)
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Create channels

--- a/providers/perplexity/client.go
+++ b/providers/perplexity/client.go
@@ -56,7 +56,7 @@ func (p *Perplexity) doChat(ctx context.Context, req *core.ChatRequest) (*core.C
 
 	// Check for error status
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Parse response

--- a/providers/perplexity/errors.go
+++ b/providers/perplexity/errors.go
@@ -2,6 +2,7 @@ package perplexity
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/petal-labs/iris/providers/internal/normalize"
 )
@@ -10,8 +11,10 @@ import (
 var ErrToolArgsInvalidJSON = errors.New("tool args invalid json")
 
 // normalizeError converts an HTTP error response to a ProviderError with the appropriate sentinel.
-func normalizeError(status int, body []byte, requestID string) error {
-	return normalize.OpenAIStyleProviderError("perplexity", status, body, requestID)
+func normalizeError(status int, body []byte, requestID string, headers ...http.Header) error {
+	return normalize.WithRetryAfter(
+		normalize.OpenAIStyleProviderError("perplexity", status, body, requestID), headers...,
+	)
 }
 
 // newNetworkError creates a ProviderError for network-related failures.

--- a/providers/perplexity/streaming.go
+++ b/providers/perplexity/streaming.go
@@ -85,7 +85,7 @@ func (p *Perplexity) doStreamChat(ctx context.Context, req *core.ChatRequest) (*
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()
 		respBody, _ := io.ReadAll(resp.Body)
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Create channels

--- a/providers/voyageai/client_contextualized.go
+++ b/providers/voyageai/client_contextualized.go
@@ -57,7 +57,7 @@ func (p *VoyageAI) CreateContextualizedEmbeddings(ctx context.Context, req *core
 	requestID := resp.Header.Get("x-request-id")
 
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	var voyageResp voyageContextualizedResponse

--- a/providers/voyageai/client_embeddings.go
+++ b/providers/voyageai/client_embeddings.go
@@ -57,7 +57,7 @@ func (p *VoyageAI) CreateEmbeddings(ctx context.Context, req *core.EmbeddingRequ
 	requestID := resp.Header.Get("x-request-id")
 
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	var voyageResp voyageEmbeddingResponse

--- a/providers/voyageai/client_rerank.go
+++ b/providers/voyageai/client_rerank.go
@@ -57,7 +57,7 @@ func (p *VoyageAI) Rerank(ctx context.Context, req *core.RerankRequest) (*core.R
 	requestID := resp.Header.Get("x-request-id")
 
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	var voyageResp voyageRerankResponse

--- a/providers/voyageai/errors.go
+++ b/providers/voyageai/errors.go
@@ -29,7 +29,7 @@ type voyageErrorResponse struct {
 }
 
 // normalizeError converts an HTTP error response to a ProviderError with the appropriate sentinel.
-func normalizeError(status int, body []byte, requestID string) error {
+func normalizeError(status int, body []byte, requestID string, headers ...http.Header) error {
 	// Parse error response if possible
 	var errResp voyageErrorResponse
 	_ = json.Unmarshal(body, &errResp)
@@ -46,7 +46,7 @@ func normalizeError(status int, body []byte, requestID string) error {
 
 	pe := normalize.ProviderError("voyageai", status, requestID, "", message, normalize.SentinelForStatus(status))
 	pe.(*core.ProviderError).Body = bodyStr
-	return pe
+	return normalize.WithRetryAfter(pe, headers...)
 }
 
 // newNetworkError creates a ProviderError for network-related failures.

--- a/providers/xai/client.go
+++ b/providers/xai/client.go
@@ -56,7 +56,7 @@ func (p *Xai) doChat(ctx context.Context, req *core.ChatRequest) (*core.ChatResp
 
 	// Check for error status
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Parse response

--- a/providers/xai/errors.go
+++ b/providers/xai/errors.go
@@ -2,6 +2,7 @@ package xai
 
 import (
 	"errors"
+	"net/http"
 
 	"github.com/petal-labs/iris/providers/internal/normalize"
 )
@@ -10,8 +11,10 @@ import (
 var ErrToolArgsInvalidJSON = errors.New("tool args invalid json")
 
 // normalizeError converts an HTTP error response to a ProviderError with the appropriate sentinel.
-func normalizeError(status int, body []byte, requestID string) error {
-	return normalize.OpenAIStyleProviderError("xai", status, body, requestID)
+func normalizeError(status int, body []byte, requestID string, headers ...http.Header) error {
+	return normalize.WithRetryAfter(
+		normalize.OpenAIStyleProviderError("xai", status, body, requestID), headers...,
+	)
 }
 
 // newNetworkError creates a ProviderError for network-related failures.

--- a/providers/xai/streaming.go
+++ b/providers/xai/streaming.go
@@ -85,7 +85,7 @@ func (p *Xai) doStreamChat(ctx context.Context, req *core.ChatRequest) (*core.Ch
 	if resp.StatusCode >= 400 {
 		defer resp.Body.Close()
 		respBody, _ := io.ReadAll(resp.Body)
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Create channels

--- a/providers/zai/client.go
+++ b/providers/zai/client.go
@@ -60,7 +60,7 @@ func (p *Zai) doChat(ctx context.Context, req *core.ChatRequest) (*core.ChatResp
 
 	// Check for error status
 	if resp.StatusCode >= 400 {
-		return nil, normalizeError(resp.StatusCode, respBody, requestID)
+		return nil, normalizeError(resp.StatusCode, respBody, requestID, resp.Header)
 	}
 
 	// Parse response

--- a/providers/zai/errors.go
+++ b/providers/zai/errors.go
@@ -36,7 +36,7 @@ type zaiErrorResponse struct {
 }
 
 // normalizeError converts an HTTP error response to a ProviderError with the appropriate sentinel.
-func normalizeError(status int, body []byte, requestID string) error {
+func normalizeError(status int, body []byte, requestID string, headers ...http.Header) error {
 	// Parse error response if possible
 	var errResp zaiErrorResponse
 	_ = json.Unmarshal(body, &errResp)
@@ -55,7 +55,7 @@ func normalizeError(status int, body []byte, requestID string) error {
 
 	pe := normalize.ProviderError("zai", status, requestID, code, message, normalize.SentinelForStatus(status))
 	pe.(*core.ProviderError).Body = bodyStr
-	return pe
+	return normalize.WithRetryAfter(pe, headers...)
 }
 
 // newNetworkError creates a ProviderError for network-related failures.

--- a/providers/zai/streaming.go
+++ b/providers/zai/streaming.go
@@ -89,7 +89,7 @@ func (p *Zai) doStreamChat(ctx context.Context, req *core.ChatRequest) (*core.Ch
 		}
 		_ = json.Unmarshal(respBody, &tempResp)
 
-		return nil, normalizeError(resp.StatusCode, respBody, tempResp.RequestID)
+		return nil, normalizeError(resp.StatusCode, respBody, tempResp.RequestID, resp.Header)
 	}
 
 	// Create channels


### PR DESCRIPTION
Closes #69

## Summary
- Honor provider Retry-After hints as minimum retry delays.
- Retry stream setup failures with the configured retry policy.
- Add core.WithRateLimiter with a concurrency-safe interval limiter.
- Preserve Retry-After metadata through provider error normalization.

## Verification
- go test ./...
- go test -race ./...
- core coverage: 90.8%
- shared normalization coverage: 94.0%

## Deferred
- Mid-stream reconnection, HTTP middleware interception, and fallback/router providers remain out of scope as documented.