### PR TITLE
[codex] standardize provider construction APIs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,6 +82,36 @@ type Provider interface {
 - `Chat()`: Synchronous request for simple use cases
 - `StreamChat()`: Streaming request for real-time output
 
+### Provider Construction Conventions
+
+Provider packages expose a common construction and option surface:
+
+- `New(apiKey string, opts ...Option)` for API-key providers
+- `NewFromEnv(opts ...Option) (*Provider, error)`
+- `WithAPIKey(key string) Option`
+- `WithHeader(key, value string) Option`
+- `DefaultAPIKeyEnvVar` as the preferred credential environment variable
+
+Two constructor signatures are intentional exceptions because their runtime
+requirements differ:
+
+- `ollama.New(opts ...Option)` — local Ollama is keyless by default. Use
+  `WithAPIKey` for authenticated remote or cloud instances.
+- `azurefoundry.New(endpoint, apiKey string, opts ...Option)` — Azure resource
+  endpoints are deployment-specific and cannot be derived from the API key.
+
+The legacy constructors remain source-compatible; changing them to one uniform
+signature would break existing Go callers because Go does not support overloads.
+`providers.CreateWithConfig` supplies both API key and endpoint values for
+registry users while the original `providers.Create(name, apiKey)` remains
+available.
+
+The type, feature, role, and error aliases in `providers/provider.go` are
+deprecated and frozen rather than expanded. Import `core` directly for those
+APIs; the `providers` package remains the supported home of registry functions.
+This avoids maintaining a second public namespace that can silently drift from
+`core`.
+
 ### Optional Provider Capability Interfaces
 
 Additional operations use small optional interfaces so providers can opt into

--- a/docs/changes/2026-08-28_v0.0.0-dev_issue-71-provider-api-consistency.md
+++ b/docs/changes/2026-08-28_v0.0.0-dev_issue-71-provider-api-consistency.md
@@ -1,0 +1,135 @@
+---
+date: 2026-08-28
+version: v0.0.0-dev
+feature: Provider API consistency and registry configuration
+product: iris
+change_type: api
+affected_components: [providers/registry.go, providers/provider.go, providers/openai/options.go, providers/ollama/provider.go, providers/ollama/options.go, providers/ollama/register.go, providers/zai/options.go, providers/azurefoundry/provider.go, providers/azurefoundry/register.go, providers/gemini/provider.go, providers/huggingface/provider.go, tests/provider_api_conformance_test.go, docs/ARCHITECTURE.md]
+related_frds: []
+---
+
+## Summary
+
+Issue #71 standardizes the public construction surface across all ten built-in provider packages without breaking existing Go callers. Every provider now exposes `NewFromEnv`, `WithAPIKey`, `WithHeader`, and `DefaultAPIKeyEnvVar`; the established API-key constructor remains canonical, with documented Ollama and Azure AI Foundry exceptions. A conformance test enforces these signatures. The partial `providers` re-export layer is explicitly deprecated and frozen in favor of direct `core` imports.
+
+The registry also gains `ProviderConfig`, `RegisterConfigured`, and `CreateWithConfig` so endpoint-dependent providers can participate without encoding resource endpoints into API keys or silently dropping credentials.
+
+## Motivation
+
+Small differences between provider packages accumulated into migration friction: OpenAI lacked `WithAPIKey`, Ollama and Z.ai only accepted whole header maps, and Ollama lacked the common environment factory. Azure AI Foundry could not receive its required endpoint through the API-key-only registry, while the Ollama registry factory discarded a supplied cloud key. The partial `providers` aliases created a second, incomplete namespace that drifted whenever `core` added a feature, role, type, or sentinel.
+
+## What Changed
+
+### New Additions
+
+- `openai.WithAPIKey(key)` with the same option-overrides-constructor semantics as the other API-key providers.
+- `ollama.WithHeader(key, value)` and `zai.WithHeader(key, value)`; existing `WithHeaders(http.Header)` functions remain available.
+- `ollama.NewFromEnv(opts...)`, reading `OLLAMA_HOST` and optional `OLLAMA_API_KEY`:
+  - neither value: keyless local defaults;
+  - host present: configured host, with optional authentication;
+  - key without host: Ollama Cloud;
+  - explicit options override environment-derived values.
+- `DefaultAPIKeyEnvVar` aliases for Azure AI Foundry, Gemini, Hugging Face, and Ollama. Existing provider-specific constant names remain source-compatible.
+- `providers.ProviderConfig`, `ConfiguredProviderFactory`, `RegisterConfigured`, and `CreateWithConfig`.
+- `tests/provider_api_conformance_test.go`, covering all registered built-in providers and enforcing constructor, environment factory, option, and environment-variable alias signatures.
+
+### Modifications
+
+- Azure AI Foundry registers a configured factory that accepts an explicit endpoint and falls back to `AZURE_AI_ENDPOINT` for legacy `Create(name, apiKey)` calls.
+- Ollama's registry factory preserves an optional API key rather than discarding it.
+- `providers.Create` delegates to the configured registry while retaining its original signature and behavior for API-key-only providers.
+- Architecture documentation defines the canonical provider surface and explains both constructor exceptions.
+- The `providers` core alias declarations and package documentation now state that the re-export layer is deprecated, incomplete by design, and frozen.
+
+### Removals
+
+None. Existing constructors, environment constants, bulk `WithHeaders` options, registry functions, and aliases remain available.
+
+## Technical Specification
+
+### Canonical Provider Surface
+
+```go
+func New(apiKey string, opts ...Option) *Provider
+func NewFromEnv(opts ...Option) (*Provider, error)
+func WithAPIKey(key string) Option
+func WithHeader(key, value string) Option
+const DefaultAPIKeyEnvVar = "PROVIDER_API_KEY"
+```
+
+Intentional constructor exceptions:
+
+```go
+func ollama.New(opts ...ollama.Option) *ollama.Ollama
+func azurefoundry.New(endpoint, apiKey string, opts ...azurefoundry.Option) *azurefoundry.AzureFoundry
+```
+
+Ollama is local and keyless by default. Azure resource endpoints are deployment-specific and cannot be derived from the API key. Go cannot overload functions, so replacing either constructor with the canonical signature would be a source-breaking change.
+
+### Registry API
+
+```go
+type ProviderConfig struct {
+    APIKey  string
+    Endpoint string
+}
+
+type ConfiguredProviderFactory func(ProviderConfig) core.Provider
+
+func RegisterConfigured(name string, factory ConfiguredProviderFactory)
+func CreateWithConfig(name string, config ProviderConfig) (core.Provider, error)
+```
+
+`Register` adapts an API-key factory into a configured factory. `RegisterConfigured` installs a backward-compatible API-key adapter for `Get` and `Create`. Duplicate names retain the existing last-registration-wins behavior under the registry mutex.
+
+## Usage Examples
+
+### Consistent option override
+
+```go
+provider := openai.New(
+    "constructor-key",
+    openai.WithAPIKey(os.Getenv(openai.DefaultAPIKeyEnvVar)),
+    openai.WithHeader("X-Request-ID", requestID),
+)
+```
+
+### Ollama environment factory
+
+```go
+provider, err := ollama.NewFromEnv(
+    ollama.WithHeader("X-Request-ID", requestID),
+)
+```
+
+### Endpoint-aware registry construction
+
+```go
+provider, err := providers.CreateWithConfig("azurefoundry", providers.ProviderConfig{
+    APIKey:  os.Getenv(azurefoundry.DefaultAPIKeyEnvVar),
+    Endpoint: os.Getenv(azurefoundry.EnvEndpoint),
+})
+```
+
+## Integration Notes
+
+Provider-specific option types remain intentionally distinct because their configuration structs differ. The conformance test checks the public function shapes through compile-time references and reflection without requiring the option types themselves to be interchangeable. It also compares the ten conformance entries with the provider registry, so a newly registered built-in provider cannot omit the policy unnoticed.
+
+Consumers should migrate imports such as `providers.FeatureChat` or `providers.ErrRateLimited` to `core.FeatureChat` and `core.ErrRateLimited`. No immediate migration is required because the existing aliases remain source-compatible.
+
+## Breaking Changes & Migration
+
+None. All changes are additive or documentation-only. Existing `New(...)`, `NewLocal`, `NewCloudFromEnv`, `WithHeaders`, `providers.Create`, and re-export usages continue to compile.
+
+## Deferred / Out of Scope
+
+- Replacing every constructor with `New(opts ...Option)` is rejected for this release because it would break all positional-key callers. A future major version could revisit a config-only constructor.
+- The root `iris.go` facade remains a curated set of common chat providers. Expanding it to endpoint-dependent and non-chat providers needs a separate facade design rather than ten inconsistent one-liners.
+- Provider model constants remain provider-specific. Hugging Face and Ollama are dynamic catalogs, and Azure deployment names are user-defined.
+- Default HTTP clients remain `http.DefaultClient`. Merely allocating separate `http.Client` values would still share `http.DefaultTransport`; callers needing isolated pools can use `WithHTTPClient`, while a secure transport policy deserves a separate design.
+
+## Testing Notes
+
+- Provider API conformance checks all ten registered packages for `NewFromEnv`, `WithAPIKey`, `WithHeader`, `DefaultAPIKeyEnvVar`, and one of the three documented constructor shapes.
+- Focused tests cover option precedence, additive headers, Ollama environment routing, configured registry adaptation, Azure endpoint propagation, and Ollama registry authentication.
+- Full verification includes unit tests, race checks for affected packages, coverage, `go vet`, `go build`, formatting, and diff whitespace checks.

--- a/providers/azurefoundry/env_test.go
+++ b/providers/azurefoundry/env_test.go
@@ -1,0 +1,42 @@
+package azurefoundry
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewFromEnv(t *testing.T) {
+	t.Run("missing endpoint", func(t *testing.T) {
+		t.Setenv(EnvEndpoint, "")
+		t.Setenv(EnvAPIKey, "key")
+		provider, err := NewFromEnv()
+		if !errors.Is(err, ErrEndpointNotFound) || provider != nil {
+			t.Fatalf("NewFromEnv() = (%v, %v), want nil, ErrEndpointNotFound", provider, err)
+		}
+	})
+
+	t.Run("missing API key", func(t *testing.T) {
+		t.Setenv(EnvEndpoint, "https://resource.services.ai.azure.com")
+		t.Setenv(EnvAPIKey, "")
+		provider, err := NewFromEnv()
+		if !errors.Is(err, ErrAPIKeyNotFound) || provider != nil {
+			t.Fatalf("NewFromEnv() = (%v, %v), want nil, ErrAPIKeyNotFound", provider, err)
+		}
+	})
+
+	t.Run("environment and option precedence", func(t *testing.T) {
+		t.Setenv(EnvEndpoint, "https://resource.services.ai.azure.com")
+		t.Setenv(EnvAPIKey, "env-key")
+		t.Setenv(EnvDeploymentID, "env-deployment")
+		provider, err := NewFromEnv(WithAPIKey("option-key"), WithDeploymentID("option-deployment"))
+		if err != nil {
+			t.Fatalf("NewFromEnv() error = %v", err)
+		}
+		if provider.config.Endpoint != "https://resource.services.ai.azure.com" {
+			t.Errorf("Endpoint = %q, want environment endpoint", provider.config.Endpoint)
+		}
+		if provider.config.APIKey.Expose() != "option-key" || provider.config.DeploymentID != "option-deployment" {
+			t.Error("explicit options should override environment-derived values")
+		}
+	})
+}

--- a/providers/azurefoundry/provider.go
+++ b/providers/azurefoundry/provider.go
@@ -20,6 +20,8 @@ const (
 	EnvAPIKey = "AZURE_AI_API_KEY"
 	// EnvDeploymentID is the optional environment variable for deployment ID.
 	EnvDeploymentID = "AZURE_AI_DEPLOYMENT_ID"
+	// DefaultAPIKeyEnvVar is the canonical API-key environment variable alias.
+	DefaultAPIKeyEnvVar = EnvAPIKey
 )
 
 // Sentinel errors.

--- a/providers/azurefoundry/register.go
+++ b/providers/azurefoundry/register.go
@@ -1,14 +1,18 @@
 package azurefoundry
 
 import (
+	"os"
+
 	"github.com/petal-labs/iris/core"
 	"github.com/petal-labs/iris/providers"
 )
 
 func init() {
-	providers.Register("azurefoundry", func(apiKey string) core.Provider {
-		// When using registry, endpoint must be set via environment
-		// or use NewFromEnv/New directly for full configuration
-		return New("", apiKey)
+	providers.RegisterConfigured("azurefoundry", func(config providers.ProviderConfig) core.Provider {
+		endpoint := config.Endpoint
+		if endpoint == "" {
+			endpoint = os.Getenv(EnvEndpoint)
+		}
+		return New(endpoint, config.APIKey)
 	})
 }

--- a/providers/azurefoundry/register_test.go
+++ b/providers/azurefoundry/register_test.go
@@ -1,0 +1,36 @@
+package azurefoundry
+
+import (
+	"testing"
+
+	"github.com/petal-labs/iris/providers"
+)
+
+func TestConfiguredRegistryFactory(t *testing.T) {
+	created, err := providers.CreateWithConfig("azurefoundry", providers.ProviderConfig{
+		APIKey:   "registry-key",
+		Endpoint: "https://configured.services.ai.azure.com",
+	})
+	if err != nil {
+		t.Fatalf("CreateWithConfig() error = %v", err)
+	}
+	provider, ok := created.(*AzureFoundry)
+	if !ok {
+		t.Fatalf("provider type = %T, want *AzureFoundry", created)
+	}
+	if provider.config.Endpoint != "https://configured.services.ai.azure.com" || provider.config.APIKey.Expose() != "registry-key" {
+		t.Errorf("registry config = %#v, want endpoint and API key", provider.config)
+	}
+}
+
+func TestLegacyRegistryFactoryUsesEnvironmentEndpoint(t *testing.T) {
+	t.Setenv(EnvEndpoint, "https://environment.services.ai.azure.com")
+	created, err := providers.Create("azurefoundry", "registry-key")
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	provider := created.(*AzureFoundry)
+	if provider.config.Endpoint != "https://environment.services.ai.azure.com" {
+		t.Errorf("Endpoint = %q, want environment endpoint", provider.config.Endpoint)
+	}
+}

--- a/providers/gemini/provider.go
+++ b/providers/gemini/provider.go
@@ -15,6 +15,8 @@ import (
 const (
 	GeminiAPIKeyEnvVar = "GEMINI_API_KEY"
 	GoogleAPIKeyEnvVar = "GOOGLE_API_KEY"
+	// DefaultAPIKeyEnvVar is the preferred Gemini API-key environment variable.
+	DefaultAPIKeyEnvVar = GeminiAPIKeyEnvVar
 )
 
 // ErrAPIKeyNotFound is returned when no API key environment variable is set.

--- a/providers/huggingface/provider.go
+++ b/providers/huggingface/provider.go
@@ -15,6 +15,8 @@ import (
 const (
 	HFTokenEnvVar          = "HF_TOKEN"
 	HuggingFaceTokenEnvVar = "HUGGINGFACE_TOKEN"
+	// DefaultAPIKeyEnvVar is the preferred Hugging Face token environment variable.
+	DefaultAPIKeyEnvVar = HFTokenEnvVar
 )
 
 // ErrAPIKeyNotFound is returned when no API token environment variable is set.

--- a/providers/ollama/options.go
+++ b/providers/ollama/options.go
@@ -80,6 +80,16 @@ func WithHeaders(headers http.Header) Option {
 	}
 }
 
+// WithHeader adds an extra header to include in requests.
+func WithHeader(key, value string) Option {
+	return func(c *Config) {
+		if c.Headers == nil {
+			c.Headers = make(http.Header)
+		}
+		c.Headers.Set(key, value)
+	}
+}
+
 // WithTimeout sets the timeout for this provider's direct (non-chat)
 // operations — model listing, embeddings, files, images, batch, and vector stores. Chat and
 // streaming honor core.WithTimeout and context deadlines.

--- a/providers/ollama/provider.go
+++ b/providers/ollama/provider.go
@@ -14,10 +14,32 @@ import (
 const (
 	OllamaAPIKeyEnvVar = "OLLAMA_API_KEY"
 	OllamaHostEnvVar   = "OLLAMA_HOST"
+	// DefaultAPIKeyEnvVar is the canonical API-key environment variable alias.
+	DefaultAPIKeyEnvVar = OllamaAPIKeyEnvVar
 )
 
 // ErrAPIKeyNotFound is returned when the API key environment variable is not set.
 var ErrAPIKeyNotFound = errors.New("ollama: OLLAMA_API_KEY environment variable not set")
+
+// NewFromEnv creates an Ollama provider using OLLAMA_HOST and the optional
+// OLLAMA_API_KEY. A missing API key is valid for local Ollama instances, so the
+// current implementation returns a nil error; the error result preserves the
+// common provider-factory shape. Explicit options override environment values.
+func NewFromEnv(opts ...Option) (*Ollama, error) {
+	envOpts := make([]Option, 0, len(opts)+2)
+	host := os.Getenv(OllamaHostEnvVar)
+	apiKey := os.Getenv(OllamaAPIKeyEnvVar)
+	if host != "" {
+		envOpts = append(envOpts, WithBaseURL(host))
+	} else if apiKey != "" {
+		envOpts = append(envOpts, WithCloud())
+	}
+	if apiKey != "" {
+		envOpts = append(envOpts, WithAPIKey(apiKey))
+	}
+	envOpts = append(envOpts, opts...)
+	return New(envOpts...), nil
+}
 
 // NewLocal creates a new Ollama provider for a local Ollama instance.
 // This is a convenience factory for quick local setup:

--- a/providers/ollama/provider_test.go
+++ b/providers/ollama/provider_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers"
 )
 
 // TestNew tests the provider constructor.
@@ -75,6 +76,77 @@ func TestNewLocalUsesConfiguredHost(t *testing.T) {
 	provider := NewLocal()
 	if provider.config.BaseURL != "http://ollama.internal:11434" {
 		t.Errorf("BaseURL = %q, want configured Ollama host", provider.config.BaseURL)
+	}
+}
+
+func TestNewFromEnv(t *testing.T) {
+	t.Run("keyless local defaults", func(t *testing.T) {
+		t.Setenv(OllamaHostEnvVar, "")
+		t.Setenv(OllamaAPIKeyEnvVar, "")
+		provider, err := NewFromEnv()
+		if err != nil {
+			t.Fatalf("NewFromEnv() error = %v", err)
+		}
+		if provider.config.BaseURL != DefaultLocalURL || !provider.config.APIKey.IsEmpty() {
+			t.Errorf("config = %#v, want keyless local defaults", provider.config)
+		}
+	})
+
+	t.Run("host and optional key", func(t *testing.T) {
+		t.Setenv(OllamaHostEnvVar, "http://ollama.internal:11434")
+		t.Setenv(OllamaAPIKeyEnvVar, "env-key")
+		provider, err := NewFromEnv()
+		if err != nil {
+			t.Fatalf("NewFromEnv() error = %v", err)
+		}
+		if provider.config.BaseURL != "http://ollama.internal:11434" || provider.config.APIKey.Expose() != "env-key" {
+			t.Errorf("NewFromEnv() did not apply environment configuration")
+		}
+	})
+
+	t.Run("API key without host selects cloud", func(t *testing.T) {
+		t.Setenv(OllamaHostEnvVar, "")
+		t.Setenv(OllamaAPIKeyEnvVar, "env-key")
+		provider, err := NewFromEnv()
+		if err != nil {
+			t.Fatalf("NewFromEnv() error = %v", err)
+		}
+		if provider.config.BaseURL != DefaultCloudURL || provider.config.APIKey.Expose() != "env-key" {
+			t.Errorf("config = %#v, want authenticated Ollama Cloud", provider.config)
+		}
+	})
+
+	t.Run("explicit options win", func(t *testing.T) {
+		t.Setenv(OllamaHostEnvVar, "http://env-host:11434")
+		t.Setenv(OllamaAPIKeyEnvVar, "env-key")
+		provider, err := NewFromEnv(WithBaseURL("http://option-host:11434"), WithAPIKey("option-key"))
+		if err != nil {
+			t.Fatalf("NewFromEnv() error = %v", err)
+		}
+		if provider.config.BaseURL != "http://option-host:11434" || provider.config.APIKey.Expose() != "option-key" {
+			t.Error("explicit options should override environment configuration")
+		}
+	})
+}
+
+func TestWithHeader(t *testing.T) {
+	provider := New(WithHeader("X-Custom", "value"), WithHeader("X-Second", "two"))
+	if provider.config.Headers.Get("X-Custom") != "value" || provider.config.Headers.Get("X-Second") != "two" {
+		t.Errorf("headers = %v, want both custom headers", provider.config.Headers)
+	}
+}
+
+func TestRegistryFactoryUsesAPIKey(t *testing.T) {
+	created, err := providers.Create("ollama", "registry-key")
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	provider, ok := created.(*Ollama)
+	if !ok {
+		t.Fatalf("provider type = %T, want *Ollama", created)
+	}
+	if provider.config.APIKey.Expose() != "registry-key" {
+		t.Error("registry factory should preserve the optional Ollama API key")
 	}
 }
 

--- a/providers/ollama/register.go
+++ b/providers/ollama/register.go
@@ -6,8 +6,9 @@ import (
 )
 
 func init() {
-	// Ollama doesn't require an API key, so we ignore the apiKey parameter.
+	// Ollama does not require an API key locally, but preserve one when registry
+	// callers target an authenticated remote or cloud instance.
 	providers.Register("ollama", func(apiKey string) core.Provider {
-		return New()
+		return New(WithAPIKey(apiKey))
 	})
 }

--- a/providers/openai/options.go
+++ b/providers/openai/options.go
@@ -40,6 +40,13 @@ const DefaultBaseURL = "https://api.openai.com/v1"
 // Option configures the OpenAI provider.
 type Option func(*Config)
 
+// WithAPIKey sets the API key, overriding any value passed to New.
+func WithAPIKey(key string) Option {
+	return func(c *Config) {
+		c.APIKey = core.NewSecret(key)
+	}
+}
+
 // WithBaseURL sets the API base URL.
 func WithBaseURL(url string) Option {
 	return func(c *Config) {

--- a/providers/openai/options_test.go
+++ b/providers/openai/options_test.go
@@ -15,6 +15,13 @@ func TestWithBaseURL(t *testing.T) {
 	}
 }
 
+func TestWithAPIKeyOverridesConstructorArg(t *testing.T) {
+	p := New("constructor-key", WithAPIKey("option-key"))
+	if got := p.config.APIKey.Expose(); got != "option-key" {
+		t.Errorf("APIKey = %q, want option-key", got)
+	}
+}
+
 func TestWithHTTPClient(t *testing.T) {
 	customClient := &http.Client{Timeout: 30 * time.Second}
 	cfg := Config{}

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -36,12 +36,20 @@
 //	if p.Supports(core.FeatureToolCalling) {
 //	    // Safe to use tools
 //	}
+//
+// # Core Re-exports
+//
+// The historical core type, feature, role, and error aliases in this package
+// are deprecated and frozen. Import github.com/petal-labs/iris/core directly
+// for those APIs. Registry functions in this package remain supported.
 package providers
 
 import "github.com/petal-labs/iris/core"
 
-// Re-export core types for convenience.
-// Provider implementations can import just the providers package.
+// Deprecated: The partial core re-export layer is frozen for backward
+// compatibility and will not receive new core APIs. Import
+// github.com/petal-labs/iris/core directly. Registry APIs in this package are
+// not deprecated.
 type (
 	// Provider is the interface that LLM providers must implement.
 	Provider = core.Provider
@@ -83,21 +91,21 @@ type (
 	ProviderError = core.ProviderError
 )
 
-// Re-export feature constants.
+// Deprecated: Import feature constants from github.com/petal-labs/iris/core.
 const (
 	FeatureChat          = core.FeatureChat
 	FeatureChatStreaming = core.FeatureChatStreaming
 	FeatureToolCalling   = core.FeatureToolCalling
 )
 
-// Re-export role constants.
+// Deprecated: Import role constants from github.com/petal-labs/iris/core.
 const (
 	RoleSystem    = core.RoleSystem
 	RoleUser      = core.RoleUser
 	RoleAssistant = core.RoleAssistant
 )
 
-// Re-export sentinel errors.
+// Deprecated: Import sentinel errors from github.com/petal-labs/iris/core.
 var (
 	ErrUnauthorized  = core.ErrUnauthorized
 	ErrRateLimited   = core.ErrRateLimited

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -9,13 +9,24 @@ import (
 )
 
 // ProviderFactory creates a provider instance with the given API key.
-// Some providers (like Ollama) may ignore the key parameter.
 type ProviderFactory func(apiKey string) core.Provider
+
+// ProviderConfig supplies common construction values to a configured registry
+// factory. Endpoint is primarily used by providers such as Azure AI Foundry
+// whose resource endpoint cannot be inferred from an API key.
+type ProviderConfig struct {
+	APIKey   string
+	Endpoint string
+}
+
+// ConfiguredProviderFactory creates a provider from common registry values.
+type ConfiguredProviderFactory func(config ProviderConfig) core.Provider
 
 // registry holds registered provider factories.
 var (
-	registryMu sync.RWMutex
-	registry   = make(map[string]ProviderFactory)
+	registryMu         sync.RWMutex
+	registry           = make(map[string]ProviderFactory)
+	configuredRegistry = make(map[string]ConfiguredProviderFactory)
 )
 
 // Register adds a provider factory to the registry.
@@ -30,9 +41,21 @@ var (
 //	    })
 //	}
 func Register(name string, factory ProviderFactory) {
+	RegisterConfigured(name, func(config ProviderConfig) core.Provider {
+		return factory(config.APIKey)
+	})
+}
+
+// RegisterConfigured adds a provider factory that can consume common values
+// beyond an API key. Get and Create remain available through an API-key-only
+// adapter for backward compatibility.
+func RegisterConfigured(name string, factory ConfiguredProviderFactory) {
 	registryMu.Lock()
 	defer registryMu.Unlock()
-	registry[name] = factory
+	configuredRegistry[name] = factory
+	registry[name] = func(apiKey string) core.Provider {
+		return factory(ProviderConfig{APIKey: apiKey})
+	}
 }
 
 // Get retrieves a provider factory by name.
@@ -46,11 +69,23 @@ func Get(name string) ProviderFactory {
 // Create creates a new provider instance by name with the given API key.
 // Returns an error if the provider is not registered.
 func Create(name, apiKey string) (core.Provider, error) {
-	factory := Get(name)
+	return CreateWithConfig(name, ProviderConfig{APIKey: apiKey})
+}
+
+// CreateWithConfig creates a registered provider with common construction
+// values such as an API key and resource endpoint.
+func CreateWithConfig(name string, config ProviderConfig) (core.Provider, error) {
+	factory := getConfigured(name)
 	if factory == nil {
 		return nil, fmt.Errorf("unknown provider: %s (available: %v)", name, List())
 	}
-	return factory(apiKey), nil
+	return factory(config), nil
+}
+
+func getConfigured(name string) ConfiguredProviderFactory {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	return configuredRegistry[name]
 }
 
 // List returns the names of all registered providers in sorted order.

--- a/providers/registry_test.go
+++ b/providers/registry_test.go
@@ -86,6 +86,31 @@ func TestCreate(t *testing.T) {
 	}
 }
 
+func TestCreateWithConfig(t *testing.T) {
+	RegisterConfigured("configured-test", func(config ProviderConfig) core.Provider {
+		return &mockProvider{id: config.Endpoint + "-" + config.APIKey}
+	})
+
+	provider, err := CreateWithConfig("configured-test", ProviderConfig{
+		APIKey:   "my-key",
+		Endpoint: "https://example.test",
+	})
+	if err != nil {
+		t.Fatalf("CreateWithConfig() error = %v", err)
+	}
+	if provider.ID() != "https://example.test-my-key" {
+		t.Errorf("provider ID = %q, want configured values", provider.ID())
+	}
+
+	legacyProvider, err := Create("configured-test", "legacy-key")
+	if err != nil {
+		t.Fatalf("Create() adapter error = %v", err)
+	}
+	if legacyProvider.ID() != "-legacy-key" {
+		t.Errorf("legacy provider ID = %q, want API-key adapter", legacyProvider.ID())
+	}
+}
+
 func TestList(t *testing.T) {
 	// Register some test providers
 	Register("list-a", func(apiKey string) core.Provider { return nil })

--- a/providers/zai/options.go
+++ b/providers/zai/options.go
@@ -63,6 +63,16 @@ func WithHeaders(headers http.Header) Option {
 	}
 }
 
+// WithHeader adds an extra header to include in requests.
+func WithHeader(key, value string) Option {
+	return func(c *Config) {
+		if c.Headers == nil {
+			c.Headers = make(http.Header)
+		}
+		c.Headers.Set(key, value)
+	}
+}
+
 // WithTimeout sets the timeout for this provider's direct (non-chat)
 // operations — embeddings, files, images, batch, and vector stores. Chat and
 // streaming honor core.WithTimeout and context deadlines.

--- a/providers/zai/options_test.go
+++ b/providers/zai/options_test.go
@@ -50,6 +50,13 @@ func TestWithHeaders(t *testing.T) {
 	}
 }
 
+func TestWithHeader(t *testing.T) {
+	p := New("test-key", WithHeader("X-Custom", "value"), WithHeader("X-Second", "two"))
+	if p.config.Headers.Get("X-Custom") != "value" || p.config.Headers.Get("X-Second") != "two" {
+		t.Errorf("headers = %v, want both custom headers", p.config.Headers)
+	}
+}
+
 func TestWithTimeout(t *testing.T) {
 	timeout := 60 * time.Second
 	p := New("test-key", WithTimeout(timeout))

--- a/tests/provider_api_conformance_test.go
+++ b/tests/provider_api_conformance_test.go
@@ -1,0 +1,136 @@
+package tests
+
+import (
+	"os"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/petal-labs/iris/providers"
+	"github.com/petal-labs/iris/providers/anthropic"
+	"github.com/petal-labs/iris/providers/azurefoundry"
+	"github.com/petal-labs/iris/providers/gemini"
+	"github.com/petal-labs/iris/providers/huggingface"
+	"github.com/petal-labs/iris/providers/ollama"
+	"github.com/petal-labs/iris/providers/openai"
+	"github.com/petal-labs/iris/providers/perplexity"
+	"github.com/petal-labs/iris/providers/voyageai"
+	"github.com/petal-labs/iris/providers/xai"
+	"github.com/petal-labs/iris/providers/zai"
+)
+
+type constructorShape string
+
+const (
+	standardConstructor constructorShape = "api-key"
+	ollamaConstructor   constructorShape = "keyless-options"
+	azureConstructor    constructorShape = "endpoint-and-api-key"
+)
+
+type providerAPISurface struct {
+	id            string
+	constructor   any
+	newFromEnv    any
+	withAPIKey    any
+	withHeader    any
+	defaultKeyEnv string
+	shape         constructorShape
+}
+
+var providerAPISurfaces = []providerAPISurface{
+	{id: "anthropic", constructor: anthropic.New, newFromEnv: anthropic.NewFromEnv, withAPIKey: anthropic.WithAPIKey, withHeader: anthropic.WithHeader, defaultKeyEnv: anthropic.DefaultAPIKeyEnvVar, shape: standardConstructor},
+	{id: "azurefoundry", constructor: azurefoundry.New, newFromEnv: azurefoundry.NewFromEnv, withAPIKey: azurefoundry.WithAPIKey, withHeader: azurefoundry.WithHeader, defaultKeyEnv: azurefoundry.DefaultAPIKeyEnvVar, shape: azureConstructor},
+	{id: "gemini", constructor: gemini.New, newFromEnv: gemini.NewFromEnv, withAPIKey: gemini.WithAPIKey, withHeader: gemini.WithHeader, defaultKeyEnv: gemini.DefaultAPIKeyEnvVar, shape: standardConstructor},
+	{id: "huggingface", constructor: huggingface.New, newFromEnv: huggingface.NewFromEnv, withAPIKey: huggingface.WithAPIKey, withHeader: huggingface.WithHeader, defaultKeyEnv: huggingface.DefaultAPIKeyEnvVar, shape: standardConstructor},
+	{id: "ollama", constructor: ollama.New, newFromEnv: ollama.NewFromEnv, withAPIKey: ollama.WithAPIKey, withHeader: ollama.WithHeader, defaultKeyEnv: ollama.DefaultAPIKeyEnvVar, shape: ollamaConstructor},
+	{id: "openai", constructor: openai.New, newFromEnv: openai.NewFromEnv, withAPIKey: openai.WithAPIKey, withHeader: openai.WithHeader, defaultKeyEnv: openai.DefaultAPIKeyEnvVar, shape: standardConstructor},
+	{id: "perplexity", constructor: perplexity.New, newFromEnv: perplexity.NewFromEnv, withAPIKey: perplexity.WithAPIKey, withHeader: perplexity.WithHeader, defaultKeyEnv: perplexity.DefaultAPIKeyEnvVar, shape: standardConstructor},
+	{id: "voyageai", constructor: voyageai.New, newFromEnv: voyageai.NewFromEnv, withAPIKey: voyageai.WithAPIKey, withHeader: voyageai.WithHeader, defaultKeyEnv: voyageai.DefaultAPIKeyEnvVar, shape: standardConstructor},
+	{id: "xai", constructor: xai.New, newFromEnv: xai.NewFromEnv, withAPIKey: xai.WithAPIKey, withHeader: xai.WithHeader, defaultKeyEnv: xai.DefaultAPIKeyEnvVar, shape: standardConstructor},
+	{id: "zai", constructor: zai.New, newFromEnv: zai.NewFromEnv, withAPIKey: zai.WithAPIKey, withHeader: zai.WithHeader, defaultKeyEnv: zai.DefaultAPIKeyEnvVar, shape: standardConstructor},
+}
+
+func TestProviderAPISurfaceConformance(t *testing.T) {
+	ids := make([]string, 0, len(providerAPISurfaces))
+	for _, surface := range providerAPISurfaces {
+		ids = append(ids, surface.id)
+		t.Run(surface.id, func(t *testing.T) {
+			assertNewFromEnvSignature(t, surface.newFromEnv)
+			assertOptionSignature(t, "WithAPIKey", surface.withAPIKey, 1)
+			assertOptionSignature(t, "WithHeader", surface.withHeader, 2)
+			assertConstructorSignature(t, surface.constructor, surface.shape)
+			if strings.TrimSpace(surface.defaultKeyEnv) == "" {
+				t.Error("DefaultAPIKeyEnvVar must not be empty")
+			}
+		})
+	}
+
+	slices.Sort(ids)
+	if registered := providers.List(); !slices.Equal(ids, registered) {
+		t.Errorf("conformance providers = %v, registered providers = %v", ids, registered)
+	}
+}
+
+func TestProviderConstructorExceptionsDocumented(t *testing.T) {
+	content, err := os.ReadFile("../docs/ARCHITECTURE.md")
+	if err != nil {
+		t.Fatalf("read architecture docs: %v", err)
+	}
+	for _, signature := range []string{
+		"ollama.New(opts ...Option)",
+		"azurefoundry.New(endpoint, apiKey string, opts ...Option)",
+	} {
+		if !strings.Contains(string(content), signature) {
+			t.Errorf("constructor exception %q is not documented", signature)
+		}
+	}
+}
+
+func assertNewFromEnvSignature(t *testing.T, fn any) {
+	t.Helper()
+	typ := reflect.TypeOf(fn)
+	errorType := reflect.TypeOf((*error)(nil)).Elem()
+	if !typ.IsVariadic() || typ.NumIn() != 1 || !isOptionSlice(typ.In(0)) {
+		t.Errorf("NewFromEnv signature = %s, want func(...Option)", typ)
+	}
+	if typ.NumOut() != 2 || typ.Out(0).Kind() != reflect.Pointer || !typ.Out(1).Implements(errorType) {
+		t.Errorf("NewFromEnv returns = %s, want (*Provider, error)", typ)
+	}
+}
+
+func assertOptionSignature(t *testing.T, name string, fn any, stringInputs int) {
+	t.Helper()
+	typ := reflect.TypeOf(fn)
+	if typ.IsVariadic() || typ.NumIn() != stringInputs || typ.NumOut() != 1 || typ.Out(0).Kind() != reflect.Func {
+		t.Errorf("%s signature = %s, want %d string inputs and one Option output", name, typ, stringInputs)
+		return
+	}
+	for i := 0; i < stringInputs; i++ {
+		if typ.In(i).Kind() != reflect.String {
+			t.Errorf("%s input %d = %s, want string", name, i, typ.In(i))
+		}
+	}
+}
+
+func assertConstructorSignature(t *testing.T, fn any, shape constructorShape) {
+	t.Helper()
+	typ := reflect.TypeOf(fn)
+	wantInputs := map[constructorShape]int{standardConstructor: 2, ollamaConstructor: 1, azureConstructor: 3}[shape]
+	if !typ.IsVariadic() || typ.NumIn() != wantInputs || typ.NumOut() != 1 || typ.Out(0).Kind() != reflect.Pointer {
+		t.Errorf("constructor signature = %s, does not match documented %s shape", typ, shape)
+		return
+	}
+	for i := 0; i < wantInputs-1; i++ {
+		if typ.In(i).Kind() != reflect.String {
+			t.Errorf("constructor input %d = %s, want string", i, typ.In(i))
+		}
+	}
+	if !isOptionSlice(typ.In(wantInputs - 1)) {
+		t.Errorf("constructor variadic input = %s, want Option", typ.In(wantInputs-1))
+	}
+}
+
+func isOptionSlice(typ reflect.Type) bool {
+	return typ.Kind() == reflect.Slice && typ.Elem().Kind() == reflect.Func
+}


### PR DESCRIPTION
Closes #71.

## Summary

This standardizes the public provider construction surface while preserving existing Go callers. All ten built-in providers now expose `NewFromEnv`, `WithAPIKey`, `WithHeader`, and `DefaultAPIKeyEnvVar`, with the established Ollama and Azure AI Foundry constructor signatures retained as documented exceptions.

The provider registry now supports endpoint-aware construction through `ProviderConfig`, `RegisterConfigured`, and `CreateWithConfig`. The original `Register`, `Get`, and `Create` APIs remain source-compatible. The partial `providers` re-export layer is explicitly deprecated and frozen in favor of importing `core` directly.

## User impact and root cause

Provider packages had accumulated small API differences that made switching providers and writing shared setup code needlessly difficult. OpenAI lacked an API-key option, Ollama and Z.ai only accepted complete header maps, Ollama lacked the common environment factory, and the API-key-only registry could neither pass Azure its required endpoint nor preserve an Ollama cloud key.

These inconsistencies came from provider APIs evolving independently and from the registry assuming every provider could be constructed from one API-key string. The `providers` package also exposed a partial mirror of `core`, which could silently drift as the core API expanded.

## Implementation

- Add the missing OpenAI API-key option and additive Ollama/Z.ai header options.
- Add Ollama environment construction for local, remote, and cloud configurations, with explicit options taking precedence.
- Add canonical environment-variable aliases where providers only exposed provider-specific names.
- Add endpoint-aware registry configuration while adapting all legacy registry entry points.
- Preserve optional Ollama credentials and pass Azure endpoints explicitly or through the legacy environment fallback.
- Deprecate and freeze the partial core re-export layer without removing existing aliases.
- Add an API conformance test that covers every registered built-in provider and verifies the documented constructor exceptions.
- Document the API policy, compatibility choices, usage examples, and deferred work.

## Validation

- `go test ./...`
- `go test -race ./providers ./providers/openai ./providers/ollama ./providers/zai ./providers/azurefoundry ./tests`
- `go vet ./...`
- `go build ./...`
- `gofmt -d` on all changed Go files
- `git diff --check`

Affected-package statement coverage is 100.0% for `providers`, 80.4% for OpenAI, 93.0% for Ollama, 82.6% for Z.ai, and 80.8% for Azure AI Foundry.
