### PR TITLE
[codex] Align local lint with CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,8 +76,14 @@ In CI, integration tests fail on missing required keys unless `IRIS_SKIP_INTEGRA
 
 ## Code Style and Quality
 
-- Format with `gofmt` (`make fmt`).
-- Keep `go vet` clean (`make vet`).
+- Run `make lint` before opening a pull request. It runs the same format, vet,
+  and golangci-lint checks enforced by CI.
+- Install the pinned golangci-lint `v2.5.0` release with
+  `make install-golangci-lint`. `make lint` fails with an installation hint if
+  the binary is missing or its version differs from CI.
+- To use a binary outside `PATH`, run
+  `make lint GOLANGCI_LINT=/path/to/golangci-lint`.
+- Format with `gofmt` (`make fmt`) and keep `go vet` clean (`make vet`).
 - Prefer small, composable functions over large control blocks.
 - Add tests for behavior changes and regressions.
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Iris SDK Makefile
 
-.PHONY: all build test lint fmt vet clean install-hooks help coverage
+.PHONY: all build test lint lint-ci install-golangci-lint fmt vet clean install-hooks help coverage
 
 # Version information
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -9,6 +9,11 @@ BUILD_DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS := -ldflags "-X github.com/petal-labs/iris/cli/commands.Version=$(VERSION) \
 	-X github.com/petal-labs/iris/cli/commands.Commit=$(COMMIT) \
 	-X github.com/petal-labs/iris/cli/commands.BuildDate=$(BUILD_DATE)"
+
+# Keep this pin synchronized with .github/workflows/ci.yml.
+GOLANGCI_LINT_VERSION := v2.5.0
+GOLANGCI_LINT_VERSION_NUMBER := $(patsubst v%,%,$(GOLANGCI_LINT_VERSION))
+GOLANGCI_LINT ?= golangci-lint
 
 # Default target
 all: lint test build
@@ -39,8 +44,30 @@ coverage-html: coverage
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "HTML report generated: coverage.html"
 
-# Lint: format check and vet
-lint: fmt-check vet
+# Run the same formatting, vet, and golangci-lint checks as CI
+lint: fmt-check vet lint-ci
+
+# Run the CI-pinned golangci-lint version and repository configuration
+lint-ci:
+	@if ! command -v "$(GOLANGCI_LINT)" >/dev/null 2>&1; then \
+		echo "golangci-lint $(GOLANGCI_LINT_VERSION) is required."; \
+		echo "Run 'make install-golangci-lint' and retry."; \
+		exit 1; \
+	fi
+	@VERSION_OUTPUT=$$("$(GOLANGCI_LINT)" version 2>&1); \
+	case "$$VERSION_OUTPUT" in \
+		*"version $(GOLANGCI_LINT_VERSION_NUMBER)"*) ;; \
+		*) \
+			echo "Expected golangci-lint $(GOLANGCI_LINT_VERSION), but found: $$VERSION_OUTPUT"; \
+			echo "Run 'make install-golangci-lint' and retry."; \
+			exit 1; \
+		;; \
+	esac
+	"$(GOLANGCI_LINT)" run
+
+# Install the exact golangci-lint release used by CI
+install-golangci-lint:
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 # Check formatting (fails if files need formatting)
 fmt-check:
@@ -97,7 +124,9 @@ help:
 	@echo "  test-cover     Run tests with coverage summary"
 	@echo "  coverage       Generate coverage.out profile for Codecov"
 	@echo "  coverage-html  Generate HTML coverage report"
-	@echo "  lint           Run fmt-check and vet"
+	@echo "  lint           Run fmt-check, vet, and the CI-pinned golangci-lint"
+	@echo "  lint-ci        Run golangci-lint with CI version validation"
+	@echo "  install-golangci-lint  Install the golangci-lint version used by CI"
 	@echo "  fmt-check      Check if files are formatted"
 	@echo "  fmt            Format all Go files"
 	@echo "  vet            Run go vet"

--- a/docs/changes/2026-08-28_v0.0.0-dev_issue-76-lint-parity.md
+++ b/docs/changes/2026-08-28_v0.0.0-dev_issue-76-lint-parity.md
@@ -1,0 +1,79 @@
+---
+date: 2026-08-28
+version: v0.0.0-dev
+feature: Local and CI lint parity
+product: iris
+change_type: infrastructure
+affected_components: [Makefile, CONTRIBUTING.md, tests/lint_parity_test.go]
+related_frds: []
+---
+
+## Summary
+
+Issue #76 makes `make lint` run the same golangci-lint configuration and pinned release as the GitHub Actions lint job. A pinned installation target, explicit version validation, contributor documentation, and repository tests prevent local and CI lint behavior from drifting apart.
+
+## Motivation
+
+The previous `make lint` target ran only gofmt and `go vet`, while CI also ran golangci-lint with `.golangci.yml`. Contributors could therefore pass the documented local checks and encounter new static-analysis failures only after opening a pull request. Local installations were also unpinned, so even contributors who ran golangci-lint could see behavior different from CI.
+
+## What Changed
+
+### New Additions
+
+- `make lint-ci` validates that golangci-lint is installed at the CI-pinned version and then runs `golangci-lint run` with `.golangci.yml`.
+- `make install-golangci-lint` installs `github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0`.
+- `tests/lint_parity_test.go` enforces Makefile/CI version parity, local target behavior, the pinned installer, and contributor documentation.
+
+### Modifications
+
+- `make lint` now runs `fmt-check`, `vet`, and `lint-ci`.
+- Makefile help describes the lint, CI-lint, and installer targets.
+- `CONTRIBUTING.md` documents the pinned version, installation command, strict mismatch behavior, and custom binary path override.
+
+### Removals
+
+- Removed the local lint path that could succeed without running golangci-lint.
+- Removed ambiguity about which golangci-lint release contributors should use.
+
+## Technical Specification
+
+`GOLANGCI_LINT_VERSION := v2.5.0` matches the `version: v2.5.0` input in `.github/workflows/ci.yml`. `lint-ci` first resolves `GOLANGCI_LINT` with `command -v`, then checks the binary's version output for `2.5.0`, and fails with the pinned installation command if either check fails. Only after those checks does it execute `golangci-lint run`.
+
+`GOLANGCI_LINT ?= golangci-lint` allows contributors and automation to select a specific binary path without changing the enforced version. The parity test extracts both pins and fails whenever Dependabot or a maintainer updates CI without updating the Makefile and documentation.
+
+## Usage Examples
+
+### Install and run the pinned linter
+
+```bash
+make install-golangci-lint
+make lint
+```
+
+### Use an isolated tool directory
+
+```bash
+GOBIN=/path/to/tools make install-golangci-lint
+make lint GOLANGCI_LINT=/path/to/tools/golangci-lint
+```
+
+## Integration Notes
+
+CI continues using `golangci/golangci-lint-action` and its immutable action SHA. The action and local target both run golangci-lint `v2.5.0` against the repository's `.golangci.yml`; existing format and vet jobs remain unchanged.
+
+## Breaking Changes & Migration
+
+There is no SDK, CLI, provider, or configuration breaking change. Contributors running `make lint` must install the pinned golangci-lint release. Existing newer or older binaries are rejected so local results remain reproducible.
+
+## Deferred / Out of Scope
+
+- A `tools.go` or Go `tool` directive is not added because it would pull the linter's large dependency graph into the application module. The Makefile pin provides reproducibility without changing runtime module dependencies.
+- A Makefile target for `cmd/gen-models` remains deferred because it is not part of the issue acceptance criteria.
+- The pre-commit hook retains its lightweight gofmt and vet checks; `make lint` remains the required pre-PR parity check.
+
+## Testing Notes
+
+- Added lint-parity tests first and confirmed they failed because the Makefile had no local pin or golangci-lint target.
+- Validate that the local and CI version pins match exactly.
+- Validate missing and mismatched binary diagnostics plus successful execution with an isolated pinned binary.
+- Run the full root and OpenTelemetry test, vet, build, format, and lint checks after implementation.

--- a/tests/lint_parity_test.go
+++ b/tests/lint_parity_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-var makefileLintVersionPattern = regexp.MustCompile(`(?m)^GOLANGCI_LINT_VERSION := (v\d+\.\d+\.\d+)$`)
+var makefileLintVersionPattern = regexp.MustCompile(`(?m)^GOLANGCI_LINT_VERSION := (v\d+\.\d+\.\d+)[ \t]*\r?$`)
 var workflowLintVersionPattern = regexp.MustCompile(`(?m)^\s+version:\s+["']?(v\d+\.\d+\.\d+)["']?\s*$`)
 
 func TestLocalLintMatchesPinnedCIVersion(t *testing.T) {
@@ -45,6 +45,14 @@ func TestContributorDocsExplainPinnedLintSetup(t *testing.T) {
 		if !strings.Contains(contributing, required) {
 			t.Errorf("CONTRIBUTING.md must document %q", required)
 		}
+	}
+}
+
+func TestMakefileLintVersionPatternSupportsCRLF(t *testing.T) {
+	content := "GOLANGCI_LINT_VERSION := v2.5.0\r\n"
+	version := requiredPatternMatch(t, makefileLintVersionPattern, content, "CRLF Makefile golangci-lint version")
+	if version != "v2.5.0" {
+		t.Errorf("parsed version = %q, want v2.5.0", version)
 	}
 }
 

--- a/tests/lint_parity_test.go
+++ b/tests/lint_parity_test.go
@@ -1,0 +1,58 @@
+package tests
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var makefileLintVersionPattern = regexp.MustCompile(`(?m)^GOLANGCI_LINT_VERSION := (v\d+\.\d+\.\d+)$`)
+var workflowLintVersionPattern = regexp.MustCompile(`(?m)^\s+version:\s+["']?(v\d+\.\d+\.\d+)["']?\s*$`)
+
+func TestLocalLintMatchesPinnedCIVersion(t *testing.T) {
+	makefile := readRepositoryFile(t, "Makefile")
+	workflow := readRepositoryFile(t, ".github/workflows/ci.yml")
+
+	localVersion := requiredPatternMatch(t, makefileLintVersionPattern, makefile, "Makefile golangci-lint version")
+	ciVersion := requiredPatternMatch(t, workflowLintVersionPattern, workflow, "CI golangci-lint version")
+	if localVersion != ciVersion {
+		t.Errorf("local golangci-lint version %s must match CI version %s", localVersion, ciVersion)
+	}
+
+	for _, required := range []string{
+		"lint: fmt-check vet lint-ci",
+		"lint-ci:",
+		"command -v \"$(GOLANGCI_LINT)\"",
+		"\"$(GOLANGCI_LINT)\" run",
+		"go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)",
+	} {
+		if !strings.Contains(makefile, required) {
+			t.Errorf("Makefile must contain %q", required)
+		}
+	}
+}
+
+func TestContributorDocsExplainPinnedLintSetup(t *testing.T) {
+	makefile := readRepositoryFile(t, "Makefile")
+	contributing := readRepositoryFile(t, "CONTRIBUTING.md")
+	version := requiredPatternMatch(t, makefileLintVersionPattern, makefile, "Makefile golangci-lint version")
+
+	for _, required := range []string{
+		"make install-golangci-lint",
+		"make lint",
+		version,
+	} {
+		if !strings.Contains(contributing, required) {
+			t.Errorf("CONTRIBUTING.md must document %q", required)
+		}
+	}
+}
+
+func requiredPatternMatch(t *testing.T, pattern *regexp.Regexp, content, description string) string {
+	t.Helper()
+	match := pattern.FindStringSubmatch(content)
+	if len(match) != 2 {
+		t.Fatalf("missing %s", description)
+	}
+	return match[1]
+}


### PR DESCRIPTION
## Summary

Issue #76 identified a local/CI lint parity gap. The documented `make lint` command only checked gofmt and `go vet`, while GitHub Actions additionally ran golangci-lint with the repository's `.golangci.yml`. Contributors could therefore pass every documented local check and encounter static-analysis failures only after opening a pull request.

The root cause was that the Makefile had no golangci-lint target or version pin. An independently installed local binary could also differ from CI and produce inconsistent findings. Since the issue was filed, the live CI linter pin advanced from `v2.1.6` to `v2.5.0`; this change intentionally synchronizes with the current workflow value.

This change adds `GOLANGCI_LINT_VERSION := v2.5.0`, makes `make lint` run format checks, vet, and a new `lint-ci` target, and rejects missing or mismatched linter binaries with a concrete installation command. `make install-golangci-lint` installs the exact CI version, while `GOLANGCI_LINT=/path/to/binary` supports isolated tool directories. Contributor documentation now explains the complete workflow, and repository tests extract the Makefile and CI versions to prevent future drift.

The linter is pinned in the Makefile instead of the application module so its large tool-only dependency graph does not affect Iris runtime dependencies. The `cmd/gen-models` Makefile target mentioned in the issue remains out of scope because it is not part of the acceptance criteria.

## Validation

- Added parity tests first and confirmed they failed on the missing Makefile pin.
- Verified a missing binary fails with an installation hint.
- Verified an installed `v2.13.0` binary is rejected as mismatched.
- Installed `v2.5.0` into an isolated temporary tool directory.
- Ran `make lint` with the isolated binary: gofmt, vet, and golangci-lint passed with zero findings.
- `go test ./... ./contrib/otel/...`
- `go vet ./... ./contrib/otel/...`
- `go build ./... ./contrib/otel/...`
- `gofmt -l .`
- `git diff --check`

Closes #76
