### PR TITLE
[codex] Add community health files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default review ownership for all repository changes.
+* @erikhoward

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,86 @@
+name: Bug report
+description: Report reproducible behavior that is incorrect or unexpected
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Iris. Do not include API keys, credentials, or other sensitive data.
+        Report security vulnerabilities through [private vulnerability reporting](https://github.com/petal-labs/iris/security/advisories/new), not this public form.
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected component
+      options:
+        - SDK core
+        - Provider integration
+        - CLI
+        - Documentation
+        - Build or CI
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior and its impact.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest example or sequence that reproduces the problem.
+      placeholder: |
+        1. Configure ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Explain what you expected to happen instead.
+    validations:
+      required: true
+  - type: input
+    id: iris-version
+    attributes:
+      label: Iris version or commit
+      placeholder: v0.18.0 or commit SHA
+    validations:
+      required: true
+  - type: input
+    id: go-version
+    attributes:
+      label: Go version
+      placeholder: Output of go version
+    validations:
+      required: true
+  - type: input
+    id: operating-system
+    attributes:
+      label: Operating system
+      placeholder: macOS 15, Ubuntu 24.04, Windows 11, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or additional context
+      description: Remove secrets and personal data before pasting logs.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Submission checklist
+      options:
+        - label: I searched existing issues for duplicates.
+          required: true
+        - label: I removed secrets, credentials, and personal data from this report.
+          required: true
+        - label: I agree to follow the project's Code of Conduct.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/petal-labs/iris/security/advisories/new
+    about: Privately report a potential security vulnerability to the maintainers.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Propose an improvement or new capability for Iris
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to suggest an improvement.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: Describe the user need or limitation this request would address.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Explain the behavior or API you would like Iris to provide.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe current workarounds or alternative designs you considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add examples, links, or other context. Do not include secrets or personal data.
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Submission checklist
+      options:
+        - label: I searched existing issues for related requests.
+          required: true
+        - label: I agree to follow the project's Code of Conduct.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- Explain what changed, why it changed, and its effect on users. -->
+
+Closes #
+
+## Testing
+
+<!-- List the exact commands and manual checks used to validate this change. -->
+
+- [ ] `make lint`
+- [ ] `make test`
+- [ ] `make build`
+- [ ] Relevant integration tests, or an explanation of why they were not run
+
+## Checklist
+
+- [ ] The change is focused and described clearly.
+- [ ] New behavior and error paths are covered by tests.
+- [ ] User-facing documentation is updated where needed.
+- [ ] A complete record was added or updated under `docs/changes/`.
+- [ ] No secrets, credentials, or sensitive data are included.
+- [ ] Breaking changes and migration steps are documented, or this change is backward compatible.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,131 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported privately to the community leader responsible for enforcement at
+[erikhoward@pm.me](mailto:erikhoward@pm.me). All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the
+[FAQ]. Translations are available at [translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for contributing to Iris.
 
+By participating, you agree to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
 ## Prerequisites
 
 - Go 1.25+

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -272,9 +272,12 @@ The V2 keystore uses Argon2id with OWASP-recommended parameters:
 
 ## Reporting Security Issues
 
-If you discover a security vulnerability in Iris, please report it responsibly:
+If you discover a security vulnerability in Iris, use
+[GitHub private vulnerability reporting](https://github.com/petal-labs/iris/security/advisories/new)
+to contact the maintainers privately. Do not open a public GitHub issue or
+discussion for suspected vulnerabilities.
 
-1. **Do not** open a public GitHub issue
-2. Email security concerns to the maintainers
-3. Include steps to reproduce the issue
-4. Allow time for a fix before public disclosure
+Include the affected version or commit, impact, reproduction steps, and any
+suggested mitigation. Remove credentials, API keys, and unrelated personal data
+from the report. The maintainers will coordinate investigation, remediation,
+and disclosure through the private advisory.

--- a/docs/changes/2026-08-28_v0.0.0-dev_issue-75-community-health.md
+++ b/docs/changes/2026-08-28_v0.0.0-dev_issue-75-community-health.md
@@ -1,0 +1,77 @@
+---
+date: 2026-08-28
+version: v0.0.0-dev
+feature: Community health and contribution guidance
+product: iris
+change_type: infrastructure
+affected_components: [.github/CODEOWNERS, .github/ISSUE_TEMPLATE/bug.yml, .github/ISSUE_TEMPLATE/feature.yml, .github/ISSUE_TEMPLATE/config.yml, .github/PULL_REQUEST_TEMPLATE.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, docs/SECURITY.md, tests/community_health_test.go]
+related_frds: []
+---
+
+## Summary
+
+Issue #75 adds the repository community-health files needed to guide contributors, route reviews, collect actionable reports, and provide private channels for security and conduct concerns. Repository tests make the accepted community-health baseline durable.
+
+## Motivation
+
+Iris welcomes public contributions, but contributors previously started from blank issues and pull requests without repository-native guidance. Reviews had no automatic owner, the project had no published conduct expectations, and the security guide directed reporters to unspecified maintainers without a concrete private contact. This increased contributor friction and created a risk that sensitive vulnerability details would be disclosed publicly.
+
+## What Changed
+
+### New Additions
+
+- `.github/CODEOWNERS` routes repository-wide review requests to `@erikhoward`.
+- Bug and feature issue forms require the context maintainers need to evaluate reports and requests.
+- `.github/ISSUE_TEMPLATE/config.yml` disables blank issues and directs vulnerability reporters to GitHub's private advisory flow.
+- `.github/PULL_REQUEST_TEMPLATE.md` mirrors the project's summary, testing, documentation, compatibility, and secret-safety expectations.
+- `CODE_OF_CONDUCT.md` adopts Contributor Covenant 2.1 and provides a private enforcement contact.
+- `tests/community_health_test.go` validates ownership, forms, templates, conduct guidance, and security reporting.
+
+### Modifications
+
+- `CONTRIBUTING.md` now links contributors to the Code of Conduct.
+- `docs/SECURITY.md` replaces its unspecified email instruction with the repository's concrete private vulnerability reporting URL and report-content guidance.
+
+### Removals
+
+- Removed the ambiguous instruction to email unnamed maintainers about vulnerabilities.
+- Removed reliance on blank GitHub issues and contributor knowledge of the pull-request checklist.
+
+## Technical Specification
+
+The issue forms use GitHub's YAML form schema and require structured problem, reproduction, expected-behavior, environment, and proposal details. Security notices tell reporters not to submit credentials or vulnerability details publicly. Existing `bug` and `enhancement` labels are applied automatically.
+
+The pull-request template requires exact validation notes and includes the existing `docs/changes/` policy. CODEOWNERS applies `@erikhoward` to `*`, covering every path unless a future, more-specific rule overrides it.
+
+Private vulnerability reporting is enabled in the GitHub repository settings. Reports use `https://github.com/petal-labs/iris/security/advisories/new`, keeping discussion and remediation in a private advisory until coordinated disclosure.
+
+## Usage Examples
+
+### Report a bug
+
+Open a new GitHub issue and select **Bug report**. Complete the required component, reproduction, expected behavior, Iris version, Go version, and operating-system fields. Use private vulnerability reporting instead when the behavior may expose a security weakness.
+
+### Open a pull request
+
+Complete the generated summary and testing sections, link the issue with `Closes #N`, and confirm each applicable checklist item before requesting review.
+
+## Integration Notes
+
+GitHub automatically discovers these files at their standard repository paths. No application configuration, Go module, workflow secret, or provider integration changes are required.
+
+## Breaking Changes & Migration
+
+None. The changes affect repository contribution and reporting workflows only; Iris SDK, CLI, provider, and configuration behavior are unchanged.
+
+## Deferred / Out of Scope
+
+- `FUNDING.yml` is not included because funding configuration was listed in the issue inventory but is not part of the acceptance criteria and no supported funding account was provided.
+- Additional component-specific CODEOWNERS rules are deferred until the project has more eligible maintainers or teams.
+- GitHub Discussions and external support channels are not linked because their availability and ownership are outside this issue.
+
+## Testing Notes
+
+- Added repository-hygiene tests first and confirmed they failed for every missing acceptance item.
+- Parse both issue forms with `gopkg.in/yaml.v3` and require a name, description, and at least one required detailed response.
+- Validate repository-wide ownership, the PR checklist, Contributor Covenant configuration and link, and the private vulnerability reporting URL.
+- Run the full root and OpenTelemetry test, vet, format, and build checks after implementation.

--- a/tests/community_health_test.go
+++ b/tests/community_health_test.go
@@ -1,0 +1,105 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type issueForm struct {
+	Name        string          `yaml:"name"`
+	Description string          `yaml:"description"`
+	Body        []issueFormItem `yaml:"body"`
+}
+
+type issueFormItem struct {
+	Type        string          `yaml:"type"`
+	Validations map[string]bool `yaml:"validations"`
+}
+
+func TestCodeOwnersRoutesRepositoryReviews(t *testing.T) {
+	codeowners := readRepositoryFile(t, ".github/CODEOWNERS")
+	if !containsTrimmedLine(codeowners, "* @erikhoward") {
+		t.Error("CODEOWNERS must route repository-wide reviews to @erikhoward")
+	}
+}
+
+func TestIssueFormsCollectRequiredContext(t *testing.T) {
+	for _, path := range []string{
+		".github/ISSUE_TEMPLATE/bug.yml",
+		".github/ISSUE_TEMPLATE/feature.yml",
+	} {
+		content := readRepositoryFile(t, path)
+		var form issueForm
+		if err := yaml.Unmarshal([]byte(content), &form); err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		if strings.TrimSpace(form.Name) == "" || strings.TrimSpace(form.Description) == "" {
+			t.Errorf("%s must define a name and description", path)
+		}
+		if !hasRequiredTextarea(form.Body) {
+			t.Errorf("%s must require at least one detailed response", path)
+		}
+	}
+}
+
+func TestIssueTemplateConfigRoutesSecurityReportsPrivately(t *testing.T) {
+	config := readRepositoryFile(t, ".github/ISSUE_TEMPLATE/config.yml")
+	for _, required := range []string{
+		"blank_issues_enabled: false",
+		"https://github.com/petal-labs/iris/security/advisories/new",
+	} {
+		if !strings.Contains(config, required) {
+			t.Errorf("issue template config must contain %q", required)
+		}
+	}
+}
+
+func TestPullRequestTemplateIncludesProjectChecklist(t *testing.T) {
+	template := readRepositoryFile(t, ".github/PULL_REQUEST_TEMPLATE.md")
+	for _, required := range []string{
+		"## Summary",
+		"## Testing",
+		"docs/changes/",
+		"- [ ]",
+	} {
+		if !strings.Contains(template, required) {
+			t.Errorf("pull request template must contain %q", required)
+		}
+	}
+}
+
+func TestContributorCodeOfConductIsLinkedAndConfigured(t *testing.T) {
+	conduct := readRepositoryFile(t, "CODE_OF_CONDUCT.md")
+	if !strings.Contains(conduct, "Contributor Covenant Code of Conduct") {
+		t.Error("CODE_OF_CONDUCT.md must use the Contributor Covenant")
+	}
+	if strings.Contains(conduct, "[INSERT CONTACT METHOD]") {
+		t.Error("CODE_OF_CONDUCT.md must define a real enforcement contact")
+	}
+
+	contributing := readRepositoryFile(t, "CONTRIBUTING.md")
+	if !strings.Contains(contributing, "[Code of Conduct](CODE_OF_CONDUCT.md)") {
+		t.Error("CONTRIBUTING.md must link to CODE_OF_CONDUCT.md")
+	}
+}
+
+func TestSecurityReportingUsesPrivateVulnerabilityReporting(t *testing.T) {
+	security := readRepositoryFile(t, "docs/SECURITY.md")
+	if !strings.Contains(security, "https://github.com/petal-labs/iris/security/advisories/new") {
+		t.Error("security reporting must link to GitHub private vulnerability reporting")
+	}
+	if !strings.Contains(security, "Do not open a public GitHub issue") {
+		t.Error("security reporting must warn against public disclosure")
+	}
+}
+
+func hasRequiredTextarea(items []issueFormItem) bool {
+	for _, item := range items {
+		if item.Type == "textarea" && item.Validations["required"] {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Issue #75 identified that Iris welcomed public contributions but lacked the standard GitHub community-health files needed to guide contributors and maintainers. Contributors started from blank issues and pull requests, reviews had no automatic owner, the project had no published conduct policy, and the security guide told reporters to contact unspecified maintainers without providing a usable private channel.

The practical effect was higher contributor friction, inconsistent issue and pull-request context, manual review routing, and a risk that vulnerability details could be disclosed in a public issue because the reporting instructions were incomplete.

The root cause was that contribution guidance existed primarily in `CONTRIBUTING.md` and had not been connected to GitHub's repository-native templates, ownership rules, community standards, or private vulnerability reporting feature.

This change adds repository-wide CODEOWNERS routing, structured bug and feature issue forms, a pull-request checklist aligned with the existing contribution policy, and Contributor Covenant 2.1 with a concrete private enforcement contact. It links the Code of Conduct from `CONTRIBUTING.md`, replaces the ambiguous security instructions with the repository's private advisory URL, and adds tests that enforce the accepted community-health baseline. GitHub private vulnerability reporting has also been enabled in the repository settings so the documented link is functional.

`FUNDING.yml` remains out of scope because it was not part of the issue acceptance criteria and no supported funding account was supplied.

## Validation

- Added acceptance tests first and confirmed they failed for each missing community-health file.
- `go test ./... ./contrib/otel/...`
- `go vet ./... ./contrib/otel/...`
- `go build ./... ./contrib/otel/...`
- `gofmt -l .`
- `git diff --check`
- Parsed all issue-template YAML files successfully.
- Verified `@erikhoward` has repository administrator access for CODEOWNERS eligibility.
- Verified GitHub private vulnerability reporting is enabled.

Closes #75
