### PR TITLE
[codex] preserve testing provider capabilities

### DIFF
--- a/core/batch.go
+++ b/core/batch.go
@@ -63,9 +63,8 @@ type BatchProvider interface {
 	ListBatches(ctx context.Context, limit int) ([]BatchInfo, error)
 }
 
-// AsBatchProvider attempts to cast a Provider to BatchProvider.
-// Returns the BatchProvider and true if the provider supports batch operations,
-// or nil and false otherwise.
+// AsBatchProvider discovers batch operations on a Provider or its unwrap chain.
+// It returns nil and false when no provider implements batch operations.
 //
 // Example:
 //
@@ -74,8 +73,7 @@ type BatchProvider interface {
 //	    // ...
 //	}
 func AsBatchProvider(p Provider) (BatchProvider, bool) {
-	bp, ok := p.(BatchProvider)
-	return bp, ok
+	return asProviderCapability[BatchProvider](p)
 }
 
 // BatchWaiter provides utilities for waiting on batch completion.

--- a/core/client.go
+++ b/core/client.go
@@ -46,11 +46,10 @@ type ImageGenerator interface {
 	StreamImage(ctx context.Context, req *ImageGenerateRequest) (*ImageStream, error)
 }
 
-// AsImageGenerator attempts to cast a Provider to ImageGenerator. It returns
-// nil and false when the provider does not implement image operations.
+// AsImageGenerator discovers image operations on a Provider or its unwrap
+// chain. It returns nil and false when no provider implements them.
 func AsImageGenerator(p Provider) (ImageGenerator, bool) {
-	generator, ok := p.(ImageGenerator)
-	return generator, ok
+	return asProviderCapability[ImageGenerator](p)
 }
 
 // Client is the main entry point for interacting with LLM providers.

--- a/core/content.go
+++ b/core/content.go
@@ -16,11 +16,10 @@ type ContentPartSupporter interface {
 	SupportsContentPart(model ModelID, role Role, part ContentPart) bool
 }
 
-// AsContentPartSupporter attempts to cast a Provider to ContentPartSupporter.
-// It returns nil and false when the provider does not declare per-part support.
+// AsContentPartSupporter discovers per-part support on a Provider or its unwrap
+// chain. It returns nil and false when no provider declares that support.
 func AsContentPartSupporter(p Provider) (ContentPartSupporter, bool) {
-	supporter, ok := p.(ContentPartSupporter)
-	return supporter, ok
+	return asProviderCapability[ContentPartSupporter](p)
 }
 
 // ImageDetail specifies the level of detail for image processing.

--- a/core/contextualized_embeddings.go
+++ b/core/contextualized_embeddings.go
@@ -11,12 +11,11 @@ type ContextualizedEmbeddingProvider interface {
 	CreateContextualizedEmbeddings(ctx context.Context, req *ContextualizedEmbeddingRequest) (*ContextualizedEmbeddingResponse, error)
 }
 
-// AsContextualizedEmbeddingProvider attempts to cast a Provider to
-// ContextualizedEmbeddingProvider. It returns nil and false when the provider
-// does not implement contextualized embeddings.
+// AsContextualizedEmbeddingProvider discovers contextualized embeddings on a
+// Provider or its unwrap chain. It returns nil and false when no provider
+// implements contextualized embeddings.
 func AsContextualizedEmbeddingProvider(p Provider) (ContextualizedEmbeddingProvider, bool) {
-	embedder, ok := p.(ContextualizedEmbeddingProvider)
-	return embedder, ok
+	return asProviderCapability[ContextualizedEmbeddingProvider](p)
 }
 
 // ContextualizedEmbeddingRequest represents a request to generate contextualized embeddings.

--- a/core/embeddings.go
+++ b/core/embeddings.go
@@ -92,11 +92,10 @@ type EmbeddingProvider interface {
 	CreateEmbeddings(ctx context.Context, req *EmbeddingRequest) (*EmbeddingResponse, error)
 }
 
-// AsEmbeddingProvider attempts to cast a Provider to EmbeddingProvider.
-// It returns nil and false when the provider does not implement embeddings.
+// AsEmbeddingProvider discovers embeddings on a Provider or its unwrap chain.
+// It returns nil and false when no provider implements embeddings.
 func AsEmbeddingProvider(p Provider) (EmbeddingProvider, bool) {
-	embedder, ok := p.(EmbeddingProvider)
-	return embedder, ok
+	return asProviderCapability[EmbeddingProvider](p)
 }
 
 // Embed generates embeddings through the client's provider. It applies the

--- a/core/provider_unwrap.go
+++ b/core/provider_unwrap.go
@@ -1,0 +1,28 @@
+package core
+
+const maxProviderUnwrapDepth = 64
+
+// ProviderUnwrapper is implemented by provider decorators that expose the
+// provider they wrap. Capability helpers follow this chain so optional
+// interfaces remain discoverable through decorators.
+type ProviderUnwrapper interface {
+	Unwrap() Provider
+}
+
+func asProviderCapability[T any](provider Provider) (T, bool) {
+	var zero T
+	for range maxProviderUnwrapDepth {
+		if provider == nil {
+			return zero, false
+		}
+		if capability, ok := any(provider).(T); ok {
+			return capability, true
+		}
+		unwrapper, ok := provider.(ProviderUnwrapper)
+		if !ok {
+			return zero, false
+		}
+		provider = unwrapper.Unwrap()
+	}
+	return zero, false
+}

--- a/core/provider_unwrap_test.go
+++ b/core/provider_unwrap_test.go
@@ -1,0 +1,60 @@
+package core
+
+import (
+	"context"
+	"testing"
+)
+
+type unwrapTestEmbedder struct {
+	Provider
+}
+
+func (p *unwrapTestEmbedder) CreateEmbeddings(context.Context, *EmbeddingRequest) (*EmbeddingResponse, error) {
+	return &EmbeddingResponse{Model: "unwrapped"}, nil
+}
+
+type unwrapTestWrapper struct {
+	Provider
+}
+
+func (w *unwrapTestWrapper) Unwrap() Provider {
+	return w.Provider
+}
+
+type cyclicUnwrapTestWrapper struct {
+	Provider
+}
+
+func (w *cyclicUnwrapTestWrapper) Unwrap() Provider {
+	return w
+}
+
+func TestAsProviderCapabilityFollowsNestedUnwrapChain(t *testing.T) {
+	embedder := &unwrapTestEmbedder{}
+	wrapped := &unwrapTestWrapper{Provider: &unwrapTestWrapper{Provider: embedder}}
+
+	got, ok := AsEmbeddingProvider(wrapped)
+	if !ok || got != embedder {
+		t.Fatalf("AsEmbeddingProvider() = (%v, %v), want underlying embedder", got, ok)
+	}
+	response, err := got.CreateEmbeddings(context.Background(), &EmbeddingRequest{})
+	if err != nil || response.Model != "unwrapped" {
+		t.Fatalf("unwrapped CreateEmbeddings() = (%v, %v), want usable capability", response, err)
+	}
+}
+
+func TestAsProviderCapabilityHandlesInvalidUnwrapChains(t *testing.T) {
+	tests := map[string]Provider{
+		"nil provider": nil,
+		"nil unwrap":   &unwrapTestWrapper{},
+		"cycle":        &cyclicUnwrapTestWrapper{},
+	}
+	for name, provider := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, ok := AsEmbeddingProvider(provider)
+			if ok || got != nil {
+				t.Errorf("AsEmbeddingProvider() = (%v, %v), want (nil, false)", got, ok)
+			}
+		})
+	}
+}

--- a/core/reranker.go
+++ b/core/reranker.go
@@ -10,11 +10,10 @@ type RerankerProvider interface {
 	Rerank(ctx context.Context, req *RerankRequest) (*RerankResponse, error)
 }
 
-// AsReranker attempts to cast a Provider to RerankerProvider. It returns nil
-// and false when the provider does not implement reranking.
+// AsReranker discovers reranking on a Provider or its unwrap chain. It returns
+// nil and false when no provider implements reranking.
 func AsReranker(p Provider) (RerankerProvider, bool) {
-	reranker, ok := p.(RerankerProvider)
-	return reranker, ok
+	return asProviderCapability[RerankerProvider](p)
 }
 
 // RerankRequest represents a request to rerank documents.

--- a/core/token_counting.go
+++ b/core/token_counting.go
@@ -16,9 +16,8 @@ type TokenCounter interface {
 	CountTokens(ctx context.Context, req *ChatRequest) (*TokenCountResponse, error)
 }
 
-// AsTokenCounter attempts to cast a Provider to TokenCounter. It returns nil
-// and false when the provider does not implement native token counting.
+// AsTokenCounter discovers token counting on a Provider or its unwrap chain.
+// It returns nil and false when no provider implements native token counting.
 func AsTokenCounter(p Provider) (TokenCounter, bool) {
-	counter, ok := p.(TokenCounter)
-	return counter, ok
+	return asProviderCapability[TokenCounter](p)
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -123,6 +123,12 @@ discovery has two complementary layers:
 2. `core.As*` helpers answer whether the concrete provider exposes the Go
    operation needed to call that capability.
 
+Provider decorators can implement `core.ProviderUnwrapper` with
+`Unwrap() core.Provider`. Every `core.As*` helper follows nested unwrap chains,
+so decorators such as `testing.RecordingProvider` preserve optional capability
+discovery without falsely implementing capabilities that the wrapped provider
+does not support. Invalid, nil, or cyclic chains safely return `(nil, false)`.
+
 Use the helper before calling a raw optional interface:
 
 ```go

--- a/docs/changes/2026-08-28_v0.0.0-dev_issue-72-testing-provider-capabilities.md
+++ b/docs/changes/2026-08-28_v0.0.0-dev_issue-72-testing-provider-capabilities.md
@@ -1,0 +1,84 @@
+---
+date: 2026-08-28
+version: v0.0.0-dev
+feature: Testing provider capability preservation
+product: iris
+change_type: api
+affected_components: [core/provider_unwrap.go, core/provider_unwrap_test.go, core/client.go, core/embeddings.go, core/content.go, core/batch.go, core/contextualized_embeddings.go, core/reranker.go, core/token_counting.go, testing/recording_provider.go, testing/mock_provider.go, testing/recording_provider_test.go, testing/mock_provider_test.go, docs/ARCHITECTURE.md, docs/guides/testing.md, testing/doc.go]
+related_frds: []
+---
+
+## Summary
+
+Issue #72 closes two testing-utility gaps. `RecordingProvider` now preserves discovery of every optional provider interface through a general `core.ProviderUnwrapper` convention, and a bare `MockProvider` advertises a chat-focused baseline that passes structured-output and web-search capability gates. Stream recordings are explicitly tested and documented to retain a cloned request even though their asynchronous response remains on `ChatStream`.
+
+## Motivation
+
+Wrapping a provider in `RecordingProvider` previously hid capabilities such as embeddings, batch operations, image generation, contextualized embeddings, reranking, token counting, and content-part support from the `core.As*` helpers. Users had to know about `Underlying()` and manually unwrap the recorder. Implementing every optional method on the recorder would be incorrect because Go interface satisfaction is static: it would make a recorder around an unsupported provider appear to support every operation.
+
+`MockProvider` also initialized `Supports` with an empty feature map while its default model advertised chat capabilities. Schema-based structured-output requests and requests with search options therefore failed in `ChatBuilder.validate` before reaching the mock, which made ordinary builder tests require unrelated setup.
+
+## What Changed
+
+### Provider unwrapping
+
+- Added `core.ProviderUnwrapper` with `Unwrap() core.Provider` for provider decorators.
+- Added bounded, nested unwrap traversal shared by all seven optional capability helpers:
+  - `AsBatchProvider`
+  - `AsContentPartSupporter`
+  - `AsContextualizedEmbeddingProvider`
+  - `AsEmbeddingProvider`
+  - `AsImageGenerator`
+  - `AsReranker`
+  - `AsTokenCounter`
+- `RecordingProvider.Unwrap` returns the wrapped provider. Existing `Underlying` remains available.
+- Direct capabilities on the outer provider take precedence. Nil, unsupported, or cyclic unwrap chains return `(nil, false)` after bounded traversal.
+
+### Mock capability defaults
+
+A new mock starts with the capabilities its generic chat implementation can exercise:
+
+```go
+core.FeatureChat
+core.FeatureChatStreaming
+core.FeatureToolCalling
+core.FeatureStructuredOutput
+core.FeatureWebSearch
+```
+
+The default `mock-model` advertises the same set, allowing both provider-level and model-level builder checks to pass. The first `WithFeatures(...)` call replaces this baseline so tests can model a limited provider. Additional chained calls continue adding features, preserving the previous additive chaining behavior. Calling `WithFeatures()` with no arguments disables all features.
+
+### Stream recording
+
+`RecordingProvider.StreamChat` already records before returning the stream. Its contract is now covered explicitly: the recording contains a cloned request, method, timing, and immediate error; `Response` remains nil because the final response is delivered asynchronously through the returned `ChatStream`.
+
+## Usage
+
+```go
+recorder := iristesting.NewRecordingProvider(openai.New(apiKey))
+
+embedder, ok := core.AsEmbeddingProvider(recorder)
+if !ok {
+    return core.ErrNotSupported
+}
+response, err := embedder.CreateEmbeddings(ctx, request)
+```
+
+To test a capability rejection:
+
+```go
+mock := iristesting.NewMockProvider().WithFeatures(core.FeatureChat)
+```
+
+## Compatibility
+
+The new interface and unwrap behavior are additive. `RecordingProvider.Underlying` remains source-compatible. Existing code that calls `WithFeatures` keeps its previous configured feature set: the first call now clears only the newly introduced defaults, and later calls remain additive.
+
+The only default behavior change is intentional: a bare mock now reports its chat-focused baseline instead of reporting every feature as unsupported.
+
+## Testing Notes
+
+- Tests cover all seven optional interfaces through real built-in providers, including nested recording wrappers and unsupported capabilities.
+- Core tests cover usable nested discovery plus nil and cyclic unwrap chains.
+- Mock tests cover default support, explicit narrowing, additive chaining, structured-output validation, and web-search validation.
+- Stream tests verify cloned request capture in addition to method and response semantics.

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -3,8 +3,6 @@
 The `testing` package provides deterministic stand-ins for real providers so
 your tests never make network calls.
 
-The `testing` package provides utilities for deterministic tests:
-
 ```go
 import "github.com/petal-labs/iris/testing"
 
@@ -17,6 +15,11 @@ client := core.NewClient(mock)
 resp, _ := client.Chat("any-model").User("Hi").GetResponse(ctx)
 // resp.Output == "Hello!"
 
+// Bare mocks support chat-builder features, including JSON schema and search.
+// The first WithFeatures call replaces those defaults when a test needs to
+// model an unsupported capability.
+limitedMock := testing.NewMockProvider().WithFeatures(core.FeatureChat)
+
 // RecordingProvider for capturing interactions
 recorder := testing.NewRecordingProvider(realProvider)
 client := core.NewClient(recorder)
@@ -27,7 +30,17 @@ client := core.NewClient(recorder)
 for _, call := range recorder.Recordings() {
     fmt.Printf("Model: %s, Messages: %d\n", call.Request.Model, len(call.Request.Messages))
 }
+
+// Optional interfaces remain available through the core discovery helpers.
+embedder, ok := core.AsEmbeddingProvider(recorder)
 ```
+
+`RecordingProvider` records both unary and stream requests. Streaming records
+keep the cloned request and timing/error metadata; their `Response` field is
+nil because the response is delivered asynchronously through `ChatStream`.
+The recorder implements `core.ProviderUnwrapper`, and all `core.As*` helpers
+follow nested wrappers while preserving a clean `(nil, false)` result for
+unsupported capabilities.
 
 ---
 

--- a/testing/doc.go
+++ b/testing/doc.go
@@ -19,6 +19,11 @@
 //	// Second call returns "How can I help?"
 //	resp, _ = client.Chat("gpt-4o").User("What's up?").GetResponse(ctx)
 //
+// A bare mock advertises chat, streaming, tool calling, structured output, and
+// web search so chat-builder capability gates do not obstruct ordinary tests.
+// The first WithFeatures call replaces those defaults; later calls add to the
+// customized set.
+//
 // # Error Simulation
 //
 // Queue errors to test error handling:
@@ -63,4 +68,7 @@
 //
 //	// Save recordings for later replay
 //	recordings := recorder.Recordings()
+//
+// RecordingProvider implements core.ProviderUnwrapper, so optional operations
+// remain discoverable through helpers such as core.AsEmbeddingProvider.
 package testing

--- a/testing/mock_provider.go
+++ b/testing/mock_provider.go
@@ -27,9 +27,10 @@ type MockStreamConfig struct {
 type MockProvider struct {
 	mu sync.Mutex
 
-	id       string
-	models   []core.ModelInfo
-	features map[core.Feature]bool
+	id                 string
+	models             []core.ModelInfo
+	features           map[core.Feature]bool
+	featuresCustomized bool
 
 	// Response queue (responses are consumed in order)
 	responses []core.ChatResponse
@@ -54,19 +55,16 @@ type MockProvider struct {
 // NewMockProvider creates a mock provider with optional canned responses.
 // Responses are returned in order; after exhaustion, a default response is used.
 func NewMockProvider(responses ...core.ChatResponse) *MockProvider {
+	defaultFeatures := defaultMockFeatures()
 	return &MockProvider{
 		id:        "mock",
-		features:  make(map[core.Feature]bool),
+		features:  featureSet(defaultFeatures),
 		responses: responses,
 		models: []core.ModelInfo{
 			{
-				ID:          "mock-model",
-				DisplayName: "Mock Model",
-				Capabilities: []core.Feature{
-					core.FeatureChat,
-					core.FeatureChatStreaming,
-					core.FeatureToolCalling,
-				},
+				ID:           "mock-model",
+				DisplayName:  "Mock Model",
+				Capabilities: defaultFeatures,
 			},
 		},
 		defaultResponse: &core.ChatResponse{
@@ -75,6 +73,24 @@ func NewMockProvider(responses ...core.ChatResponse) *MockProvider {
 			Output: "mock response",
 		},
 	}
+}
+
+func defaultMockFeatures() []core.Feature {
+	return []core.Feature{
+		core.FeatureChat,
+		core.FeatureChatStreaming,
+		core.FeatureToolCalling,
+		core.FeatureStructuredOutput,
+		core.FeatureWebSearch,
+	}
+}
+
+func featureSet(features []core.Feature) map[core.Feature]bool {
+	result := make(map[core.Feature]bool, len(features))
+	for _, feature := range features {
+		result[feature] = true
+	}
+	return result
 }
 
 // WithID sets the provider ID.
@@ -93,12 +109,18 @@ func (m *MockProvider) WithModels(models ...core.ModelInfo) *MockProvider {
 	return m
 }
 
-// WithFeatures sets the supported features.
+// WithFeatures customizes the supported feature set. The first call replaces
+// the defaults; later calls add features, preserving the existing chaining
+// behavior. Call WithFeatures() without arguments to disable all features.
 func (m *MockProvider) WithFeatures(features ...core.Feature) *MockProvider {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for _, f := range features {
-		m.features[f] = true
+	if !m.featuresCustomized {
+		m.features = make(map[core.Feature]bool, len(features))
+		m.featuresCustomized = true
+	}
+	for _, feature := range features {
+		m.features[feature] = true
 	}
 	return m
 }

--- a/testing/mock_provider_test.go
+++ b/testing/mock_provider_test.go
@@ -43,19 +43,51 @@ func TestMockProvider_Models(t *testing.T) {
 
 func TestMockProvider_Supports(t *testing.T) {
 	provider := NewMockProvider()
-	if provider.Supports(core.FeatureChat) {
-		t.Error("Supports(FeatureChat) = true, want false (no features set)")
+	for _, feature := range []core.Feature{
+		core.FeatureChat,
+		core.FeatureChatStreaming,
+		core.FeatureToolCalling,
+		core.FeatureStructuredOutput,
+		core.FeatureWebSearch,
+	} {
+		if !provider.Supports(feature) {
+			t.Errorf("Supports(%s) = false, want true by default", feature)
+		}
 	}
 
-	provider.WithFeatures(core.FeatureChat, core.FeatureToolCalling)
+	provider.WithFeatures(core.FeatureChat)
 	if !provider.Supports(core.FeatureChat) {
 		t.Error("Supports(FeatureChat) = false, want true")
 	}
-	if !provider.Supports(core.FeatureToolCalling) {
-		t.Error("Supports(FeatureToolCalling) = false, want true")
+	if provider.Supports(core.FeatureStructuredOutput) {
+		t.Error("WithFeatures should replace the default feature set")
 	}
-	if provider.Supports(core.FeatureReasoning) {
-		t.Error("Supports(FeatureReasoning) = true, want false")
+	provider.WithFeatures(core.FeatureToolCalling)
+	if !provider.Supports(core.FeatureChat) || !provider.Supports(core.FeatureToolCalling) {
+		t.Error("subsequent WithFeatures calls should preserve additive chaining")
+	}
+}
+
+func TestMockProvider_BareMockPassesBuilderCapabilityGates(t *testing.T) {
+	provider := NewMockProvider()
+	client := core.NewClient(provider)
+	schema := &core.JSONSchemaDefinition{
+		Name:   "result",
+		Schema: []byte(`{"type":"object"}`),
+	}
+
+	if _, err := client.Chat("mock-model").
+		User("return JSON").
+		ResponseJSONSchemaNonStrict(schema).
+		GetResponse(context.Background()); err != nil {
+		t.Fatalf("bare mock structured-output request failed: %v", err)
+	}
+
+	if _, err := client.Chat("mock-model").
+		User("search").
+		SearchOptions(&core.SearchOptions{}).
+		GetResponse(context.Background()); err != nil {
+		t.Fatalf("bare mock web-search request failed: %v", err)
 	}
 }
 

--- a/testing/recording_provider.go
+++ b/testing/recording_provider.go
@@ -128,6 +128,11 @@ func (r *RecordingProvider) Clear() {
 	r.recordings = nil
 }
 
+// Unwrap returns the wrapped provider for core capability discovery.
+func (r *RecordingProvider) Unwrap() core.Provider {
+	return r.underlying
+}
+
 // Underlying returns the wrapped provider.
 func (r *RecordingProvider) Underlying() core.Provider {
 	return r.underlying
@@ -135,3 +140,6 @@ func (r *RecordingProvider) Underlying() core.Provider {
 
 // Compile-time verification that RecordingProvider implements Provider.
 var _ core.Provider = (*RecordingProvider)(nil)
+
+// Compile-time verification that optional capabilities can be unwrapped.
+var _ core.ProviderUnwrapper = (*RecordingProvider)(nil)

--- a/testing/recording_provider_test.go
+++ b/testing/recording_provider_test.go
@@ -7,6 +7,9 @@ import (
 	"time"
 
 	"github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/anthropic"
+	"github.com/petal-labs/iris/providers/openai"
+	"github.com/petal-labs/iris/providers/voyageai"
 )
 
 func TestRecordingProvider_DelegatesID(t *testing.T) {
@@ -143,11 +146,16 @@ func TestRecordingProvider_StreamChat_RecordsCall(t *testing.T) {
 	mock := NewMockProvider().
 		WithStreamingResponse([]string{"Hello"}, nil)
 	recorder := NewRecordingProvider(mock)
+	req := &core.ChatRequest{
+		Model:    "test",
+		Messages: []core.Message{{Role: core.RoleUser, Content: "stream me"}},
+	}
 
-	stream, err := recorder.StreamChat(ctx, &core.ChatRequest{Model: "test"})
+	stream, err := recorder.StreamChat(ctx, req)
 	if err != nil {
 		t.Fatalf("StreamChat() error = %v", err)
 	}
+	req.Model = "mutated-after-call"
 
 	// Drain stream
 	for range stream.Ch {
@@ -162,6 +170,9 @@ func TestRecordingProvider_StreamChat_RecordsCall(t *testing.T) {
 	rec := recordings[0]
 	if rec.Method != "StreamChat" {
 		t.Errorf("Recording.Method = %q, want %q", rec.Method, "StreamChat")
+	}
+	if rec.Request == nil || rec.Request.Model != "test" || rec.Request.Messages[0].Content != "stream me" {
+		t.Errorf("Recording.Request = %#v, want cloned stream request", rec.Request)
 	}
 	// Response should be nil for streaming (captured separately)
 	if rec.Response != nil {
@@ -235,6 +246,60 @@ func TestRecordingProvider_Underlying(t *testing.T) {
 	if recorder.Underlying() != mock {
 		t.Error("Underlying() did not return the wrapped provider")
 	}
+	if recorder.Unwrap() != mock {
+		t.Error("Unwrap() did not return the wrapped provider")
+	}
+}
+
+func TestRecordingProvider_PreservesOptionalInterfaces(t *testing.T) {
+	t.Run("OpenAI capabilities", func(t *testing.T) {
+		provider := openai.New("test-key")
+		recorder := NewRecordingProvider(provider)
+
+		if got, ok := core.AsContentPartSupporter(recorder); !ok || got != provider {
+			t.Error("AsContentPartSupporter() did not unwrap the recording provider")
+		}
+		if got, ok := core.AsEmbeddingProvider(recorder); !ok || got != provider {
+			t.Error("AsEmbeddingProvider() did not unwrap the recording provider")
+		}
+		if got, ok := core.AsImageGenerator(recorder); !ok || got != provider {
+			t.Error("AsImageGenerator() did not unwrap the recording provider")
+		}
+		if got, ok := core.AsBatchProvider(recorder); !ok || got != provider {
+			t.Error("AsBatchProvider() did not unwrap the recording provider")
+		}
+	})
+
+	t.Run("Voyage AI capabilities through nested recorders", func(t *testing.T) {
+		provider := voyageai.New("test-key")
+		recorder := NewRecordingProvider(NewRecordingProvider(provider))
+
+		if got, ok := core.AsEmbeddingProvider(recorder); !ok || got != provider {
+			t.Error("AsEmbeddingProvider() did not unwrap nested recording providers")
+		}
+		if got, ok := core.AsContextualizedEmbeddingProvider(recorder); !ok || got != provider {
+			t.Error("AsContextualizedEmbeddingProvider() did not unwrap nested recording providers")
+		}
+		if got, ok := core.AsReranker(recorder); !ok || got != provider {
+			t.Error("AsReranker() did not unwrap nested recording providers")
+		}
+	})
+
+	t.Run("Anthropic token counting", func(t *testing.T) {
+		provider := anthropic.New("test-key")
+		recorder := NewRecordingProvider(provider)
+
+		if got, ok := core.AsTokenCounter(recorder); !ok || got != provider {
+			t.Error("AsTokenCounter() did not unwrap the recording provider")
+		}
+	})
+
+	t.Run("unsupported capability stays unsupported", func(t *testing.T) {
+		recorder := NewRecordingProvider(NewMockProvider())
+		if got, ok := core.AsEmbeddingProvider(recorder); ok || got != nil {
+			t.Errorf("AsEmbeddingProvider() = (%v, %v), want (nil, false)", got, ok)
+		}
+	})
 }
 
 func TestRecordingProvider_ConcurrentAccess(t *testing.T) {


### PR DESCRIPTION
Closes #72.

## Summary

This fixes capability loss in `testing.RecordingProvider`, gives `MockProvider` practical chat-focused capability defaults, and explicitly verifies that stream calls retain cloned requests in recordings.

Provider decorators can now implement `core.ProviderUnwrapper`. Every existing `core.As*` optional-capability helper follows bounded nested unwrap chains, so recording a provider preserves embeddings, batch operations, image generation, contextualized embeddings, reranking, token counting, and content-part support without making unsupported providers appear to implement those interfaces.

## User impact and root cause

`RecordingProvider` previously exposed only the required `core.Provider` methods. Because Go interface satisfaction is static, wrapping OpenAI or Voyage AI hid their optional interfaces from capability discovery. Callers had to know about `Underlying()` and manually unwrap the recorder. Adding every optional method directly to the recorder would create the opposite bug: every recorder would claim every capability regardless of its underlying provider.

A new `MockProvider` also started with an empty `Supports` map even though its default model advertised chat functionality. Requests using JSON schemas or search options therefore failed `ChatBuilder` capability validation before reaching the mock, making normal builder tests require unrelated feature setup.

## Implementation

- Add `core.ProviderUnwrapper` with `Unwrap() core.Provider`.
- Route all seven `core.As*` helpers through a bounded unwrap-aware capability lookup.
- Add `RecordingProvider.Unwrap()` while retaining `Underlying()` for compatibility.
- Preserve direct outer capabilities, nested wrappers, and correct false results for nil, unsupported, or cyclic chains.
- Give bare mocks chat, streaming, tool-calling, structured-output, and web-search support at both provider and default-model levels.
- Make the first `WithFeatures` call replace those defaults while preserving additive behavior for later chained calls.
- Strengthen stream recording coverage to verify request cloning and asynchronous response semantics.
- Document the public wrapper convention, mock defaults, compatibility behavior, and usage.

## Validation

- `go test ./...`
- `go test -race ./core ./testing ./tests`
- `go vet ./...`
- `go build ./...`
- `gofmt -d` on all changed Go files
- `git diff --check`

Statement coverage is 90.9% for `core` and 87.3% for `testing`.
