### PR TITLE
[codex] improve repository hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,6 @@ profile.cov
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-# Go workspace sum file (generated)
-go.work.sum
-
 # env file
 .env
 
@@ -38,4 +35,4 @@ go.work.sum
 CLAUDE.md
 
 # misc
-.DS_STORE
+.DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,10 +79,84 @@ In CI, integration tests fail on missing required keys unless `IRIS_SKIP_INTEGRA
 - Prefer small, composable functions over large control blocks.
 - Add tests for behavior changes and regressions.
 
+## Change Documentation
+
+Every repository change must create or update one change record under
+`docs/changes/`. These files feed the automated documentation pipeline and are
+part of the implementation, not an optional follow-up.
+
+Use this filename convention:
+
+```text
+docs/changes/YYYY-MM-DD_v{version}_{feature-slug}.md
+```
+
+- Use the current UTC date.
+- Use the semantic version declared by the nearest module or `VERSION` file;
+  use `v0.0.0-dev` when no release version is declared.
+- Use a specific kebab-case feature slug.
+- Keep related edits in one record; use separate records for unrelated work.
+- Do not overwrite another feature's record. If the same feature record already
+  exists for the day, add a timestamped revision section.
+
+Every record must include YAML front matter with `date`, `version`, `feature`,
+`product`, `change_type`, exhaustive `affected_components`, and `related_frds`.
+Use `product: iris`; valid change types are `feature`, `bugfix`, `breaking`,
+`deprecation`, `refactor`, `schema`, `api`, `cli`, `docs`, and
+`infrastructure`.
+
+Include all of these sections, writing `N/A` with a brief reason when a section
+does not apply:
+
+1. Summary
+2. Motivation
+3. What Changed (New Additions, Modifications, and Removals)
+4. Technical Specification
+5. Usage Examples
+6. Integration Notes
+7. Breaking Changes & Migration
+8. Deferred / Out of Scope
+9. Testing Notes
+
+Be concrete: name changed APIs and files, include exact signatures or schemas
+when applicable, explain intent and compatibility, and record the checks that
+actually ran. Existing records in `docs/changes/` are useful examples.
+
+## Release Process
+
+Releases are cut from `main` using semantic-version tags. Maintainers should:
+
+1. Open and merge a release-preparation pull request that moves the relevant
+   `CHANGELOG.md` entries from `Unreleased` into a `X.Y.Z` section dated in UTC,
+   confirms all required `docs/changes/` records are present, and passes CI.
+2. Update local `main` and confirm the release commit:
+
+   ```bash
+   git checkout main
+   git pull --ff-only
+   git status --short
+   ```
+
+3. Create and push an annotated semantic-version tag. Never move or reuse a
+   published tag:
+
+   ```bash
+   git tag -a vX.Y.Z -m "vX.Y.Z"
+   git push origin vX.Y.Z
+   ```
+
+4. The tag triggers `.github/workflows/release.yml`, which builds Linux, macOS,
+   and Windows CLI binaries, generates SHA-256 checksums, and creates the GitHub
+   Release with generated notes.
+5. Verify the workflow succeeded and the release contains all four binaries
+   plus `checksums.txt`. If it fails, fix the cause on `main` and cut a new
+   patch version; do not replace the published tag.
+
 ## Pull Request Checklist
 
 - [ ] Scope is focused and described clearly.
 - [ ] `make lint`, `make test`, and `make build` pass locally.
 - [ ] Integration tests were run when relevant, or explicitly noted as not run.
 - [ ] New behavior is covered by tests.
+- [ ] A complete `docs/changes/` record is added or updated.
 - [ ] User-facing docs are updated when behavior or APIs change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ history. Listed here so they are discoverable rather than hidden.
 
 | Directory | Purpose |
 |---|---|
-| [`changes/`](changes/) | Per-feature change records consumed by the automated documentation pipeline. One file per logical feature, named `YYYY-MM-DD_v{version}_{slug}.md`. See the repository `CLAUDE.md` for the required structure. |
+| [`changes/`](changes/) | Per-feature change records consumed by the automated documentation pipeline. One file per logical feature, named `YYYY-MM-DD_v{version}_{slug}.md`. See [`CONTRIBUTING.md`](../CONTRIBUTING.md#change-documentation) for the required structure. |
 | [`superpowers/`](superpowers/) | Design specs (`specs/`) and implementation plans (`plans/`) produced while building features. Kept in-tree because they feed the documentation pipeline. |
 
 ## 🔗 Elsewhere in the repository

--- a/docs/changes/2026-08-28_v0.0.0-dev_issue-78-repository-hygiene.md
+++ b/docs/changes/2026-08-28_v0.0.0-dev_issue-78-repository-hygiene.md
@@ -1,0 +1,103 @@
+---
+date: 2026-08-28
+version: v0.0.0-dev
+feature: Repository hygiene and contributor release policy
+product: iris
+change_type: docs
+affected_components: [.gitignore, go.work.sum, CONTRIBUTING.md, docs/README.md, tests/repository_hygiene_test.go, gen-models]
+related_frds: []
+---
+
+## Summary
+
+Issue #78 makes workspace dependency checksums reproducible, exposes the change-documentation contract to every contributor, fixes macOS metadata ignores, removes a stray local generator binary, and documents the maintainer release process. Repository-level tests now guard the trackable workspace checksum, case-correct ignore pattern, and required contributor documentation.
+
+## Motivation
+
+The repository committed `go.work` while ignoring `go.work.sum`, so a fresh checkout could not retain workspace-only dependency checksums for offline and reproducible builds. The required `docs/changes/` pipeline lived only in an ignored local `CLAUDE.md`, while `docs/README.md` directed contributors to that unavailable file. The `.DS_STORE` spelling was ineffective on case-sensitive Linux filesystems, a local 11.6 MB `gen-models` build artifact remained at the repository root, and no tracked document explained how `CHANGELOG.md`, semantic-version tags, and the release workflow fit together.
+
+## What Changed
+
+### New Additions
+
+- `go.work.sum` is now trackable and committed with the checksums required by the three-module workspace.
+- `CONTRIBUTING.md` gains a `Change Documentation` section defining the filename, front matter, required headings, and completeness rules for `docs/changes/` records.
+- `CONTRIBUTING.md` gains a `Release Process` section covering the changelog pull request, annotated semantic-version tag, tag push, automated release workflow, and release-asset verification.
+- `tests/repository_hygiene_test.go` prevents regressions in the workspace checksum policy, `.DS_Store` pattern, and contributor-facing change/release documentation.
+
+### Modifications
+
+- `.gitignore` no longer ignores `go.work.sum` and now uses the case-correct `.DS_Store` pattern.
+- `docs/README.md` links to the tracked `CONTRIBUTING.md#change-documentation` policy instead of the ignored local `CLAUDE.md`.
+- The pull-request checklist now requires a complete `docs/changes/` record.
+
+### Removals
+
+- Removed the ignored local `/gen-models` executable (11,647,458 bytes), a build artifact of `cmd/gen-models`. The `/gen-models` ignore rule remains so future local builds do not enter commits accidentally.
+
+## Technical Specification
+
+### Configuration
+
+The relevant ignore rules are now:
+
+```gitignore
+/gen-models
+.DS_Store
+```
+
+There is intentionally no `go.work.sum` ignore rule. A checkout containing `go.work` must retain its generated workspace checksum alongside the workspace definition.
+
+### Documentation Contract
+
+Change records use:
+
+```text
+docs/changes/YYYY-MM-DD_v{version}_{feature-slug}.md
+```
+
+They require front matter for date, version, feature, product, change type, exhaustive affected components, and related FRDs, followed by Summary, Motivation, What Changed, Technical Specification, Usage Examples, Integration Notes, Breaking Changes & Migration, Deferred / Out of Scope, and Testing Notes sections. Non-applicable sections must explain why they are N/A.
+
+### Release Automation
+
+Maintainers merge a release-preparation pull request, update local `main`, create an annotated `vX.Y.Z` tag, and push that tag. `.github/workflows/release.yml` responds to `v*.*.*`, builds four platform binaries, writes SHA-256 checksums, and creates the GitHub Release with generated notes.
+
+## Usage Examples
+
+### Example: Create a change record
+
+```bash
+today="$(date -u +%Y-%m-%d)"
+touch "docs/changes/${today}_v0.0.0-dev_my-feature.md"
+```
+
+### Example: Cut a release after its preparation PR merges
+
+```bash
+git checkout main
+git pull --ff-only
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+## Integration Notes
+
+The committed workspace checksum covers local workspace dependency resolution across the main SDK, examples, and `contrib/otel` modules. The release instructions describe the existing workflow without changing its permissions, trigger, build matrix, or generated assets. No PetalFlow, Cortex, PetalTrace, or provider runtime integration changes are introduced.
+
+## Breaking Changes & Migration
+
+None. Ignore behavior and contributor documentation change, but Go packages, APIs, module paths, CLI behavior, and release automation remain unchanged.
+
+## Deferred / Out of Scope
+
+- Renaming the public `testing` package to `iristest` or `testutil` is deferred because it is a source-breaking module API change requiring a dedicated migration plan.
+- Moving `cli/cmd/iris` under the root `cmd/` tree is deferred because the current layout is functional and restructuring it provides no acceptance-critical behavior.
+- The local `CLAUDE.md` remains ignored; its repository-relevant documentation policy now lives in tracked, tool-neutral contributor documentation.
+- Dependabot configuration is out of scope for this hygiene pass.
+
+## Testing Notes
+
+- Added the tests first; they failed for the ignored workspace checksum, incorrect `.DS_STORE` spelling, and missing change/release sections.
+- `go work sync` confirmed `go.work.sum` was current. Its unrelated attempt to promote transitive test dependencies into the root module was intentionally discarded.
+- Focused repository-hygiene tests pass after the configuration and documentation changes.
+- Final verification covers root and `contrib/otel` build, unit tests, race/coverage, vet, formatting, and diff whitespace checks.

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,2 @@
+golang.org/x/net v0.48.0/go.mod h1:+ndRgGjkh8FGtu1w1FGbEC31if4VrNVMuKTgcAAnQRY=
+golang.org/x/text v0.33.0/go.mod h1:LuMebE6+rBincTi9+xWTY8TztLzKHc/9C1uBCG27+q8=

--- a/tests/repository_hygiene_test.go
+++ b/tests/repository_hygiene_test.go
@@ -1,0 +1,46 @@
+package tests
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestWorkspaceChecksumIsCommittedPolicy(t *testing.T) {
+	gitignore := readRepositoryFile(t, ".gitignore")
+	if containsTrimmedLine(gitignore, "go.work.sum") {
+		t.Error("go.work.sum must not be ignored")
+	}
+	info, err := os.Stat("../go.work.sum")
+	if err != nil {
+		t.Fatalf("go.work.sum must exist: %v", err)
+	}
+	if info.Size() == 0 {
+		t.Error("go.work.sum must not be empty")
+	}
+}
+
+func TestMacOSMetadataIgnorePattern(t *testing.T) {
+	gitignore := readRepositoryFile(t, ".gitignore")
+	if !containsTrimmedLine(gitignore, ".DS_Store") {
+		t.Error(".gitignore must contain the case-correct .DS_Store pattern")
+	}
+	if containsTrimmedLine(gitignore, ".DS_STORE") {
+		t.Error(".gitignore must not contain the incorrect .DS_STORE pattern")
+	}
+}
+
+func TestContributorDocumentationIncludesChangeAndReleaseProcesses(t *testing.T) {
+	contributing := readRepositoryFile(t, "CONTRIBUTING.md")
+	for _, required := range []string{
+		"## Change Documentation",
+		"docs/changes/YYYY-MM-DD_v{version}_{feature-slug}.md",
+		"## Release Process",
+		".github/workflows/release.yml",
+		"git tag",
+	} {
+		if !strings.Contains(contributing, required) {
+			t.Errorf("CONTRIBUTING.md must document %q", required)
+		}
+	}
+}


### PR DESCRIPTION
Closes #78.

## Summary

This resolves the issue #78 repository-hygiene acceptance items by committing the workspace checksum, moving the change-documentation contract into tracked contributor documentation, fixing case-sensitive macOS metadata ignores, documenting the release process, and adding regression guards.

The ignored local 11.6 MB `gen-models` build artifact was also removed from the working checkout. It was never tracked, so no binary deletion appears in the Git diff; `/gen-models` remains ignored and the executable can be regenerated from `cmd/gen-models`.

## User impact and root cause

The repository committed `go.work` but ignored `go.work.sum`, preventing fresh checkouts from retaining workspace-only dependency checksums. The required `docs/changes/` pipeline existed only in an ignored local `CLAUDE.md`, while tracked documentation pointed contributors to that unavailable file. The `.DS_STORE` spelling was ineffective on case-sensitive Linux filesystems, and no tracked document explained the changelog-to-tag-to-release workflow.

Together, these gaps reduced reproducibility, made required contribution policy invisible, allowed macOS metadata to slip into subdirectories, and left release mechanics dependent on maintainer tribal knowledge.

## Implementation

- Remove the `go.work.sum` ignore rule and commit the current workspace checksum.
- Replace `.DS_STORE` with the case-correct recursive `.DS_Store` pattern.
- Add contributor-facing change-record filename, front matter, required-section, and completeness requirements to `CONTRIBUTING.md`.
- Update `docs/README.md` to link to the tracked contributor policy instead of ignored `CLAUDE.md`.
- Document release preparation, annotated semantic-version tagging, `.github/workflows/release.yml`, and asset verification.
- Add `tests/repository_hygiene_test.go` to enforce the checksum, ignore, and contributor-policy requirements.
- Add the complete issue #78 change record, including compatibility and explicitly deferred breaking package/layout work.

The suggested `testing` package rename and `cmd/` restructuring remain out of scope because they are not acceptance criteria and the former is source-breaking.

## Validation

- `go build ./... ./contrib/otel/...`
- `go test ./... ./contrib/otel/...`
- `go test -race -coverprofile=/private/tmp/iris-issue-78-coverage.out -covermode=atomic ./... ./contrib/otel/...`
- `go vet ./... ./contrib/otel/...`
- `gofmt -l .`
- `git diff --check`

All checks pass. The regression tests were added first and failed on the ignored checksum, incorrect metadata pattern, and missing contributor documentation before the fix was applied.
