### PR TITLE
[codex] add token counting and dynamic Ollama models

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Iris solves these problems by providing:
 
 ### SDK Features
 - Fluent chat builder with `System()`, `User()`, `Assistant()`, `Temperature()`, `MaxTokens()`, and `Tools()`
+- Native token counting for Anthropic and Gemini through `core.TokenCounter`
 - Non-streaming and streaming response modes
 - Tool/function calling support
 - Tool middleware stack for logging, timeout, rate limiting, cache, validation, retry, and circuit breaking

--- a/core/capability_helpers_test.go
+++ b/core/capability_helpers_test.go
@@ -55,6 +55,12 @@ func (*contentPartCapableProvider) SupportsContentPart(ModelID, Role, ContentPar
 	return true
 }
 
+type tokenCountingCapableProvider struct{ *capabilityBaseProvider }
+
+func (*tokenCountingCapableProvider) CountTokens(context.Context, *ChatRequest) (*TokenCountResponse, error) {
+	return &TokenCountResponse{InputTokens: 42}, nil
+}
+
 func TestAsEmbeddingProvider(t *testing.T) {
 	provider := &embeddingCapableProvider{capabilityBaseProvider: &capabilityBaseProvider{id: "embedding"}}
 	got, ok := AsEmbeddingProvider(provider)
@@ -117,5 +123,18 @@ func TestAsContentPartSupporter(t *testing.T) {
 	got, ok = AsContentPartSupporter(&capabilityBaseProvider{id: "base"})
 	if ok || got != nil {
 		t.Fatalf("AsContentPartSupporter(non-capable) = (%v, %v), want nil, false", got, ok)
+	}
+}
+
+func TestAsTokenCounter(t *testing.T) {
+	provider := &tokenCountingCapableProvider{capabilityBaseProvider: &capabilityBaseProvider{id: "token-counter"}}
+	got, ok := AsTokenCounter(provider)
+	if !ok || got != provider {
+		t.Fatalf("AsTokenCounter() = (%v, %v), want provider, true", got, ok)
+	}
+
+	got, ok = AsTokenCounter(&capabilityBaseProvider{id: "base"})
+	if ok || got != nil {
+		t.Fatalf("AsTokenCounter(non-capable) = (%v, %v), want nil, false", got, ok)
 	}
 }

--- a/core/doc.go
+++ b/core/doc.go
@@ -108,6 +108,7 @@
 //   - [FeatureReasoning]: Extended reasoning capabilities
 //   - [FeatureBuiltInTools]: Web search, file search, code interpreter
 //   - [FeatureResponseChain]: Multi-turn response chaining
+//   - [FeatureTokenCounting]: Native input-token counting
 //   - [FeatureEmbeddings]: Text embedding generation
 //   - [FeatureContextualizedEmbeddings]: Document-aware embeddings
 //   - [FeatureReranking]: Search result reranking

--- a/core/token_counting.go
+++ b/core/token_counting.go
@@ -1,0 +1,24 @@
+package core
+
+import "context"
+
+// TokenCountResponse contains the number of input tokens a provider would
+// process for a chat request.
+type TokenCountResponse struct {
+	InputTokens int `json:"input_tokens"`
+}
+
+// TokenCounter is an optional interface for providers with a native token
+// counting endpoint. The request should be the same ChatRequest that will be
+// sent for generation so system messages, multimodal parts, and tools can be
+// included in the provider's count.
+type TokenCounter interface {
+	CountTokens(ctx context.Context, req *ChatRequest) (*TokenCountResponse, error)
+}
+
+// AsTokenCounter attempts to cast a Provider to TokenCounter. It returns nil
+// and false when the provider does not implement native token counting.
+func AsTokenCounter(p Provider) (TokenCounter, bool) {
+	counter, ok := p.(TokenCounter)
+	return counter, ok
+}

--- a/core/types.go
+++ b/core/types.go
@@ -13,6 +13,7 @@ const (
 	FeatureReasoning                Feature = "reasoning"
 	FeatureBuiltInTools             Feature = "builtin_tools"
 	FeatureResponseChain            Feature = "response_chain"
+	FeatureTokenCounting            Feature = "token_counting"
 	FeatureEmbeddings               Feature = "embeddings"
 	FeatureContextualizedEmbeddings Feature = "contextualized_embeddings"
 	FeatureReranking                Feature = "reranking"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,6 +113,7 @@ current optional interfaces and built-in implementers are:
 | `EmbeddingProvider` | `AsEmbeddingProvider` | `FeatureEmbeddings` | Azure AI Foundry, Gemini, Ollama, OpenAI, Voyage AI |
 | `ContextualizedEmbeddingProvider` | `AsContextualizedEmbeddingProvider` | `FeatureContextualizedEmbeddings` | Voyage AI |
 | `RerankerProvider` | `AsReranker` | `FeatureReranking` | Voyage AI |
+| `TokenCounter` | `AsTokenCounter` | `FeatureTokenCounting` | Anthropic, Gemini |
 | `ImageGenerator` | `AsImageGenerator` | `FeatureImageGeneration` | Gemini, OpenAI |
 | `ContentPartSupporter` | `AsContentPartSupporter` | Per-content-part declaration | Anthropic, Azure AI Foundry, Gemini, OpenAI |
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -1,24 +1,25 @@
 # Provider Comparison
 
 This document provides a comprehensive comparison of the AI providers supported by Iris.
-Model catalogs mirror each provider's `Models()` implementation in `providers/<name>/models.go`.
+Static model catalogs mirror each provider's `Models()` implementation in `providers/<name>/models.go`.
+Ollama is the exception: its catalog is discovered from the configured instance at runtime.
 
 ## Feature Support Matrix
 
 Cells reflect each provider's `Supports()` implementation. For chat-based features, availability can also vary by model — see the model-specific tables below.
 
-| Provider | Chat | Streaming | Tool Calling | Reasoning | Built-in Tools | Response Chain | Structured Output | Embeddings | Reranking | Images |
-|----------|------|-----------|--------------|-----------|----------------|----------------|--------------------|------------|-----------|--------|
-| OpenAI | Yes | Yes | Yes | Yes* | Yes* | Yes* | Yes | Yes | No | Yes |
-| Anthropic | Yes | Yes | Yes | Yes | No | No | No† | No | No | No |
-| Gemini | Yes | Yes | Yes | Yes | No | No | Yes | Yes | No | Yes |
-| xAI (Grok) | Yes | Yes | Yes | Yes | No | No | No† | No | No | No |
-| Perplexity | Yes | Yes | Yes | Yes | No | No | No† | No | No | No |
-| Z.ai (GLM) | Yes | Yes | Yes | Yes | No | No | No† | No | No | No |
-| Ollama | Yes | Yes | Yes | Yes | No | No | No† | Yes | No | No |
-| HuggingFace | Yes | Yes | Yes | No | No | No | No† | No | No | No |
-| Azure AI Foundry | Yes | Yes | Yes | Yes | No | No | Yes | Yes | No | No |
-| VoyageAI | No | No | No | No | No | No | N/A | Yes | Yes | No |
+| Provider | Chat | Streaming | Tool Calling | Reasoning | Built-in Tools | Response Chain | Token Counting | Structured Output | Embeddings | Reranking | Images |
+|----------|------|-----------|--------------|-----------|----------------|----------------|----------------|--------------------|------------|-----------|--------|
+| OpenAI | Yes | Yes | Yes | Yes* | Yes* | Yes* | No | Yes | Yes | No | Yes |
+| Anthropic | Yes | Yes | Yes | Yes | No | No | Yes | No† | No | No | No |
+| Gemini | Yes | Yes | Yes | Yes | No | No | Yes | Yes | Yes | No | Yes |
+| xAI (Grok) | Yes | Yes | Yes | Yes | No | No | No | No† | No | No | No |
+| Perplexity | Yes | Yes | Yes | Yes | No | No | No | No† | No | No | No |
+| Z.ai (GLM) | Yes | Yes | Yes | Yes | No | No | No | No† | No | No | No |
+| Ollama | Yes | Yes | Yes | Yes | No | No | No | No† | Yes | No | No |
+| HuggingFace | Yes | Yes | Yes | No | No | No | No | No† | No | No | No |
+| Azure AI Foundry | Yes | Yes | Yes | Yes | No | No | No | Yes | Yes | No | No |
+| VoyageAI | No | No | No | No | No | No | No | N/A | Yes | Yes | No |
 
 Perplexity additionally supports web-search grounding (`core.SearchOptions`, response citations) via `core.FeatureWebSearch`.
 
@@ -31,8 +32,8 @@ Perplexity additionally supports web-search grounding (`core.SearchOptions`, res
 | Provider | Status | Features |
 |----------|--------|----------|
 | OpenAI | Supported | Chat, Streaming, Tools, Reasoning, Batch API, Structured Output, Embeddings, Images, Responses API (GPT-5+) |
-| Anthropic | Supported | Chat, Streaming, Tools, Reasoning |
-| Google Gemini | Supported | Chat, Streaming, Tools, Reasoning, Structured Output, Embeddings, Images |
+| Anthropic | Supported | Chat, Streaming, Tools, Reasoning, Token Counting |
+| Google Gemini | Supported | Chat, Streaming, Tools, Reasoning, Token Counting, Structured Output, Embeddings, Images |
 | xAI Grok | Supported | Chat, Streaming, Tools, Reasoning |
 | Z.ai GLM | Supported | Chat, Streaming, Tools, Thinking |
 | Perplexity | Supported | Chat, Streaming, Tools, Reasoning, Web Search + Citations |
@@ -155,6 +156,7 @@ resp, err := client.Chat(openai.ModelGPT4o).
 - Built-in safety guardrails
 - Thinking/reasoning modes
 - Vision input via hosted image URLs or base64 data URLs
+- Native input-token counting through `POST /v1/messages/count_tokens`
 
 **Usage Example**:
 ```go
@@ -165,6 +167,13 @@ resp, err := client.Chat(anthropic.ModelClaudeSonnet46).
     System("You are a helpful assistant.").
     User("Explain quantum computing.").
     GetResponse(ctx)
+
+counter, _ := core.AsTokenCounter(provider)
+count, err := counter.CountTokens(ctx, &core.ChatRequest{
+    Model: anthropic.ModelClaudeSonnet46,
+    Messages: []core.Message{{Role: core.RoleUser, Content: "Explain quantum computing."}},
+})
+fmt.Println(count.InputTokens)
 ```
 
 ---
@@ -207,6 +216,7 @@ resp, err := client.Chat(anthropic.ModelClaudeSonnet46).
 - Long context windows
 - Grounding with Google Search
 - Batch text embeddings with query/document retrieval optimization
+- Native input-token counting through `POST /v1beta/models/{model}:countTokens`
 
 **Usage Example**:
 ```go
@@ -370,8 +380,15 @@ resp, err := client.Chat(zai.ModelGLM47).
 
 **Authentication**: No key required for local; API key for Ollama Cloud
 
-**Models**: Dynamic — any model you have pulled locally with `ollama pull <model>`.
-The models below ship in the built-in catalog; see
+**Models**: Dynamic — `Models()` queries `GET /api/tags` on the configured
+instance and returns the installed model IDs. Use `ListModels(ctx)` when the
+caller needs an explicit discovery error. Because the upstream endpoint does
+not report per-model capabilities, dynamically discovered `ModelInfo` entries
+leave `Capabilities` empty.
+
+If discovery fails, `Models()` returns the illustrative fallback catalog below
+after a maximum two-second discovery attempt. A successful empty response stays
+empty and does not activate the fallback. See
 [ollama.com/library](https://ollama.com/library) for everything else.
 
 | Model | Display Name | Reasoning | Tool Calling |
@@ -404,6 +421,8 @@ provider := ollama.New(
     ollama.WithCloud(),
     ollama.WithAPIKey(os.Getenv("OLLAMA_API_KEY")),
 )
+
+models, err := provider.ListModels(ctx) // explicit /api/tags discovery
 
 client := core.NewClient(provider)
 resp, err := client.Chat("llama3.2").

--- a/docs/changes/2026-08-28_v0.0.0-dev_issue-70-token-counting-ollama-models.md
+++ b/docs/changes/2026-08-28_v0.0.0-dev_issue-70-token-counting-ollama-models.md
@@ -1,0 +1,117 @@
+---
+date: 2026-08-28
+version: v0.0.0-dev
+feature: Native token counting and dynamic Ollama model discovery
+product: iris
+change_type: api
+affected_components: [core/token_counting.go, core/types.go, providers/anthropic/token_counting.go, providers/anthropic/provider.go, providers/gemini/token_counting.go, providers/gemini/provider.go, providers/ollama/models.go, providers/ollama/provider.go, docs/PROVIDERS.md, docs/ARCHITECTURE.md]
+related_frds: []
+---
+
+## Summary
+
+Issue #70 adds a provider-neutral optional token-counting contract with native Anthropic and Gemini implementations. Ollama model discovery now reads the configured instance's `/api/tags` endpoint, while preserving the former eight-entry catalog only as a bounded offline fallback. Audio APIs remain explicitly deferred to a post-1.0 design.
+
+## Motivation
+
+Iris previously exposed token usage only after generation, which prevented callers from measuring a conversation before deciding whether to trim it. Ollama also returned eight hardcoded examples regardless of what was installed locally. These gaps made context-window management and model selection less reliable than the underlying providers allowed.
+
+## What Changed
+
+### New Additions
+
+- `core.TokenCounter` — optional interface accepting the same `core.ChatRequest` intended for generation.
+- `core.TokenCountResponse` — provider-neutral input-token result.
+- `core.AsTokenCounter` and `core.FeatureTokenCounting` — operation and capability discovery.
+- Anthropic `CountTokens` through `POST /v1/messages/count_tokens`.
+- Gemini `CountTokens` through `POST /v1beta/models/{model}:countTokens` with a nested `generateContentRequest`, preserving the required `models/{model}` resource name, system instructions, and function declarations.
+- Ollama `ListModels(ctx)` — context-aware, error-returning discovery through `GET /api/tags`.
+
+### Modifications
+
+- Anthropic and Gemini now report `FeatureTokenCounting` from `Supports`.
+- Ollama `Models()` performs live discovery with a maximum two-second bound. It returns the live empty catalog when no models are installed and falls back to the former illustrative list only when discovery fails.
+- Provider and architecture documentation now describes token counting, Ollama discovery behavior, and the fallback semantics.
+
+### Removals
+
+None. The former Ollama catalog remains available as an offline fallback.
+
+## Technical Specification
+
+### Go Package API
+
+```go
+type TokenCountResponse struct {
+    InputTokens int `json:"input_tokens"`
+}
+
+type TokenCounter interface {
+    CountTokens(context.Context, *ChatRequest) (*TokenCountResponse, error)
+}
+
+func AsTokenCounter(Provider) (TokenCounter, bool)
+
+func (p *ollama.Ollama) ListModels(context.Context) ([]core.ModelInfo, error)
+```
+
+Token counting validates credentials, context, request, model, and message presence before sending HTTP. Both provider implementations use the existing normalized error mapping and direct-operation timeout. Gemini model IDs are restricted to the safe model-name character set before interpolation into the URL path.
+
+Ollama's tags response supplies model identity and storage metadata but no capability declaration. Iris therefore maps the model ID and display name while intentionally leaving dynamic `Capabilities` empty rather than inventing model-specific support.
+
+### API Endpoints
+
+- Anthropic: `POST /v1/messages/count_tokens`; maps `input_tokens` to `TokenCountResponse.InputTokens`.
+- Gemini: `POST /v1beta/models/{model}:countTokens`; maps `totalTokens` to `TokenCountResponse.InputTokens`.
+- Ollama: `GET /api/tags`; maps each non-empty `name` (or legacy `model` fallback) to `core.ModelInfo`.
+
+## Usage Examples
+
+```go
+provider := anthropic.New(os.Getenv("ANTHROPIC_API_KEY"))
+counter, ok := core.AsTokenCounter(provider)
+if !ok {
+    return core.ErrNotSupported
+}
+
+count, err := counter.CountTokens(ctx, &core.ChatRequest{
+    Model: anthropic.ModelClaudeSonnet46,
+    Messages: []core.Message{
+        {Role: core.RoleSystem, Content: "Be concise."},
+        {Role: core.RoleUser, Content: "Summarize this report."},
+    },
+})
+if err != nil {
+    return err
+}
+fmt.Println(count.InputTokens)
+```
+
+```go
+provider := ollama.NewLocal()
+models, err := provider.ListModels(ctx)
+if err != nil {
+    return err
+}
+for _, model := range models {
+    fmt.Println(model.ID)
+}
+```
+
+## Integration Notes
+
+`TokenCounter` is optional and does not expand the required `core.Provider` interface, so third-party providers remain source-compatible. Callers that already hold a `ChatRequest` can pass it directly without maintaining a second request representation. `Models()` remains compatible with registry and UI code that cannot handle errors; consumers that need to distinguish an empty installation from an unreachable server should call `ListModels(ctx)`.
+
+## Breaking Changes & Migration
+
+None at the type level. Ollama `Models()` is behaviorally more accurate: when the configured instance is reachable it now returns installed models instead of the illustrative list. Code that specifically relied on those examples should use explicit model IDs or account for the documented offline fallback.
+
+## Deferred / Out of Scope
+
+- Audio transcription, speech synthesis, and audio message parts are deferred until after 1.0. They need separate binary-input/output and streaming lifecycle contracts; adding provider-specific methods now would prematurely lock the core API.
+- A heuristic tokenizer fallback is deferred. Character-based estimates are unreliable across provider tokenizers and especially misleading for images, documents, and tool schemas. Providers without a native endpoint continue to report no `FeatureTokenCounting` support.
+- Ollama capability inference is out of scope because `/api/tags` does not expose per-model operation support.
+
+## Testing Notes
+
+Tests cover optional-interface discovery, request mapping of system messages and tools, authentication and input validation, normalized rate-limit errors, malformed responses, provider timeouts, successful/empty Ollama catalogs, and the offline illustrative fallback. The documentation matrix test now enforces token-counting capability declarations for every built-in provider.

--- a/providers/anthropic/options.go
+++ b/providers/anthropic/options.go
@@ -26,7 +26,7 @@ type Config struct {
 	Headers http.Header
 
 	// Timeout sets the timeout for this provider's direct (non-chat)
-	// operations — embeddings, files, images, batch, and vector stores.
+	// operations — token counting, embeddings, files, images, batch, and vector stores.
 	// Chat and streaming honor core.WithTimeout and context deadlines.
 	Timeout time.Duration
 
@@ -85,7 +85,7 @@ func WithHeader(key, value string) Option {
 }
 
 // WithTimeout sets the timeout for this provider's direct (non-chat)
-// operations — embeddings, files, images, batch, and vector stores. Chat and
+// operations — token counting, embeddings, files, images, batch, and vector stores. Chat and
 // streaming honor core.WithTimeout and context deadlines.
 func WithTimeout(d time.Duration) Option {
 	return func(c *Config) {

--- a/providers/anthropic/provider.go
+++ b/providers/anthropic/provider.go
@@ -75,7 +75,7 @@ func (p *Anthropic) Models() []core.ModelInfo {
 // Supports reports whether the provider supports the given feature.
 func (p *Anthropic) Supports(feature core.Feature) bool {
 	switch feature {
-	case core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling, core.FeatureReasoning:
+	case core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling, core.FeatureReasoning, core.FeatureTokenCounting:
 		return true
 	default:
 		return false

--- a/providers/anthropic/token_counting.go
+++ b/providers/anthropic/token_counting.go
@@ -1,0 +1,123 @@
+package anthropic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
+	"github.com/petal-labs/iris/providers/internal/timeoutx"
+)
+
+const (
+	messagesTokenCountPath     = "/v1/messages/count_tokens"
+	maxTokenCountResponseBytes = 1 << 20
+)
+
+type anthropicTokenCountRequest struct {
+	Model    string             `json:"model"`
+	Messages []anthropicMessage `json:"messages"`
+	System   string             `json:"system,omitempty"`
+	Tools    []anthropicTool    `json:"tools,omitempty"`
+}
+
+type anthropicTokenCountResponse struct {
+	InputTokens *int `json:"input_tokens"`
+}
+
+// CountTokens returns Anthropic's input-token count for a chat request without
+// creating a message.
+func (p *Anthropic) CountTokens(ctx context.Context, req *core.ChatRequest) (*core.TokenCountResponse, error) {
+	if err := normalize.RequireAPIKey("anthropic", p.config.APIKey); err != nil {
+		return nil, err
+	}
+	antReq, err := buildTokenCountRequest(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := timeoutx.Apply(ctx, p.config.Timeout)
+	defer cancel()
+
+	body, err := json.Marshal(antReq)
+	if err != nil {
+		return nil, newDecodeError(err)
+	}
+	return p.sendTokenCountRequest(ctx, body)
+}
+
+func (p *Anthropic) sendTokenCountRequest(ctx context.Context, body []byte) (*core.TokenCountResponse, error) {
+	endpoint := strings.TrimRight(p.config.BaseURL, "/") + messagesTokenCountPath
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+	for key, values := range p.buildHeaders() {
+		for _, value := range values {
+			httpReq.Header.Add(key, value)
+		}
+	}
+
+	resp, err := p.config.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxTokenCountResponseBytes+1))
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+	if len(respBody) > maxTokenCountResponseBytes {
+		return nil, newDecodeError(fmt.Errorf("token count response exceeds %d bytes", maxTokenCountResponseBytes))
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, normalizeError(resp.StatusCode, respBody, resp.Header.Get("request-id"), resp.Header)
+	}
+	return decodeTokenCountResponse(respBody)
+}
+
+func decodeTokenCountResponse(body []byte) (*core.TokenCountResponse, error) {
+	var antResp anthropicTokenCountResponse
+	if err := json.Unmarshal(body, &antResp); err != nil {
+		return nil, newDecodeError(err)
+	}
+	if antResp.InputTokens == nil || *antResp.InputTokens < 0 {
+		return nil, newDecodeError(fmt.Errorf("invalid input_tokens in response"))
+	}
+	return &core.TokenCountResponse{InputTokens: *antResp.InputTokens}, nil
+}
+
+func buildTokenCountRequest(ctx context.Context, req *core.ChatRequest) (*anthropicTokenCountRequest, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("anthropic: token counting context cannot be nil")
+	}
+	if req == nil {
+		return nil, fmt.Errorf("anthropic: token counting request cannot be nil")
+	}
+	if strings.TrimSpace(string(req.Model)) == "" {
+		return nil, fmt.Errorf("anthropic: token counting model cannot be empty")
+	}
+
+	system, messages := mapMessages(req.Messages)
+	if len(messages) == 0 {
+		return nil, fmt.Errorf("anthropic: token counting messages cannot be empty")
+	}
+
+	request := &anthropicTokenCountRequest{
+		Model:    string(req.Model),
+		Messages: messages,
+		System:   system,
+	}
+	if len(req.Tools) > 0 {
+		request.Tools = mapTools(req.Tools)
+	}
+	return request, nil
+}
+
+var _ core.TokenCounter = (*Anthropic)(nil)

--- a/providers/anthropic/token_counting_test.go
+++ b/providers/anthropic/token_counting_test.go
@@ -1,0 +1,172 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestCountTokens(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if r.URL.Path != "/v1/messages/count_tokens" {
+			t.Errorf("path = %q, want /v1/messages/count_tokens", r.URL.Path)
+		}
+		if r.Header.Get("x-api-key") != "test-key" {
+			t.Errorf("x-api-key = %q, want test-key", r.Header.Get("x-api-key"))
+		}
+		if r.Header.Get("anthropic-version") != DefaultVersion {
+			t.Errorf("anthropic-version = %q, want %q", r.Header.Get("anthropic-version"), DefaultVersion)
+		}
+
+		var body struct {
+			Model    string             `json:"model"`
+			System   string             `json:"system"`
+			Messages []anthropicMessage `json:"messages"`
+			Tools    []anthropicTool    `json:"tools"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if body.Model != string(ModelClaudeSonnet5) {
+			t.Errorf("model = %q, want %q", body.Model, ModelClaudeSonnet5)
+		}
+		if body.System != "Be concise." {
+			t.Errorf("system = %q, want Be concise.", body.System)
+		}
+		if len(body.Messages) != 1 || body.Messages[0].Role != "user" {
+			t.Errorf("messages = %#v, want one user message", body.Messages)
+		}
+		if len(body.Tools) != 1 || body.Tools[0].Name != "weather" {
+			t.Errorf("tools = %#v, want weather tool", body.Tools)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]int{"input_tokens": 37})
+	}))
+	defer server.Close()
+
+	provider := New("test-key", WithBaseURL(server.URL))
+	response, err := provider.CountTokens(context.Background(), tokenCountRequest(ModelClaudeSonnet5))
+	if err != nil {
+		t.Fatalf("CountTokens() error = %v", err)
+	}
+	if response.InputTokens != 37 {
+		t.Errorf("InputTokens = %d, want 37", response.InputTokens)
+	}
+}
+
+func TestCountTokensValidationAndAuth(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *Anthropic
+		ctx      context.Context
+		request  *core.ChatRequest
+		wantAuth bool
+	}{
+		{name: "empty API key", provider: New(""), ctx: context.Background(), request: tokenCountRequest(ModelClaudeSonnet5), wantAuth: true},
+		{name: "nil context", provider: New("test-key"), ctx: nil, request: tokenCountRequest(ModelClaudeSonnet5)},
+		{name: "nil request", provider: New("test-key"), ctx: context.Background(), request: nil},
+		{name: "missing model", provider: New("test-key"), ctx: context.Background(), request: tokenCountRequest("")},
+		{name: "missing messages", provider: New("test-key"), ctx: context.Background(), request: &core.ChatRequest{Model: ModelClaudeSonnet5}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//nolint:staticcheck // The nil-context case verifies public API validation.
+			_, err := tt.provider.CountTokens(tt.ctx, tt.request)
+			if err == nil {
+				t.Fatal("CountTokens() should reject invalid input")
+			}
+			if tt.wantAuth && !errors.Is(err, core.ErrUnauthorized) {
+				t.Errorf("error = %v, want ErrUnauthorized", err)
+			}
+		})
+	}
+}
+
+func TestCountTokensErrorsAndTimeout(t *testing.T) {
+	t.Run("HTTP error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTooManyRequests)
+			json.NewEncoder(w).Encode(map[string]any{
+				"type":  "error",
+				"error": map[string]string{"type": "rate_limit_error", "message": "slow down"},
+			})
+		}))
+		defer server.Close()
+
+		provider := New("test-key", WithBaseURL(server.URL))
+		_, err := provider.CountTokens(context.Background(), tokenCountRequest(ModelClaudeSonnet5))
+		if !errors.Is(err, core.ErrRateLimited) {
+			t.Fatalf("error = %v, want ErrRateLimited", err)
+		}
+	})
+
+	t.Run("malformed response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"input_tokens":`))
+		}))
+		defer server.Close()
+
+		provider := New("test-key", WithBaseURL(server.URL))
+		_, err := provider.CountTokens(context.Background(), tokenCountRequest(ModelClaudeSonnet5))
+		if !errors.Is(err, core.ErrDecode) {
+			t.Fatalf("error = %v, want ErrDecode", err)
+		}
+	})
+
+	t.Run("provider timeout", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		}))
+		t.Cleanup(func() { go server.Close() })
+
+		provider := New("test-key", WithBaseURL(server.URL), WithTimeout(20*time.Millisecond))
+		_, err := provider.CountTokens(context.Background(), tokenCountRequest(ModelClaudeSonnet5))
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("error = %v, want context.DeadlineExceeded", err)
+		}
+	})
+}
+
+func tokenCountRequest(model core.ModelID) *core.ChatRequest {
+	return &core.ChatRequest{
+		Model: model,
+		Messages: []core.Message{
+			{Role: core.RoleSystem, Content: "Be concise."},
+			{Role: core.RoleUser, Content: "What is the weather?"},
+		},
+		Tools: []core.Tool{tokenCountTool{}},
+	}
+}
+
+type tokenCountTool struct{}
+
+func (tokenCountTool) Name() string        { return "weather" }
+func (tokenCountTool) Description() string { return "Get the weather" }
+func (tokenCountTool) Schema() core.ToolSchema {
+	return core.ToolSchema{JSONSchema: json.RawMessage(`{"type":"object"}`)}
+}
+
+func TestCountTokensSupportsCapability(t *testing.T) {
+	provider := New("test-key")
+	if !provider.Supports(core.FeatureTokenCounting) {
+		t.Error("Anthropic should report token-counting support")
+	}
+	if _, ok := core.AsTokenCounter(provider); !ok {
+		t.Error("Anthropic should implement core.TokenCounter")
+	}
+	if got := strings.TrimSpace(string(core.FeatureTokenCounting)); got != "token_counting" {
+		t.Errorf("FeatureTokenCounting = %q, want token_counting", got)
+	}
+}

--- a/providers/gemini/options.go
+++ b/providers/gemini/options.go
@@ -23,7 +23,7 @@ type Config struct {
 	Headers http.Header
 
 	// Timeout sets the timeout for this provider's direct (non-chat)
-	// operations — embeddings, files, images, batch, and vector stores.
+	// operations — token counting, embeddings, files, images, batch, and vector stores.
 	// Chat and streaming honor core.WithTimeout and context deadlines.
 	Timeout time.Duration
 }
@@ -66,7 +66,7 @@ func WithHeader(key, value string) Option {
 }
 
 // WithTimeout sets the timeout for this provider's direct (non-chat)
-// operations — embeddings, files, images, batch, and vector stores. Chat and
+// operations — token counting, embeddings, files, images, batch, and vector stores. Chat and
 // streaming honor core.WithTimeout and context deadlines.
 func WithTimeout(d time.Duration) Option {
 	return func(c *Config) {

--- a/providers/gemini/provider.go
+++ b/providers/gemini/provider.go
@@ -80,7 +80,7 @@ func (p *Gemini) Models() []core.ModelInfo {
 func (p *Gemini) Supports(feature core.Feature) bool {
 	switch feature {
 	case core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling, core.FeatureReasoning,
-		core.FeatureImageGeneration, core.FeatureStructuredOutput, core.FeatureEmbeddings:
+		core.FeatureImageGeneration, core.FeatureStructuredOutput, core.FeatureEmbeddings, core.FeatureTokenCounting:
 		return true
 	default:
 		return false

--- a/providers/gemini/provider_test.go
+++ b/providers/gemini/provider_test.go
@@ -1,12 +1,48 @@
 package gemini
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/petal-labs/iris/core"
 )
+
+func TestNewFromEnv(t *testing.T) {
+	t.Run("missing keys", func(t *testing.T) {
+		t.Setenv(GeminiAPIKeyEnvVar, "")
+		t.Setenv(GoogleAPIKeyEnvVar, "")
+		provider, err := NewFromEnv()
+		if !errors.Is(err, ErrAPIKeyNotFound) || provider != nil {
+			t.Fatalf("NewFromEnv() = (%v, %v), want nil, ErrAPIKeyNotFound", provider, err)
+		}
+	})
+
+	t.Run("Google fallback", func(t *testing.T) {
+		t.Setenv(GeminiAPIKeyEnvVar, "")
+		t.Setenv(GoogleAPIKeyEnvVar, "google-key")
+		provider, err := NewFromEnv()
+		if err != nil {
+			t.Fatalf("NewFromEnv() error = %v", err)
+		}
+		if provider.config.APIKey.Expose() != "google-key" {
+			t.Error("NewFromEnv() did not use GOOGLE_API_KEY")
+		}
+	})
+
+	t.Run("Gemini key takes precedence", func(t *testing.T) {
+		t.Setenv(GeminiAPIKeyEnvVar, "gemini-key")
+		t.Setenv(GoogleAPIKeyEnvVar, "google-key")
+		provider, err := NewFromEnv()
+		if err != nil {
+			t.Fatalf("NewFromEnv() error = %v", err)
+		}
+		if provider.config.APIKey.Expose() != "gemini-key" {
+			t.Error("NewFromEnv() did not prefer GEMINI_API_KEY")
+		}
+	})
+}
 
 func TestNew(t *testing.T) {
 	p := New("test-key")

--- a/providers/gemini/token_counting.go
+++ b/providers/gemini/token_counting.go
@@ -1,0 +1,118 @@
+package gemini
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/normalize"
+	"github.com/petal-labs/iris/providers/internal/timeoutx"
+)
+
+const (
+	geminiTokenCountPathFormat = "%s/v1beta/models/%s:countTokens"
+	maxTokenCountResponseBytes = 1 << 20
+)
+
+var geminiTokenCountModelPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+
+type geminiTokenCountRequest struct {
+	GenerateContentRequest *geminiRequest `json:"generateContentRequest"`
+}
+
+type geminiTokenCountResponse struct {
+	TotalTokens *int `json:"totalTokens"`
+}
+
+// CountTokens returns Gemini's input-token count for a chat request without
+// generating content.
+func (p *Gemini) CountTokens(ctx context.Context, req *core.ChatRequest) (*core.TokenCountResponse, error) {
+	if err := normalize.RequireAPIKey("gemini", p.config.APIKey); err != nil {
+		return nil, err
+	}
+	if err := validateGeminiTokenCountRequest(ctx, req); err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := timeoutx.Apply(ctx, p.config.Timeout)
+	defer cancel()
+
+	body, err := json.Marshal(buildGeminiTokenCountRequest(req))
+	if err != nil {
+		return nil, newDecodeError(err)
+	}
+	return p.sendTokenCountRequest(ctx, req.Model, body)
+}
+
+func (p *Gemini) sendTokenCountRequest(ctx context.Context, model core.ModelID, body []byte) (*core.TokenCountResponse, error) {
+	endpoint := fmt.Sprintf(geminiTokenCountPathFormat, strings.TrimRight(p.config.BaseURL, "/"), model)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+	for key, values := range p.buildHeaders() {
+		for _, value := range values {
+			httpReq.Header.Add(key, value)
+		}
+	}
+
+	resp, err := p.config.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxTokenCountResponseBytes+1))
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+	if len(respBody) > maxTokenCountResponseBytes {
+		return nil, newDecodeError(fmt.Errorf("token count response exceeds %d bytes", maxTokenCountResponseBytes))
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, normalizeError(resp.StatusCode, respBody, resp.Header)
+	}
+	return decodeTokenCountResponse(respBody)
+}
+
+func decodeTokenCountResponse(body []byte) (*core.TokenCountResponse, error) {
+	var gemResp geminiTokenCountResponse
+	if err := json.Unmarshal(body, &gemResp); err != nil {
+		return nil, newDecodeError(err)
+	}
+	if gemResp.TotalTokens == nil || *gemResp.TotalTokens < 0 {
+		return nil, newDecodeError(fmt.Errorf("invalid totalTokens in response"))
+	}
+	return &core.TokenCountResponse{InputTokens: *gemResp.TotalTokens}, nil
+}
+
+func validateGeminiTokenCountRequest(ctx context.Context, req *core.ChatRequest) error {
+	if ctx == nil {
+		return fmt.Errorf("gemini: token counting context cannot be nil")
+	}
+	if req == nil {
+		return fmt.Errorf("gemini: token counting request cannot be nil")
+	}
+	if !geminiTokenCountModelPattern.MatchString(string(req.Model)) {
+		return fmt.Errorf("gemini: invalid token counting model %q", req.Model)
+	}
+	if len(req.Messages) == 0 {
+		return fmt.Errorf("gemini: token counting messages cannot be empty")
+	}
+	return nil
+}
+
+func buildGeminiTokenCountRequest(req *core.ChatRequest) *geminiTokenCountRequest {
+	generateRequest := buildRequest(req)
+	generateRequest.Model = "models/" + string(req.Model)
+	generateRequest.GenerationConfig = nil
+	return &geminiTokenCountRequest{GenerateContentRequest: generateRequest}
+}
+
+var _ core.TokenCounter = (*Gemini)(nil)

--- a/providers/gemini/token_counting_test.go
+++ b/providers/gemini/token_counting_test.go
@@ -1,0 +1,218 @@
+package gemini
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestCountTokens(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		wantPath := "/v1beta/models/" + string(ModelGemini35Flash) + ":countTokens"
+		if r.URL.Path != wantPath {
+			t.Errorf("path = %q, want %q", r.URL.Path, wantPath)
+		}
+		if r.Header.Get("x-goog-api-key") != "test-key" {
+			t.Errorf("x-goog-api-key = %q, want test-key", r.Header.Get("x-goog-api-key"))
+		}
+
+		var body struct {
+			GenerateContentRequest geminiRequest `json:"generateContentRequest"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		request := body.GenerateContentRequest
+		if request.Model != "models/"+string(ModelGemini35Flash) {
+			t.Errorf("nested model = %q, want models/%s", request.Model, ModelGemini35Flash)
+		}
+		if request.SystemInstruction == nil || request.SystemInstruction.Parts[0].Text != "Be concise." {
+			t.Errorf("system instruction = %#v, want Be concise.", request.SystemInstruction)
+		}
+		if len(request.Contents) != 1 || request.Contents[0].Role != "user" {
+			t.Errorf("contents = %#v, want one user content", request.Contents)
+		}
+		if len(request.Tools) != 1 || request.Tools[0].FunctionDeclarations[0].Name != "weather" {
+			t.Errorf("tools = %#v, want weather tool", request.Tools)
+		}
+		if request.GenerationConfig != nil {
+			t.Errorf("generationConfig = %#v, want omitted", request.GenerationConfig)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]int{"totalTokens": 29})
+	}))
+	defer server.Close()
+
+	provider := New("test-key", WithBaseURL(server.URL))
+	response, err := provider.CountTokens(context.Background(), validGeminiTokenCountRequest(ModelGemini35Flash))
+	if err != nil {
+		t.Fatalf("CountTokens() error = %v", err)
+	}
+	if response.InputTokens != 29 {
+		t.Errorf("InputTokens = %d, want 29", response.InputTokens)
+	}
+}
+
+func TestCountTokensValidatesInputAndAuth(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *Gemini
+		ctx      context.Context
+		request  *core.ChatRequest
+		wantAuth bool
+	}{
+		{name: "empty API key", provider: New(""), ctx: context.Background(), request: validGeminiTokenCountRequest(ModelGemini35Flash), wantAuth: true},
+		{name: "nil context", provider: New("test-key"), ctx: nil, request: validGeminiTokenCountRequest(ModelGemini35Flash)},
+		{name: "nil request", provider: New("test-key"), ctx: context.Background(), request: nil},
+		{name: "missing model", provider: New("test-key"), ctx: context.Background(), request: validGeminiTokenCountRequest("")},
+		{name: "unsafe model", provider: New("test-key"), ctx: context.Background(), request: validGeminiTokenCountRequest("../unsafe")},
+		{name: "missing messages", provider: New("test-key"), ctx: context.Background(), request: &core.ChatRequest{Model: ModelGemini35Flash}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			//nolint:staticcheck // The nil-context case verifies public API validation.
+			_, err := tt.provider.CountTokens(tt.ctx, tt.request)
+			if err == nil {
+				t.Fatal("CountTokens() should reject invalid input")
+			}
+			if tt.wantAuth && !errors.Is(err, core.ErrUnauthorized) {
+				t.Errorf("error = %v, want ErrUnauthorized", err)
+			}
+		})
+	}
+}
+
+func TestCountTokensErrorsAndTimeout(t *testing.T) {
+	t.Run("HTTP error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTooManyRequests)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"code": 429, "message": "quota exhausted", "status": "RESOURCE_EXHAUSTED"},
+			})
+		}))
+		defer server.Close()
+
+		provider := New("test-key", WithBaseURL(server.URL))
+		_, err := provider.CountTokens(context.Background(), validGeminiTokenCountRequest(ModelGemini35Flash))
+		if !errors.Is(err, core.ErrRateLimited) {
+			t.Fatalf("error = %v, want ErrRateLimited", err)
+		}
+	})
+
+	t.Run("malformed response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"totalTokens":`))
+		}))
+		defer server.Close()
+
+		provider := New("test-key", WithBaseURL(server.URL))
+		_, err := provider.CountTokens(context.Background(), validGeminiTokenCountRequest(ModelGemini35Flash))
+		if !errors.Is(err, core.ErrDecode) {
+			t.Fatalf("error = %v, want ErrDecode", err)
+		}
+	})
+
+	t.Run("missing token count", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{}`))
+		}))
+		defer server.Close()
+
+		provider := New("test-key", WithBaseURL(server.URL))
+		_, err := provider.CountTokens(context.Background(), validGeminiTokenCountRequest(ModelGemini35Flash))
+		if !errors.Is(err, core.ErrDecode) {
+			t.Fatalf("error = %v, want ErrDecode", err)
+		}
+	})
+
+	t.Run("oversized response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(strings.Repeat("x", maxTokenCountResponseBytes+1)))
+		}))
+		defer server.Close()
+
+		provider := New("test-key", WithBaseURL(server.URL))
+		_, err := provider.CountTokens(context.Background(), validGeminiTokenCountRequest(ModelGemini35Flash))
+		if !errors.Is(err, core.ErrDecode) {
+			t.Fatalf("error = %v, want ErrDecode", err)
+		}
+	})
+
+	t.Run("invalid base URL", func(t *testing.T) {
+		provider := New("test-key", WithBaseURL("://invalid"))
+		_, err := provider.CountTokens(context.Background(), validGeminiTokenCountRequest(ModelGemini35Flash))
+		if !errors.Is(err, core.ErrNetwork) {
+			t.Fatalf("error = %v, want ErrNetwork", err)
+		}
+	})
+
+	t.Run("invalid tool schema", func(t *testing.T) {
+		request := validGeminiTokenCountRequest(ModelGemini35Flash)
+		request.Tools = []core.Tool{invalidTokenCountTool{}}
+		provider := New("test-key")
+		_, err := provider.CountTokens(context.Background(), request)
+		if !errors.Is(err, core.ErrDecode) {
+			t.Fatalf("error = %v, want ErrDecode", err)
+		}
+	})
+
+	t.Run("provider timeout", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		}))
+		t.Cleanup(func() { go server.Close() })
+
+		provider := New("test-key", WithBaseURL(server.URL), WithTimeout(20*time.Millisecond))
+		_, err := provider.CountTokens(context.Background(), validGeminiTokenCountRequest(ModelGemini35Flash))
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("error = %v, want context.DeadlineExceeded", err)
+		}
+	})
+}
+
+func validGeminiTokenCountRequest(model core.ModelID) *core.ChatRequest {
+	return &core.ChatRequest{
+		Model: model,
+		Messages: []core.Message{
+			{Role: core.RoleSystem, Content: "Be concise."},
+			{Role: core.RoleUser, Content: "What is the weather?"},
+		},
+		Tools: []core.Tool{tokenCountTool{}},
+	}
+}
+
+type tokenCountTool struct{}
+
+func (tokenCountTool) Name() string        { return "weather" }
+func (tokenCountTool) Description() string { return "Get the weather" }
+func (tokenCountTool) Schema() core.ToolSchema {
+	return core.ToolSchema{JSONSchema: json.RawMessage(`{"type":"object"}`)}
+}
+
+type invalidTokenCountTool struct{ tokenCountTool }
+
+func (invalidTokenCountTool) Schema() core.ToolSchema {
+	return core.ToolSchema{JSONSchema: json.RawMessage(`[`)}
+}
+
+func TestCountTokensSupportsCapability(t *testing.T) {
+	provider := New("test-key")
+	if !provider.Supports(core.FeatureTokenCounting) {
+		t.Error("Gemini should report token-counting support")
+	}
+	if _, ok := core.AsTokenCounter(provider); !ok {
+		t.Error("Gemini should implement core.TokenCounter")
+	}
+}

--- a/providers/gemini/types_gemini.go
+++ b/providers/gemini/types_gemini.go
@@ -5,6 +5,7 @@ import "encoding/json"
 
 // geminiRequest represents a request to the Gemini generateContent API.
 type geminiRequest struct {
+	Model             string           `json:"model,omitempty"`
 	Contents          []geminiContent  `json:"contents"`
 	SystemInstruction *geminiContent   `json:"system_instruction,omitempty"`
 	GenerationConfig  *geminiGenConfig `json:"generationConfig,omitempty"`

--- a/providers/ollama/doc.go
+++ b/providers/ollama/doc.go
@@ -42,7 +42,10 @@
 // # Models
 //
 // Unlike other providers, Ollama models are dynamic - you can use any model
-// that you have pulled locally. Common models include:
+// that you have pulled locally. Models queries the configured instance's
+// /api/tags endpoint and uses a short, illustrative catalog only when discovery
+// fails. ListModels provides context-aware, error-returning discovery. Common
+// models include:
 //   - llama3.2, llama3.2:70b
 //   - mistral, mixtral
 //   - qwen3

--- a/providers/ollama/models.go
+++ b/providers/ollama/models.go
@@ -1,0 +1,129 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/internal/timeoutx"
+)
+
+const (
+	modelListPath             = "/api/tags"
+	defaultDiscoveryTimeout   = 2 * time.Second
+	maxModelListResponseBytes = 8 << 20
+)
+
+type ollamaModelListResponse struct {
+	Models []ollamaModelEntry `json:"models"`
+}
+
+type ollamaModelEntry struct {
+	Name  string `json:"name"`
+	Model string `json:"model"`
+}
+
+// ListModels returns the models currently installed on the configured Ollama
+// instance. Ollama's tags API does not report per-model capabilities, so the
+// returned capability lists are intentionally empty.
+func (p *Ollama) ListModels(ctx context.Context) ([]core.ModelInfo, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("ollama: model listing context cannot be nil")
+	}
+	ctx, cancel := timeoutx.Apply(ctx, p.config.Timeout)
+	defer cancel()
+
+	resp, err := p.sendModelListRequest(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return decodeModelListResponse(resp)
+}
+
+func (p *Ollama) sendModelListRequest(ctx context.Context) (*http.Response, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, modelListEndpoint(p.config.BaseURL), nil)
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+	for key, values := range p.buildHeaders() {
+		for _, value := range values {
+			httpReq.Header.Add(key, value)
+		}
+	}
+
+	resp, err := p.config.HTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+	return resp, nil
+}
+
+func decodeModelListResponse(resp *http.Response) ([]core.ModelInfo, error) {
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, parseErrorResponse(resp)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxModelListResponseBytes+1))
+	if err != nil {
+		return nil, newNetworkError(err)
+	}
+	if len(body) > maxModelListResponseBytes {
+		return nil, newDecodeError(fmt.Errorf("model list response exceeds %d bytes", maxModelListResponseBytes))
+	}
+	var list ollamaModelListResponse
+	if err := json.Unmarshal(body, &list); err != nil {
+		return nil, newDecodeErrorWithBody(err, body)
+	}
+
+	return mapModelList(list.Models), nil
+}
+
+func mapModelList(entries []ollamaModelEntry) []core.ModelInfo {
+	models := make([]core.ModelInfo, 0, len(entries))
+	for _, entry := range entries {
+		id := entry.Name
+		if id == "" {
+			id = entry.Model
+		}
+		if id == "" {
+			continue
+		}
+		models = append(models, core.ModelInfo{ID: core.ModelID(id), DisplayName: id})
+	}
+	return models
+}
+
+func modelListEndpoint(baseURL string) string {
+	baseURL = strings.TrimRight(baseURL, "/")
+	if strings.HasSuffix(baseURL, "/api") {
+		return baseURL + "/tags"
+	}
+	return baseURL + modelListPath
+}
+
+func (p *Ollama) discoveryContext() (context.Context, context.CancelFunc) {
+	timeout := defaultDiscoveryTimeout
+	if p.config.Timeout > 0 && p.config.Timeout < timeout {
+		timeout = p.config.Timeout
+	}
+	return context.WithTimeout(context.Background(), timeout)
+}
+
+func illustrativeModels() []core.ModelInfo {
+	return []core.ModelInfo{
+		{ID: "llama3.2", DisplayName: "Llama 3.2", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling}},
+		{ID: "llama3.2:70b", DisplayName: "Llama 3.2 70B", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling}},
+		{ID: "mistral", DisplayName: "Mistral 7B", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling}},
+		{ID: "mixtral", DisplayName: "Mixtral 8x7B", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling}},
+		{ID: "qwen3", DisplayName: "Qwen 3", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling, core.FeatureReasoning}},
+		{ID: "gemma3", DisplayName: "Gemma 3", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming}},
+		{ID: "deepseek-coder", DisplayName: "DeepSeek Coder", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming}},
+		{ID: "codellama", DisplayName: "Code Llama", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming}},
+	}
+}

--- a/providers/ollama/models_test.go
+++ b/providers/ollama/models_test.go
@@ -1,0 +1,169 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/iris/core"
+)
+
+func TestListModels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.URL.Path != "/api/tags" {
+			t.Errorf("path = %q, want /api/tags", r.URL.Path)
+		}
+		if r.Header.Get("X-Custom") != "value" {
+			t.Errorf("X-Custom = %q, want value", r.Header.Get("X-Custom"))
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"models": []any{
+				map[string]any{"name": "qwen3:8b", "model": "qwen3:8b", "size": 5_000_000_000},
+				map[string]any{"model": "nomic-embed-text:latest"},
+				map[string]any{},
+			},
+		})
+	}))
+	defer server.Close()
+
+	provider := New(WithBaseURL(server.URL), WithHeaders(http.Header{"X-Custom": []string{"value"}}))
+	models, err := provider.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("len(models) = %d, want 2", len(models))
+	}
+	if models[0].ID != "qwen3:8b" || models[0].DisplayName != "qwen3:8b" {
+		t.Errorf("models[0] = %#v, want qwen3:8b", models[0])
+	}
+	if models[1].ID != "nomic-embed-text:latest" {
+		t.Errorf("models[1] = %#v, want legacy model-field fallback", models[1])
+	}
+	if len(models[0].Capabilities) != 0 {
+		t.Errorf("capabilities = %v, want empty because /api/tags does not advertise them", models[0].Capabilities)
+	}
+}
+
+func TestModelsUsesLocalTags(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"models": []any{map[string]any{"name": "local-only:latest"}},
+		})
+	}))
+	defer server.Close()
+
+	provider := New(WithBaseURL(server.URL))
+	models := provider.Models()
+	if len(models) != 1 || models[0].ID != "local-only:latest" {
+		t.Fatalf("Models() = %#v, want local /api/tags result", models)
+	}
+}
+
+func TestModelsReturnsEmptyLocalCatalog(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"models": []any{}})
+	}))
+	defer server.Close()
+
+	provider := New(WithBaseURL(server.URL))
+	if models := provider.Models(); len(models) != 0 {
+		t.Fatalf("Models() = %#v, want empty local catalog", models)
+	}
+}
+
+func TestModelsFallsBackToIllustrativeCatalog(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]string{"error": "offline"})
+	}))
+	defer server.Close()
+
+	provider := New(WithBaseURL(server.URL))
+	models := provider.Models()
+	if !hasModel(models, "llama3.2") {
+		t.Fatalf("Models() fallback = %#v, want illustrative llama3.2 entry", models)
+	}
+}
+
+func TestListModelsAvoidsDuplicateAPIPath(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/tags" {
+			t.Errorf("path = %q, want /api/tags", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"models": []any{}})
+	}))
+	defer server.Close()
+
+	provider := New(WithBaseURL(server.URL + "/api"))
+	if _, err := provider.ListModels(context.Background()); err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+}
+
+func TestListModelsErrors(t *testing.T) {
+	t.Run("nil context", func(t *testing.T) {
+		provider := New()
+		//nolint:staticcheck // Intentionally verify that the public API rejects a nil context.
+		_, err := provider.ListModels(nil)
+		if err == nil {
+			t.Fatal("ListModels() should reject a nil context")
+		}
+	})
+
+	t.Run("HTTP error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusTooManyRequests)
+			json.NewEncoder(w).Encode(map[string]string{"error": "busy"})
+		}))
+		defer server.Close()
+
+		provider := New(WithBaseURL(server.URL))
+		_, err := provider.ListModels(context.Background())
+		if !errors.Is(err, core.ErrRateLimited) {
+			t.Fatalf("error = %v, want ErrRateLimited", err)
+		}
+	})
+
+	t.Run("malformed response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(`{"models":`))
+		}))
+		defer server.Close()
+
+		provider := New(WithBaseURL(server.URL))
+		_, err := provider.ListModels(context.Background())
+		if !errors.Is(err, core.ErrDecode) {
+			t.Fatalf("error = %v, want ErrDecode", err)
+		}
+	})
+
+	t.Run("provider timeout", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		}))
+		t.Cleanup(func() { go server.Close() })
+
+		provider := New(WithBaseURL(server.URL), WithTimeout(20*time.Millisecond))
+		_, err := provider.ListModels(context.Background())
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("error = %v, want context.DeadlineExceeded", err)
+		}
+	})
+}
+
+func hasModel(models []core.ModelInfo, id core.ModelID) bool {
+	for _, model := range models {
+		if model.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/providers/ollama/options.go
+++ b/providers/ollama/options.go
@@ -34,7 +34,7 @@ type Config struct {
 	Headers http.Header
 
 	// Timeout sets the timeout for this provider's direct (non-chat)
-	// operations — embeddings, files, images, batch, and vector stores.
+	// operations — model listing, embeddings, files, images, batch, and vector stores.
 	// Chat and streaming honor core.WithTimeout and context deadlines.
 	Timeout time.Duration
 }
@@ -81,7 +81,7 @@ func WithHeaders(headers http.Header) Option {
 }
 
 // WithTimeout sets the timeout for this provider's direct (non-chat)
-// operations — embeddings, files, images, batch, and vector stores. Chat and
+// operations — model listing, embeddings, files, images, batch, and vector stores. Chat and
 // streaming honor core.WithTimeout and context deadlines.
 func WithTimeout(timeout time.Duration) Option {
 	return func(c *Config) {

--- a/providers/ollama/provider.go
+++ b/providers/ollama/provider.go
@@ -84,21 +84,18 @@ func (p *Ollama) ID() string {
 	return "ollama"
 }
 
-// Models returns example models available through Ollama.
-// Note: Ollama models are dynamic - you can use any model you have pulled locally.
+// Models returns models installed on the configured Ollama instance. Because
+// Provider.Models cannot return an error or accept a context, discovery is
+// bounded to two seconds and falls back to an illustrative catalog when the
+// instance cannot be reached. Use ListModels for error-aware discovery.
 func (p *Ollama) Models() []core.ModelInfo {
-	// Return common example models for documentation purposes
-	// Users can use any model they have pulled
-	return []core.ModelInfo{
-		{ID: "llama3.2", DisplayName: "Llama 3.2", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling}},
-		{ID: "llama3.2:70b", DisplayName: "Llama 3.2 70B", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling}},
-		{ID: "mistral", DisplayName: "Mistral 7B", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling}},
-		{ID: "mixtral", DisplayName: "Mixtral 8x7B", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling}},
-		{ID: "qwen3", DisplayName: "Qwen 3", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming, core.FeatureToolCalling, core.FeatureReasoning}},
-		{ID: "gemma3", DisplayName: "Gemma 3", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming}},
-		{ID: "deepseek-coder", DisplayName: "DeepSeek Coder", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming}},
-		{ID: "codellama", DisplayName: "Code Llama", Capabilities: []core.Feature{core.FeatureChat, core.FeatureChatStreaming}},
+	ctx, cancel := p.discoveryContext()
+	defer cancel()
+	models, err := p.ListModels(ctx)
+	if err == nil {
+		return models
 	}
+	return illustrativeModels()
 }
 
 // Supports reports whether the provider supports the given feature.

--- a/providers/ollama/provider_test.go
+++ b/providers/ollama/provider_test.go
@@ -113,28 +113,6 @@ func TestProviderID(t *testing.T) {
 	}
 }
 
-// TestProviderModels tests the Models method.
-func TestProviderModels(t *testing.T) {
-	p := New()
-	models := p.Models()
-
-	if len(models) == 0 {
-		t.Error("Models() should return example models")
-	}
-
-	// Check that llama3.2 is in the list
-	found := false
-	for _, m := range models {
-		if m.ID == "llama3.2" {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Error("Models() should include llama3.2")
-	}
-}
-
 // TestProviderSupports tests the Supports method.
 func TestProviderSupports(t *testing.T) {
 	p := New()

--- a/tests/docs_test.go
+++ b/tests/docs_test.go
@@ -79,6 +79,7 @@ var matrixColumns = []struct {
 	{"Reasoning", core.FeatureReasoning},
 	{"Built-in Tools", core.FeatureBuiltInTools},
 	{"Response Chain", core.FeatureResponseChain},
+	{"Token Counting", core.FeatureTokenCounting},
 	{"Structured Output", core.FeatureStructuredOutput},
 	{"Embeddings", core.FeatureEmbeddings},
 	{"Reranking", core.FeatureReranking},


### PR DESCRIPTION
## Summary

Closes #70.

Iris previously exposed token usage only after generation and had no provider-neutral way to count a pending request. This prevented callers from reliably trimming conversations or checking context-window budgets before sending them. Ollama model discovery also returned eight hardcoded examples regardless of which models were actually installed on the configured instance.

This PR adds a `core.TokenCounter` optional capability with native Anthropic and Gemini implementations, and makes Ollama model discovery reflect `/api/tags` while retaining the former catalog as a bounded offline fallback.

## Root cause

The core capability model did not define a token-counting operation, so provider-native endpoints could not be exposed consistently. Anthropic and Gemini therefore mapped response usage but never implemented their preflight counting APIs. Separately, `Provider.Models()` has no context or error return, which led the Ollama implementation to use a static list instead of querying the local service.

## Changes

- Add `core.TokenCounter`, `core.TokenCountResponse`, `core.AsTokenCounter`, and `core.FeatureTokenCounting`.
- Implement Anthropic `POST /v1/messages/count_tokens`, including system messages, multimodal message mapping, and tools.
- Implement Gemini `POST /v1beta/models/{model}:countTokens` using a complete nested `generateContentRequest`, including the required model resource, system instructions, and tools.
- Validate credentials, contexts, requests, model identifiers, and message presence before HTTP calls.
- Preserve existing provider timeout behavior and normalized network, decode, rate-limit, and API errors.
- Bound token-count and model-list response reads.
- Add Ollama `ListModels(ctx)` backed by `GET /api/tags`.
- Make Ollama `Models()` use live discovery with a maximum two-second attempt and return the illustrative catalog only when discovery fails; a valid empty local catalog remains empty.
- Handle both host-style base URLs and `/api`-suffixed Ollama base URLs without producing `/api/api/tags`.
- Document capability discovery, provider support, Ollama fallback semantics, and the intentional post-1.0 audio deferral.

## User impact

Callers can now measure the same `core.ChatRequest` they plan to generate with Anthropic or Gemini before consuming generation quota. Ollama-backed model selectors can show the models actually installed on the configured instance, while callers that need explicit error handling can use `ListModels(ctx)`.

Audio transcription/synthesis and a heuristic tokenizer fallback remain out of scope. Audio needs a deliberate binary and streaming API design, while character-based estimates would be misleading across provider tokenizers, images, documents, and tool schemas.

## Verification

- `go test ./...`
- `go test -race ./core ./providers/anthropic ./providers/gemini ./providers/ollama`
- `go vet ./...`
- `go build ./...`
- `git diff --check`

Affected-package coverage:

- Core: 90.9%
- Anthropic: 83.2%
- Gemini: 80.7%
- Ollama: 91.8%
