### PR TITLE
[codex] Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    groups:
+      root-go-modules:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/examples"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    groups:
+      example-go-modules:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/contrib/otel"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    groups:
+      otel-go-modules:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -15,9 +22,9 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24.x"
           cache: true
@@ -26,8 +33,12 @@ jobs:
         run: go build ./... ./contrib/otel/...
 
       - name: Test
-        if: matrix.os != 'ubuntu-latest'
+        if: matrix.os == 'windows-latest'
         run: go test ./... ./contrib/otel/...
+
+      - name: Test with race detector
+        if: matrix.os == 'macos-latest'
+        run: go test -race ./... ./contrib/otel/...
 
       - name: Test with coverage
         if: matrix.os == 'ubuntu-latest'
@@ -35,7 +46,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage.out
           path: coverage.out
@@ -43,7 +54,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@04b047e8bb82a0c002c8312c1c880fbc6a999d45 # v5
         with:
           token: ${{ env.CODECOV_TOKEN }}
           files: ./coverage.out
@@ -65,15 +76,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24.x"
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: v2.1.6
 
@@ -81,15 +92,15 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24.x"
           cache: true
 
       - name: Run gosec
-        uses: securego/gosec@v2.22.11
+        uses: securego/gosec@b72378a2da300339c40788e1eddf1ddea6498558 # v2.22.11
         with:
           # G101: env var names (not actual secrets)
           # G104: unhandled errors on non-critical JSON encoding

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "30 3 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze Go
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.24.x"
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5ba2889ada762081db2c4f32a729827dce632c7b # v3
+        with:
+          languages: go
+
+      - name: Build workspace modules
+        run: go build ./... ./contrib/otel/...
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@5ba2889ada762081db2c4f32a729827dce632c7b # v3

--- a/.github/workflows/integration-smoke.yml
+++ b/.github/workflows/integration-smoke.yml
@@ -7,15 +7,19 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24.x"
           cache: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,15 +6,18 @@ on:
     # Run weekly on Sunday at 2 AM UTC
     - cron: "0 2 * * 0"
 
+permissions:
+  contents: read
+
 jobs:
   integration:
     runs-on: ubuntu-latest
     environment: CI
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24.x"
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,16 +6,18 @@ on:
       - "v*.*.*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.24.x"
           cache: true
@@ -39,7 +41,7 @@ jobs:
           sha256sum * > checksums.txt
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: |
             dist/iris-linux-amd64

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  precision: 1
+  round: down
+  range: "80...100"
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -169,6 +169,20 @@ env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
+The repository workflows apply these supply-chain controls:
+
+- every external action is pinned to a full commit SHA, with Dependabot
+  maintaining GitHub Actions and all three Go workspace modules;
+- workflows default to `contents: read`, while release and CodeQL jobs receive
+  only their required write permissions;
+- superseded pull-request CI, smoke, and CodeQL runs are cancelled;
+- gosec and CodeQL run complementary static analysis;
+- race-enabled tests run on Linux and macOS; Windows retains a plain test pass;
+- Codecov enforces 80% project and patch targets, with a 1% project tolerance.
+
+Action version comments are informational. The full SHA after `@` is the
+security boundary and must not be replaced with a mutable tag.
+
 ### Environment-Specific Keys
 
 Use different master keys for different environments:

--- a/docs/changes/2026-08-28_v0.0.0-dev_issue-74-ci-hardening.md
+++ b/docs/changes/2026-08-28_v0.0.0-dev_issue-74-ci-hardening.md
@@ -1,0 +1,114 @@
+---
+date: 2026-08-28
+version: v0.0.0-dev
+feature: GitHub Actions and dependency-update hardening
+product: iris
+change_type: infrastructure
+affected_components: [.github/dependabot.yml, .github/workflows/ci.yml, .github/workflows/integration.yml, .github/workflows/integration-smoke.yml, .github/workflows/release.yml, .github/workflows/codeql.yml, codecov.yml, tests/github_workflows_test.go, docs/SECURITY.md]
+related_frds: []
+---
+
+## Summary
+
+Issue #74 hardens GitHub automation with immutable action pins, least-privilege permissions, pull-request concurrency cancellation, Dependabot coverage, CodeQL scanning, multi-OS race testing, and enforceable Codecov thresholds. Repository tests make these controls durable by failing if future workflow edits weaken the accepted baseline.
+
+## Motivation
+
+The existing CI matrix built and tested across three operating systems and ran gosec, but mutable action tags left workflow execution exposed to upstream tag movement. Most workflows inherited GitHub's default token permissions, active pull requests accumulated superseded runs, the OTel and example modules had no dependency automation, and only Linux exercised the race detector. Codecov received coverage without enforcing a project or patch baseline, and there was no GitHub-native code-scanning workflow.
+
+## What Changed
+
+### New Additions
+
+- `.github/dependabot.yml` schedules grouped weekly updates for GitHub Actions and Go modules in `/`, `/examples`, and `/contrib/otel`.
+- `.github/workflows/codeql.yml` scans Go on pushes and pull requests to `main` plus a weekly schedule. Its job builds the root and OTel workspace modules before analysis.
+- `codecov.yml` enforces 80% project and patch coverage; project coverage allows a 1% change tolerance.
+- `tests/github_workflows_test.go` validates dependency automation, action SHAs, permissions, PR concurrency, CodeQL, multi-OS race commands, and Codecov policy.
+
+### Modifications
+
+- All external actions in CI, integration, smoke, release, and CodeQL workflows now use full 40-character commit SHAs.
+- Every workflow defaults to `contents: read`. The release job alone receives `contents: write`; the CodeQL job alone receives `security-events: write` and `packages: read`.
+- CI, integration smoke, and CodeQL cancel superseded runs using the workflow plus pull-request number/ref as the concurrency key.
+- macOS now runs `go test -race`; Linux retains race plus coverage, and Windows retains its plain test pass.
+- Security documentation describes the enforced repository controls and states that SHA pins, not version comments, are authoritative.
+
+### Removals
+
+- Removed all mutable action tag references such as `@v4`, `@v5`, and `@v7` from workflow execution.
+- Removed workflow-level `contents: write` from the release workflow; write access now exists only on its release job.
+
+## Technical Specification
+
+### Action Pins
+
+| Action | Immutable commit | Version comment |
+|---|---|---|
+| `actions/checkout` | `11d5960a326750d5838078e36cf38b85af677262` | `v4` |
+| `actions/setup-go` | `40f1582b2485089dde7abd97c1529aa768e1baff` | `v5` |
+| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | `v4` |
+| `codecov/codecov-action` | `04b047e8bb82a0c002c8312c1c880fbc6a999d45` | `v5` |
+| `golangci/golangci-lint-action` | `9fae48acfc02a90574d7c304a1758ef9895495fa` | `v7` |
+| `securego/gosec` | `b72378a2da300339c40788e1eddf1ddea6498558` | `v2.22.11` |
+| `softprops/action-gh-release` | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` | `v2` |
+| `github/codeql-action` | `5ba2889ada762081db2c4f32a729827dce632c7b` | `v3` |
+
+Each SHA was resolved directly from the configured upstream GitHub tag. Dependabot's `github-actions` ecosystem updates these pinned SHAs and their comments together.
+
+### Permissions
+
+All workflow tokens start with:
+
+```yaml
+permissions:
+  contents: read
+```
+
+Only release asset publication adds job-scoped `contents: write`. CodeQL adds job-scoped `security-events: write` and `packages: read` for result upload and analysis dependencies.
+
+### Concurrency
+
+Pull-request workflows use:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+```
+
+### Coverage
+
+The measured full root-plus-OTel profile is 81.9%. The 80% project target therefore enforces the repository requirement without beginning below threshold. A 1% project tolerance avoids noise from small generated or command-package shifts; changed lines retain an 80% patch target.
+
+## Usage Examples
+
+### Example: Pin a new action
+
+```yaml
+- uses: owner/action@0123456789abcdef0123456789abcdef01234567 # v1
+```
+
+Resolve the SHA from the action's upstream repository, include a readable version comment, and let Dependabot maintain future updates. Never use only a mutable tag or branch.
+
+## Integration Notes
+
+CodeQL and the existing CI build include `./... ./contrib/otel/...`, so changes to core interfaces continue compiling against the OTel integration. Dependabot separately tracks all workspace module manifests. Integration secrets and provider test behavior are unchanged; the integration workflows gain only immutable pins and read-only defaults.
+
+## Breaking Changes & Migration
+
+None. These changes affect repository automation and status checks, not SDK packages, CLI behavior, module paths, or runtime configuration. Pull requests may now be blocked when project/patch coverage falls below policy or CodeQL finds a configured blocking alert.
+
+## Deferred / Out of Scope
+
+- OSSF Scorecard and its badge are deferred because CodeQL plus gosec satisfies this issue's code-scanning acceptance criterion; Scorecard requires a separate permissions and publishing design.
+- Windows retains plain tests. Race coverage now runs on the required two operating systems (Linux and macOS), balancing platform coverage against CI duration.
+- Scheduled/manual integration runs do not cancel one another because they are not superseded pull-request revisions.
+- Repository settings outside version control, including branch protection and organization-wide token defaults, are not changed by this pull request.
+
+## Testing Notes
+
+- Added hardening guards first; they failed for every missing acceptance item before configuration changes.
+- Resolved all action SHAs from their upstream Git tags.
+- Parsed every new and modified YAML file successfully.
+- Confirmed the existing full coverage profile totals 81.9% before selecting the 80% threshold.
+- Final verification includes repository guards, the full root and OTel test/race/build/vet suite, formatting, workflow scans, and diff whitespace checks.

--- a/tests/github_workflows_test.go
+++ b/tests/github_workflows_test.go
@@ -1,0 +1,114 @@
+package tests
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+var actionReferencePattern = regexp.MustCompile(`uses:\s+[^@\s]+@([^\s#]+)`)
+var fullCommitSHAPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+func TestDependabotCoversActionsAndWorkspaceModules(t *testing.T) {
+	config := readRepositoryFile(t, ".github/dependabot.yml")
+	for _, required := range []string{
+		`package-ecosystem: "github-actions"`,
+		`package-ecosystem: "gomod"`,
+		`directory: "/"`,
+		`directory: "/examples"`,
+		`directory: "/contrib/otel"`,
+	} {
+		if !strings.Contains(config, required) {
+			t.Errorf("dependabot config must contain %q", required)
+		}
+	}
+}
+
+func TestWorkflowActionsUseFullCommitSHAs(t *testing.T) {
+	for path, workflow := range readWorkflowFiles(t) {
+		for _, match := range actionReferencePattern.FindAllStringSubmatch(workflow, -1) {
+			if !fullCommitSHAPattern.MatchString(match[1]) {
+				t.Errorf("%s action ref %q must be a full commit SHA", path, match[1])
+			}
+		}
+	}
+}
+
+func TestWorkflowsDefaultToReadOnlyPermissions(t *testing.T) {
+	for path, workflow := range readWorkflowFiles(t) {
+		if !strings.Contains(workflow, "\npermissions:\n  contents: read\n") {
+			t.Errorf("%s must set top-level contents: read permissions", path)
+		}
+	}
+}
+
+func TestPullRequestWorkflowsCancelSupersededRuns(t *testing.T) {
+	for path, workflow := range readWorkflowFiles(t) {
+		if !strings.Contains(workflow, "pull_request:") {
+			continue
+		}
+		if !strings.Contains(workflow, "\nconcurrency:\n") || !strings.Contains(workflow, "cancel-in-progress: true") {
+			t.Errorf("%s must cancel superseded pull-request runs", path)
+		}
+	}
+}
+
+func TestCodeQLAndMultiOSRaceCoverageConfigured(t *testing.T) {
+	codeql := readRepositoryFile(t, ".github/workflows/codeql.yml")
+	for _, required := range []string{
+		"github/codeql-action/init@",
+		"github/codeql-action/analyze@",
+		"security-events: write",
+	} {
+		if !strings.Contains(codeql, required) {
+			t.Errorf("CodeQL workflow must contain %q", required)
+		}
+	}
+
+	ci := readRepositoryFile(t, ".github/workflows/ci.yml")
+	if !strings.Contains(ci, "if: matrix.os == 'macos-latest'") || strings.Count(ci, "go test -race") < 2 {
+		t.Error("CI must run race-enabled tests on Ubuntu and macOS")
+	}
+}
+
+func TestCodecovEnforcesProjectAndPatchThresholds(t *testing.T) {
+	config := readRepositoryFile(t, "codecov.yml")
+	for _, required := range []string{"project:", "patch:", "target: 80%"} {
+		if !strings.Contains(config, required) {
+			t.Errorf("codecov.yml must contain %q", required)
+		}
+	}
+}
+
+func TestGitHubYAMLConfigurationParses(t *testing.T) {
+	configs := readWorkflowFiles(t)
+	for _, path := range []string{".github/dependabot.yml", "codecov.yml"} {
+		configs[path] = readRepositoryFile(t, path)
+	}
+	for path, content := range configs {
+		var parsed any
+		if err := yaml.Unmarshal([]byte(content), &parsed); err != nil {
+			t.Errorf("parse %s: %v", path, err)
+		}
+	}
+}
+
+func readWorkflowFiles(t *testing.T) map[string]string {
+	t.Helper()
+	paths, err := filepath.Glob("../.github/workflows/*.yml")
+	if err != nil {
+		t.Fatalf("list workflow files: %v", err)
+	}
+	if len(paths) == 0 {
+		t.Fatal("no GitHub workflows found")
+	}
+	workflows := make(map[string]string, len(paths))
+	for _, path := range paths {
+		repositoryPath := strings.TrimPrefix(path, "../")
+		workflows[repositoryPath] = readRepositoryFile(t, repositoryPath)
+	}
+	return workflows
+}

--- a/tests/github_workflows_test.go
+++ b/tests/github_workflows_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -98,7 +99,7 @@ func TestGitHubYAMLConfigurationParses(t *testing.T) {
 
 func readWorkflowFiles(t *testing.T) map[string]string {
 	t.Helper()
-	paths, err := filepath.Glob("../.github/workflows/*.yml")
+	paths, err := filepath.Glob(filepath.Join("..", ".github", "workflows", "*.yml"))
 	if err != nil {
 		t.Fatalf("list workflow files: %v", err)
 	}
@@ -107,8 +108,15 @@ func readWorkflowFiles(t *testing.T) map[string]string {
 	}
 	workflows := make(map[string]string, len(paths))
 	for _, path := range paths {
-		repositoryPath := strings.TrimPrefix(path, "../")
-		workflows[repositoryPath] = readRepositoryFile(t, repositoryPath)
+		repositoryPath, err := filepath.Rel("..", path)
+		if err != nil {
+			t.Fatalf("resolve repository path for %s: %v", path, err)
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", repositoryPath, err)
+		}
+		workflows[filepath.ToSlash(repositoryPath)] = string(content)
 	}
 	return workflows
 }

--- a/tests/repository_ci_test.go
+++ b/tests/repository_ci_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -22,7 +23,7 @@ func TestContribOtelIsCoveredByWorkspaceAndCI(t *testing.T) {
 
 func readRepositoryFile(t *testing.T, path string) string {
 	t.Helper()
-	content, err := os.ReadFile("../" + path)
+	content, err := os.ReadFile(filepath.Join("..", filepath.FromSlash(path)))
 	if err != nil {
 		t.Fatalf("read %s: %v", path, err)
 	}


### PR DESCRIPTION
## Summary

Issue #74 identified several gaps in the repository's CI security and reliability controls. GitHub Actions were referenced by mutable version tags, workflow permissions were not consistently explicit, redundant pull-request runs were not cancelled, dependency update automation was absent, and the repository did not have CodeQL or an enforced coverage policy.

These gaps made CI behavior less predictable and increased the risk that upstream action changes, overly broad token permissions, or stale dependency pins could affect contributors and maintainers. Race detection also ran on only one operating system, leaving platform-specific concurrency behavior with less coverage.

This change hardens the CI configuration by pinning every action to an immutable commit SHA, adding least-privilege permissions to every workflow, and restricting release write access to the release job. It adds pull-request concurrency cancellation, Dependabot coverage for GitHub Actions and all Go modules, a scheduled and pull-request CodeQL workflow, and race testing on both Ubuntu and macOS. It also adds an 80% Codecov project and patch target, documents the security controls, and introduces repository-policy tests that prevent these controls from silently regressing.

The root cause was that these controls had accumulated organically across independent workflows without a single enforced repository policy. The new tests parse the workflow and configuration YAML and assert the expected pinning, permissions, concurrency, analysis, race, dependency, and coverage settings.

## Validation

- `go build ./... ./contrib/otel/...`
- `go test ./... ./contrib/otel/...`
- `go test -race ./... ./contrib/otel/...`
- `go vet ./... ./contrib/otel/...`
- `gofmt -l .`
- `git diff --check`
- Focused GitHub workflow policy tests
- YAML parsing for workflows, Dependabot, and Codecov configuration
- Existing aggregate coverage measured at 81.9%

Closes #74
