### PR TITLE
[codex] Harden release artifact publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
           go-version: "1.25.x"
           cache: true
 
+      - name: Validate release tag against CHANGELOG
+        run: go run ./cmd/releasecheck -tag "${GITHUB_REF_NAME}" -changelog CHANGELOG.md
+
       - name: Build binaries
         run: |
           mkdir -p dist
@@ -35,10 +38,32 @@ jobs:
           GOOS=darwin GOARCH=arm64 go build -ldflags="${LDFLAGS}" -o dist/iris-darwin-arm64 ./cmd/iris
           GOOS=windows GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o dist/iris-windows-amd64.exe ./cmd/iris
 
+      - name: Smoke test Linux release binary
+        run: |
+          VERSION_OUTPUT="$(./dist/iris-linux-amd64 version)"
+          printf '%s\n' "${VERSION_OUTPUT}"
+          grep -Fq "iris ${GITHUB_REF_NAME}" <<<"${VERSION_OUTPUT}"
+
+      - name: Inspect release binary metadata
+        run: |
+          for binary in dist/iris-*; do
+            go version -m "${binary}"
+          done
+
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: dist
+          format: spdx-json
+          output-file: dist/iris-${{ github.ref_name }}.spdx.json
+          syft-version: v1.51.1
+          upload-artifact: false
+          upload-release-assets: false
+
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum * > checksums.txt
+          sha256sum iris-* > checksums.txt
 
       - name: Upload release assets
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
@@ -48,5 +73,6 @@ jobs:
             dist/iris-darwin-amd64
             dist/iris-darwin-arm64
             dist/iris-windows-amd64.exe
+            dist/iris-${{ github.ref_name }}.spdx.json
             dist/checksums.txt
           generate_release_notes: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,12 +153,14 @@ Releases are cut from `main` using semantic-version tags. Maintainers should:
    git push origin vX.Y.Z
    ```
 
-4. The tag triggers `.github/workflows/release.yml`, which builds Linux, macOS,
-   and Windows CLI binaries, generates SHA-256 checksums, and creates the GitHub
-   Release with generated notes.
-5. Verify the workflow succeeded and the release contains all four binaries
-   plus `checksums.txt`. If it fails, fix the cause on `main` and cut a new
-   patch version; do not replace the published tag.
+4. The tag triggers `.github/workflows/release.yml`, which verifies the tag
+   matches the latest dated `CHANGELOG.md` entry, builds Linux, macOS, and
+   Windows CLI binaries, smoke-tests the Linux binary, inspects every binary's
+   Go build metadata, and creates the GitHub Release with generated notes.
+5. Verify the workflow succeeded and the release contains all four binaries,
+   `checksums.txt`, and `iris-vX.Y.Z.spdx.json`. The checksums cover both the
+   binaries and SBOM. If the workflow fails, fix the cause on `main` and cut a
+   new patch version; do not replace the published tag.
 
 ## Pull Request Checklist
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ go get github.com/petal-labs/iris
 go install github.com/petal-labs/iris/cmd/iris@latest
 ```
 
+The CLI reads the module version recorded by Go, so binaries installed with
+`@latest` report that released version from `iris version`. Release downloads
+also include an injected commit and build date. Other source builds report the
+module or VCS-derived pseudo-version when Go records one, falling back to `dev`
+when build information is unavailable; commit and build date remain unknown
+without release linker flags.
+
 ## 🚀 Quick Start
 
 ### Using the SDK

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"runtime"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
@@ -24,17 +25,39 @@ func (a *App) newVersionCommand() *cobra.Command {
 		Short: "Print version information",
 		Long:  `Print detailed version information including version, commit, build date, and Go runtime.`,
 		Run: func(cmd *cobra.Command, args []string) {
+			version := resolvedVersion()
 			if a.jsonOutput {
 				fmt.Fprintf(a.stdout, `{"version":"%s","commit":"%s","buildDate":"%s","goVersion":"%s","platform":"%s/%s"}`+"\n",
-					Version, Commit, BuildDate, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+					version, Commit, BuildDate, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 				return
 			}
 
-			fmt.Fprintf(a.stdout, "iris %s\n", Version)
+			fmt.Fprintf(a.stdout, "iris %s\n", version)
 			fmt.Fprintf(a.stdout, "  commit:     %s\n", Commit)
 			fmt.Fprintf(a.stdout, "  built:      %s\n", BuildDate)
 			fmt.Fprintf(a.stdout, "  go version: %s\n", runtime.Version())
 			fmt.Fprintf(a.stdout, "  platform:   %s/%s\n", runtime.GOOS, runtime.GOARCH)
 		},
 	}
+}
+
+func resolvedVersion() string {
+	moduleVersion := ""
+	if info, ok := debug.ReadBuildInfo(); ok {
+		moduleVersion = info.Main.Version
+	}
+	return resolveVersion(Version, moduleVersion)
+}
+
+func resolveVersion(linkedVersion, moduleVersion string) string {
+	if linkedVersion != "" && linkedVersion != "dev" {
+		return linkedVersion
+	}
+	if moduleVersion != "" && moduleVersion != "(devel)" {
+		return moduleVersion
+	}
+	if linkedVersion == "" {
+		return "dev"
+	}
+	return linkedVersion
 }

--- a/cli/commands/version_test.go
+++ b/cli/commands/version_test.go
@@ -39,3 +39,25 @@ func TestVersionDefaults(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveVersion(t *testing.T) {
+	tests := []struct {
+		name          string
+		linkedVersion string
+		moduleVersion string
+		want          string
+	}{
+		{name: "release ldflags win", linkedVersion: "v1.2.3", moduleVersion: "v1.2.2", want: "v1.2.3"},
+		{name: "go install module version", linkedVersion: "dev", moduleVersion: "v1.2.3", want: "v1.2.3"},
+		{name: "local build", linkedVersion: "dev", moduleVersion: "(devel)", want: "dev"},
+		{name: "missing build info", linkedVersion: "dev", moduleVersion: "", want: "dev"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveVersion(tt.linkedVersion, tt.moduleVersion); got != tt.want {
+				t.Errorf("resolveVersion(%q, %q) = %q, want %q", tt.linkedVersion, tt.moduleVersion, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/releasecheck/main.go
+++ b/cmd/releasecheck/main.go
@@ -1,0 +1,75 @@
+// Command releasecheck validates release inputs before artifacts are published.
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var semanticVersionTagPattern = regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$`)
+var changelogReleasePattern = regexp.MustCompile(`^## \[([0-9A-Za-z.+-]+)\] - ([0-9]{4}-[0-9]{2}-[0-9]{2})\r?$`)
+
+func main() {
+	tag := flag.String("tag", "", "semantic-version release tag")
+	changelogPath := flag.String("changelog", "CHANGELOG.md", "path to the changelog")
+	flag.Parse()
+
+	content, err := os.ReadFile(*changelogPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read changelog: %v\n", err)
+		os.Exit(1)
+	}
+	if err := validateReleaseTag(*tag, string(content)); err != nil {
+		fmt.Fprintf(os.Stderr, "validate release: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("release tag %s matches the latest CHANGELOG entry\n", *tag)
+}
+
+func validateReleaseTag(tag, changelog string) error {
+	if !validSemanticVersionTag(tag) {
+		return fmt.Errorf("%q is not a valid v-prefixed semantic-version tag", tag)
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(changelog))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "## [") || line == "## [Unreleased]" {
+			continue
+		}
+		match := changelogReleasePattern.FindStringSubmatch(line)
+		if len(match) != 3 {
+			return fmt.Errorf("latest CHANGELOG release heading %q is malformed", line)
+		}
+		if _, err := time.Parse("2006-01-02", match[2]); err != nil {
+			return fmt.Errorf("latest CHANGELOG release has invalid date %q: %w", match[2], err)
+		}
+		version := strings.TrimPrefix(tag, "v")
+		if match[1] != version {
+			return fmt.Errorf("tag %q does not match latest CHANGELOG release %q", tag, match[1])
+		}
+		return nil
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scan CHANGELOG: %w", err)
+	}
+	return fmt.Errorf("CHANGELOG contains no dated release heading")
+}
+
+func validSemanticVersionTag(tag string) bool {
+	match := semanticVersionTagPattern.FindStringSubmatch(tag)
+	if len(match) == 0 {
+		return false
+	}
+	for _, identifier := range strings.Split(match[4], ".") {
+		if len(identifier) > 1 && identifier[0] == '0' && strings.Trim(identifier, "0123456789") == "" {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/releasecheck/main_test.go
+++ b/cmd/releasecheck/main_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateReleaseTagMatchesLatestChangelogEntry(t *testing.T) {
+	changelog := `# Changelog
+
+## [Unreleased]
+
+## [1.2.0] - 2026-08-28
+
+## [1.1.0] - 2026-08-01
+`
+	if err := validateReleaseTag("v1.2.0", changelog); err != nil {
+		t.Fatalf("validate matching release: %v", err)
+	}
+}
+
+func TestValidateReleaseTagSupportsCRLFChangelog(t *testing.T) {
+	changelog := "## [Unreleased]\r\n\r\n## [1.2.0] - 2026-08-28\r\n"
+	if err := validateReleaseTag("v1.2.0", changelog); err != nil {
+		t.Fatalf("validate CRLF changelog: %v", err)
+	}
+}
+
+func TestValidateReleaseTagRejectsStaleTag(t *testing.T) {
+	changelog := "## [1.2.0] - 2026-08-28\n\n## [1.1.0] - 2026-08-01\n"
+	err := validateReleaseTag("v1.1.0", changelog)
+	if err == nil || !strings.Contains(err.Error(), "latest CHANGELOG release") {
+		t.Fatalf("expected latest release mismatch, got %v", err)
+	}
+}
+
+func TestValidateReleaseTagRejectsInvalidInputs(t *testing.T) {
+	tests := []struct {
+		name      string
+		tag       string
+		changelog string
+		wantError string
+	}{
+		{name: "invalid tag", tag: "1.2.0", changelog: "## [1.2.0] - 2026-08-28\n", wantError: "semantic-version tag"},
+		{name: "invalid numeric prerelease", tag: "v1.2.0-01", changelog: "## [1.2.0-01] - 2026-08-28\n", wantError: "semantic-version tag"},
+		{name: "missing release", tag: "v1.2.0", changelog: "## [Unreleased]\n", wantError: "no dated release"},
+		{name: "invalid date", tag: "v1.2.0", changelog: "## [1.2.0] - 2026-99-99\n", wantError: "invalid date"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateReleaseTag(tt.tag, tt.changelog)
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantError, err)
+			}
+		})
+	}
+}

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -183,6 +183,19 @@ The repository workflows apply these supply-chain controls:
 Action version comments are informational. The full SHA after `@` is the
 security boundary and must not be replaced with a mutable tag.
 
+### Release Artifacts
+
+Each GitHub Release includes SHA-256 checksums and an SPDX JSON software bill of
+materials generated from the packaged CLI binaries with a pinned Syft release.
+The release workflow verifies the tag against the latest dated changelog entry,
+executes the Linux binary's `version` command, and inspects Go build metadata in
+all cross-compiled binaries before publishing.
+
+Checksums and SBOMs improve integrity checking and dependency transparency, but
+they are not cryptographic proof of publisher identity. Keyless Sigstore signing
+is deferred until the project defines its OIDC identity, certificate, and
+verification policy; no long-lived signing key is stored in repository secrets.
+
 ### Environment-Specific Keys
 
 Use different master keys for different environments:

--- a/docs/changes/2026-08-28_v0.0.0-dev_issue-77-release-hygiene.md
+++ b/docs/changes/2026-08-28_v0.0.0-dev_issue-77-release-hygiene.md
@@ -1,0 +1,88 @@
+---
+date: 2026-08-28
+version: v0.0.0-dev
+feature: Release validation, SBOM, and version provenance
+product: iris
+change_type: infrastructure
+affected_components: [.github/workflows/release.yml, cmd/releasecheck/main.go, cmd/releasecheck/main_test.go, cli/commands/version.go, cli/commands/version_test.go, README.md, CONTRIBUTING.md, docs/SECURITY.md, tests/github_workflows_test.go]
+related_frds: []
+---
+
+## Summary
+
+Issue #77 hardens the release pipeline with tag-to-changelog validation, executable and metadata smoke checks, a pinned SPDX SBOM, and checksums that cover both binaries and the SBOM. CLI builds installed with `go install ...@version` now report their recorded Go module version instead of always reporting `dev`.
+
+## Motivation
+
+The previous release workflow cross-compiled four binaries and generated checksums, but it could publish a tag that did not match the latest changelog release, never executed a packaged binary, and provided no machine-readable dependency inventory. Checksums alone detect corruption only when consumers already trust the checksum source. Separately, direct Go installs bypassed release linker flags and therefore produced misleading `iris dev` output even when built from a tagged module release.
+
+## What Changed
+
+### New Additions
+
+- `cmd/releasecheck` validates a v-prefixed semantic-version tag against the first dated release entry in `CHANGELOG.md`.
+- Release builds execute `iris-linux-amd64 version`, require the output to contain the pushed tag, and inspect `go version -m` metadata for every cross-compiled binary.
+- `anchore/sbom-action` v0.24.0, pinned to commit `e22c389904149dbc22b58101806040fa8d37a610`, runs Syft v1.51.1 against the release binaries and writes `iris-vX.Y.Z.spdx.json`.
+- Unit and repository-policy tests cover release validation, installed-version resolution, and workflow hygiene.
+
+### Modifications
+
+- Release checksums now include every `iris-*` binary and the SPDX JSON SBOM.
+- The SBOM is attached to the GitHub Release alongside the four binaries and `checksums.txt`.
+- `cli/commands/version.go` falls back to `debug.ReadBuildInfo().Main.Version` when linker-injected `Version` remains `dev`.
+- README, contributor, and security documentation explain installed-version behavior, release validation, attached assets, and the signing decision.
+
+### Removals
+
+- Removed the ability to publish a release tag that differs from the latest dated changelog entry.
+- Removed the assumption that checksums alone provide sufficient release metadata.
+- Removed `dev` as the reported version for binaries installed from a tagged module version when Go build information is available.
+
+## Technical Specification
+
+`cmd/releasecheck -tag vX.Y.Z -changelog CHANGELOG.md` accepts a validated semantic-version tag, scans from the top of the changelog, and compares the tag without its `v` prefix to the first `## [X.Y.Z] - YYYY-MM-DD` heading. It rejects malformed tags, malformed or invalid release dates, missing release headings, and tags matching an older changelog entry instead of the latest one.
+
+The release workflow builds with linker-injected version, commit, and UTC build date values. The native Linux artifact must exit successfully from `version` and print `iris ${GITHUB_REF_NAME}`. `go version -m` validates readable Go build information in Linux, Darwin, and Windows artifacts without attempting to execute foreign binaries.
+
+Syft scans `dist` before checksums are generated and emits SPDX JSON to `dist/iris-${{ github.ref_name }}.spdx.json`. Action-managed artifact and release uploads are disabled so the existing release publisher remains the single upload path. `sha256sum iris-*` then covers all four binaries and the SBOM.
+
+For version output, explicit release linker flags remain authoritative. When `Version == "dev"`, Iris uses the main module version embedded by Go. Tagged installs report the release version, and newer toolchains may record a VCS-derived pseudo-version for source builds; `(devel)`, empty, or unavailable build information retains `dev`.
+
+## Usage Examples
+
+### Validate a release before tagging
+
+```bash
+go run ./cmd/releasecheck -tag v0.18.0 -changelog CHANGELOG.md
+```
+
+### Install a tagged CLI through Go
+
+```bash
+go install github.com/petal-labs/iris/cmd/iris@latest
+iris version
+# iris vX.Y.Z
+```
+
+## Integration Notes
+
+The release job retains job-scoped `contents: write`; the SBOM action's own artifact and release uploads are disabled, so no additional workflow permission is required. Existing immutable action pin tests cover the new Anchore action. The runtime fallback uses standard-library build information and adds no module dependency.
+
+Release-preparation pull requests must add the dated changelog heading before creating the tag. The validation intentionally fails when `Unreleased` has not been promoted or an older tag is pushed.
+
+## Breaking Changes & Migration
+
+No SDK or CLI command syntax changes. `iris version` output becomes more accurate for `go install ...@version` builds and source builds carrying Go module metadata: the version changes from `dev` to the recorded module or pseudo-version while commit and build date remain `unknown`. Release binaries keep their existing linker-injected output.
+
+## Deferred / Out of Scope
+
+- Keyless Sigstore signing is deferred until the repository defines an OIDC identity, certificate issuer/subject expectations, and consumer verification policy. No long-lived signing key is introduced. The attached SBOM satisfies this issue's artifact-metadata acceptance criterion but is explicitly not a signature.
+- Native execution of Darwin and Windows artifacts would require a multi-runner packaging redesign. This workflow executes the Linux artifact and validates Go build metadata in every cross-compiled file.
+- The stale historical README version sample was corrected by issue #56 and is not changed again here.
+
+## Testing Notes
+
+- Added release validator, version-resolution, and workflow-hygiene tests first and confirmed they failed before implementation.
+- Cover matching, stale, malformed, missing, and invalid-date changelog/tag inputs.
+- Cover linker-version precedence, tagged Go installs, local development builds, and missing build information.
+- Validate every workflow YAML file, immutable action references, shell checks, local smoke builds, full Go test/race/build/vet checks, formatting, and diff whitespace before completion.

--- a/tests/github_workflows_test.go
+++ b/tests/github_workflows_test.go
@@ -84,6 +84,23 @@ func TestCodecovEnforcesProjectAndPatchThresholds(t *testing.T) {
 	}
 }
 
+func TestReleaseWorkflowEnforcesReleaseHygiene(t *testing.T) {
+	release := readRepositoryFile(t, ".github/workflows/release.yml")
+	for _, required := range []string{
+		"go run ./cmd/releasecheck",
+		"./dist/iris-linux-amd64 version",
+		"go version -m",
+		"anchore/sbom-action@",
+		"syft-version: v1.51.1",
+		"output-file: dist/iris-${{ github.ref_name }}.spdx.json",
+		"dist/iris-${{ github.ref_name }}.spdx.json",
+	} {
+		if !strings.Contains(release, required) {
+			t.Errorf("release workflow must contain %q", required)
+		}
+	}
+}
+
 func TestGitHubYAMLConfigurationParses(t *testing.T) {
 	configs := readWorkflowFiles(t)
 	for _, path := range []string{".github/dependabot.yml", "codecov.yml"} {


### PR DESCRIPTION
Closes #77.

## Issue

The release workflow did not enforce tag/changelog consistency, smoke-test a packaged CLI, publish an SBOM, or clearly explain the version reported by `go install` builds.

## Cause and impact

Release tags and changelog entries were trusted without automated validation, and cross-compiled artifacts were uploaded without runtime or embedded-module metadata checks. Consumers received checksums, but no software bill of materials. Builds made outside the release workflow also remained labeled `dev` even when Go embedded useful module version information.

## Fix

- add a tested `cmd/releasecheck` validator for v-prefixed SemVer tags and the latest dated changelog heading
- validate releases before building and smoke-test `iris version` on the Linux artifact
- inspect Go build metadata for every cross-compiled executable
- generate and publish a pinned SPDX JSON SBOM, covered by release checksums
- resolve non-linker CLI versions from Go build information while preserving linker-injected release versions
- document release artifacts, `go install` version behavior, and the explicit decision to defer keyless signing until an OIDC identity and verification policy are established
- add workflow policy tests and release/process documentation

## Validation

- `go test ./... ./contrib/otel/...`
- `go test -race ./... ./contrib/otel/...`
- `go vet ./... ./contrib/otel/...`
- `go build ./... ./contrib/otel/...`
- `golangci-lint run ./... ./contrib/otel/...` (v2.5.0; 0 issues)
- `gofmt -l .`
- `git diff --check`
- release validator against the current `v0.17.0` changelog entry
- release-style CLI version smoke test
- `go version -m` checks on Linux amd64, Darwin amd64/arm64, and Windows amd64 artifacts
