### PR TITLE
[codex] test contrib/otel in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,15 @@ jobs:
           cache: true
 
       - name: Build
-        run: go build ./...
+        run: go build ./... ./contrib/otel/...
 
       - name: Test
         if: matrix.os != 'ubuntu-latest'
-        run: go test ./...
+        run: go test ./... ./contrib/otel/...
 
       - name: Test with coverage
         if: matrix.os == 'ubuntu-latest'
-        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+        run: go test -race -coverprofile=coverage.out -covermode=atomic ./... ./contrib/otel/...
 
       - name: Upload coverage artifact
         if: matrix.os == 'ubuntu-latest'
@@ -51,7 +51,7 @@ jobs:
           verbose: true
 
       - name: Vet
-        run: go vet ./...
+        run: go vet ./... ./contrib/otel/...
 
       - name: Format check
         shell: bash

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -160,17 +160,29 @@ This prevents CI failures due to formatting issues.
 
 ## Module Structure
 
-Iris uses a Go workspace with two modules:
+Iris uses a Go workspace with three modules:
 
 ```
 iris/
-├── go.mod        # Main SDK module (github.com/petal-labs/iris)
-├── go.work       # Workspace file for local development
+├── go.mod             # Main SDK module (github.com/petal-labs/iris)
+├── go.work            # Workspace file for local development
+├── contrib/otel/
+│   └── go.mod         # OpenTelemetry integration module
 └── examples/
-    └── go.mod    # Examples module (github.com/petal-labs/iris/examples)
+    └── go.mod         # Examples module (github.com/petal-labs/iris/examples)
 ```
 
-The workspace allows you to develop on both modules simultaneously. When you run `go build ./...` or `go test ./...` from the root, it builds/tests both modules.
+The workspace keeps local imports pointed at the current SDK checkout. Go's
+`./...` pattern does not cross nested module boundaries, so include nested
+modules explicitly when validating them. CI uses:
+
+```bash
+go build ./... ./contrib/otel/...
+go test ./... ./contrib/otel/...
+```
+
+This ensures changes to interfaces such as `core.TelemetryHook` are compiled
+against the OpenTelemetry integration on every pull request.
 
 **Importing the SDK:**
 

--- a/docs/changes/2026-08-28_v0.0.0-dev_issue-73-contrib-otel-ci.md
+++ b/docs/changes/2026-08-28_v0.0.0-dev_issue-73-contrib-otel-ci.md
@@ -1,0 +1,53 @@
+---
+date: 2026-08-28
+version: v0.0.0-dev
+feature: OpenTelemetry contrib module CI coverage
+product: iris
+change_type: infrastructure
+affected_components: [go.work, .github/workflows/ci.yml, tests/repository_ci_test.go, docs/DEVELOPMENT.md]
+related_frds: []
+---
+
+## Summary
+
+Issue #73 adds the standalone `contrib/otel` module to the repository's Go workspace and explicitly compiles, tests, race-checks, measures, and vets it in the cross-platform CI matrix. A repository-level guard test prevents future changes from silently removing the module from either `go.work` or the CI build/test commands.
+
+## Motivation
+
+`contrib/otel` has its own `go.mod`, so root package patterns do not descend into it. The module was also absent from `go.work`, while CI only ran `go build ./...`, `go test ./...`, and `go vet ./...` from the root module. As a result, its compile-time assertions for `core.TelemetryHook` and `core.ContextualTelemetryHook` were never exercised by pull requests. A breaking core telemetry change could merge successfully and leave the published OpenTelemetry integration uncompilable.
+
+## What Changed
+
+- Added `./contrib/otel` to the `go.work` use list.
+- Extended the CI matrix commands with the explicit `./contrib/otel/...` package pattern:
+  - build on Linux, macOS, and Windows;
+  - standard tests on macOS and Windows;
+  - race-enabled tests and coverage on Linux;
+  - vet on all three operating systems.
+- Added `TestContribOtelIsCoveredByWorkspaceAndCI`, which fails if the workspace entry or explicit CI build/test command disappears.
+- Corrected the development guide's module count and documented why nested modules require explicit package patterns.
+
+## Technical Notes
+
+The existing OTel hook already contains compile-time interface assertions:
+
+```go
+var (
+    _ core.TelemetryHook           = (*Hook)(nil)
+    _ core.ContextualTelemetryHook = (*Hook)(nil)
+)
+```
+
+Running the nested module in CI therefore makes an incompatible change to either core interface fail during every pull request build or test.
+
+Coverage remains in the existing `coverage.out` artifact because the Linux command tests the root and OTel package patterns together with one `-coverprofile` flag.
+
+## Compatibility
+
+There are no runtime or public API changes. The OTel module remains independently versioned with its existing `go.mod` and replace directive; `go.work` only controls development and CI resolution inside this repository checkout.
+
+## Testing Notes
+
+- The repository guard test was added first and failed for the missing workspace, build, and test entries.
+- Focused validation runs the guard and `go test ./contrib/otel/...`.
+- Final verification mirrors the CI build, test, race/coverage, and vet commands across both package patterns.

--- a/go.work
+++ b/go.work
@@ -2,5 +2,6 @@ go 1.24.0
 
 use (
 	.
+	./contrib/otel
 	./examples
 )

--- a/tests/repository_ci_test.go
+++ b/tests/repository_ci_test.go
@@ -1,0 +1,48 @@
+package tests
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestContribOtelIsCoveredByWorkspaceAndCI(t *testing.T) {
+	workspace := readRepositoryFile(t, "go.work")
+	if !containsTrimmedLine(workspace, "./contrib/otel") {
+		t.Error("go.work must include ./contrib/otel")
+	}
+
+	workflow := readRepositoryFile(t, ".github/workflows/ci.yml")
+	for _, command := range []string{"go build", "go test"} {
+		if !containsCommandForModule(workflow, command, "./contrib/otel/...") {
+			t.Errorf("CI must run %q for ./contrib/otel/...", command)
+		}
+	}
+}
+
+func readRepositoryFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile("../" + path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(content)
+}
+
+func containsTrimmedLine(content, want string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsCommandForModule(content, command, module string) bool {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, command) && strings.Contains(line, module) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #73.

## Summary

This adds the standalone `contrib/otel` module to the Go workspace and explicitly includes it in every cross-platform CI build, test, race/coverage, and vet command. A repository-level regression test now prevents the workspace or CI coverage from silently dropping the module again.

## User impact and root cause

`contrib/otel` has its own `go.mod`, and Go package patterns do not cross nested module boundaries. The root workflow previously ran only `go build ./...`, `go test ./...`, and `go vet ./...`, while `go.work` omitted the OTel module entirely. Consequently, pull requests never compiled or tested the integration against the current SDK.

The hook already has compile-time assertions for `core.TelemetryHook` and `core.ContextualTelemetryHook`, but those assertions were ineffective in CI because the package containing them was never loaded. A breaking telemetry-interface change could therefore merge while leaving the published integration uncompilable.

## Implementation

- Add `./contrib/otel` to the `go.work` use list.
- Include `./contrib/otel/...` alongside the root package pattern for CI build, standard test, Linux race/coverage, and vet commands.
- Preserve the existing single `coverage.out` artifact by testing both package patterns in one Linux coverage invocation.
- Add `TestContribOtelIsCoveredByWorkspaceAndCI` to enforce the workspace entry and explicit CI build/test commands.
- Correct the development guide's workspace module count and explain nested-module package-pattern behavior.
- Add the required change record with compatibility and validation details.

## Validation

- `go build ./... ./contrib/otel/...`
- `go test ./... ./contrib/otel/...`
- `go test -race -coverprofile=/private/tmp/iris-issue-73-coverage.out -covermode=atomic ./... ./contrib/otel/...`
- `go vet ./... ./contrib/otel/...`
- `gofmt -l .`
- `git diff --check`

The OTel module passes with 97.1% statement coverage. Its compile-time telemetry-interface assertions are now exercised by every pull request.
