### PR TITLE
[codex] Prevent scaffold SDK version drift

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,10 @@ Releases are cut from `main` using semantic-version tags. Maintainers should:
 
 1. Open and merge a release-preparation pull request that moves the relevant
    `CHANGELOG.md` entries from `Unreleased` into a `X.Y.Z` section dated in UTC,
+   updates `scaffoldSDKVersionFallback` in `cli/commands/init.go` to `vX.Y.Z`,
    confirms all required `docs/changes/` records are present, and passes CI.
+   CI requires the fallback to match the latest dated changelog release; tagged
+   CLI builds derive the scaffold dependency from their own build version.
 2. Update local `main` and confirm the release commit:
 
    ```bash

--- a/cli/commands/init.go
+++ b/cli/commands/init.go
@@ -78,7 +78,7 @@ func createProject(projectPath, projectName, provider string) error {
 		ProjectName: projectName,
 		Provider:    provider,
 		GoVersion:   scaffoldGoVersion,
-		SDKVersion:  scaffoldSDKVersion,
+		SDKVersion:  scaffoldSDKVersion(),
 	}
 	if err := generateFile(filepath.Join(projectPath, "main.go"), mainTemplateForProvider(provider), data); err != nil {
 		return fmt.Errorf("failed to create main.go: %w", err)
@@ -135,9 +135,43 @@ type templateData struct {
 }
 
 const (
-	scaffoldGoVersion  = "1.25.0"
-	scaffoldSDKVersion = "v0.17.0"
+	scaffoldGoVersion          = "1.25.0"
+	scaffoldSDKVersionFallback = "v0.17.0"
 )
+
+var (
+	scaffoldSemanticVersionPattern = regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
+	gitDescribeVersionPattern      = regexp.MustCompile(`(?:-[0-9]+-g[0-9a-f]+|-dirty)$`)
+)
+
+func scaffoldSDKVersion() string {
+	return resolveScaffoldSDKVersion(Version, mainModuleVersion())
+}
+
+func resolveScaffoldSDKVersion(linkedVersion, moduleVersion string) string {
+	for _, version := range []string{linkedVersion, moduleVersion} {
+		if validScaffoldSDKVersion(version) {
+			return version
+		}
+	}
+	return scaffoldSDKVersionFallback
+}
+
+func validScaffoldSDKVersion(version string) bool {
+	if gitDescribeVersionPattern.MatchString(version) {
+		return false
+	}
+	match := scaffoldSemanticVersionPattern.FindStringSubmatch(version)
+	if len(match) == 0 {
+		return false
+	}
+	for _, identifier := range strings.Split(match[4], ".") {
+		if len(identifier) > 1 && identifier[0] == '0' && strings.Trim(identifier, "0123456789") == "" {
+			return false
+		}
+	}
+	return true
+}
 
 var templateFuncs = template.FuncMap{
 	"envVar":       envVarForProvider,

--- a/cli/commands/init_test.go
+++ b/cli/commands/init_test.go
@@ -1,10 +1,12 @@
 package commands
 
 import (
+	"bufio"
 	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -132,6 +134,113 @@ func TestGenerateFileWithFuncs(t *testing.T) {
 	expected := "Provider: openai, Env: OPENAI_API_KEY, Model: gpt-4o"
 	if string(content) != expected {
 		t.Errorf("generateFile() content = %q, want %q", string(content), expected)
+	}
+}
+
+func TestGenerateFileRejectsInvalidTemplate(t *testing.T) {
+	err := generateFile(filepath.Join(t.TempDir(), "invalid.txt"), "{{", templateData{})
+	if err == nil {
+		t.Fatal("generateFile() should reject an invalid template")
+	}
+}
+
+func TestCreateProjectRejectsFilePath(t *testing.T) {
+	projectPath := filepath.Join(t.TempDir(), "project")
+	if err := os.WriteFile(projectPath, []byte("occupied"), 0600); err != nil {
+		t.Fatalf("write project-path fixture: %v", err)
+	}
+	err := createProject(projectPath, "project", "openai")
+	if err == nil || !strings.Contains(err.Error(), "failed to create project directories") {
+		t.Fatalf("createProject() error = %v, want project-directory error", err)
+	}
+}
+
+func TestCreateProjectReportsMainFileError(t *testing.T) {
+	projectPath := filepath.Join(t.TempDir(), "project")
+	if err := os.MkdirAll(filepath.Join(projectPath, "main.go"), 0755); err != nil {
+		t.Fatalf("create main.go directory fixture: %v", err)
+	}
+	err := createProject(projectPath, "project", "openai")
+	if err == nil || !strings.Contains(err.Error(), "failed to create main.go") {
+		t.Fatalf("createProject() error = %v, want main.go creation error", err)
+	}
+}
+
+func TestResolveScaffoldSDKVersion(t *testing.T) {
+	tests := []struct {
+		name          string
+		linkedVersion string
+		moduleVersion string
+		want          string
+	}{
+		{name: "release build", linkedVersion: "v0.18.0", moduleVersion: "(devel)", want: "v0.18.0"},
+		{name: "tagged go install", linkedVersion: "dev", moduleVersion: "v0.18.0", want: "v0.18.0"},
+		{name: "pseudo-version install", linkedVersion: "dev", moduleVersion: "v0.0.0-20260828120000-abcdef123456", want: "v0.0.0-20260828120000-abcdef123456"},
+		{name: "module version after development linker version", linkedVersion: "v0.17.0-74-g243be7c", moduleVersion: "v0.18.0", want: "v0.18.0"},
+		{name: "make development build", linkedVersion: "v0.17.0-74-g243be7c", moduleVersion: "(devel)", want: scaffoldSDKVersionFallback},
+		{name: "dirty tagged build", linkedVersion: "v0.18.0-dirty", moduleVersion: "(devel)", want: scaffoldSDKVersionFallback},
+		{name: "go development build", linkedVersion: "dev", moduleVersion: "(devel)", want: scaffoldSDKVersionFallback},
+		{name: "missing build version", linkedVersion: "", moduleVersion: "", want: scaffoldSDKVersionFallback},
+		{name: "malformed linked version", linkedVersion: "release", moduleVersion: "(devel)", want: scaffoldSDKVersionFallback},
+		{name: "leading-zero prerelease", linkedVersion: "v1.2.3-01", moduleVersion: "(devel)", want: scaffoldSDKVersionFallback},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveScaffoldSDKVersion(tt.linkedVersion, tt.moduleVersion)
+			if got != tt.want {
+				t.Errorf("resolveScaffoldSDKVersion(%q, %q) = %q, want %q", tt.linkedVersion, tt.moduleVersion, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScaffoldSDKVersionFallbackMatchesLatestChangelogRelease(t *testing.T) {
+	file, err := os.Open(filepath.Join("..", "..", "CHANGELOG.md"))
+	if err != nil {
+		t.Fatalf("open CHANGELOG.md: %v", err)
+	}
+	t.Cleanup(func() { _ = file.Close() })
+
+	releaseHeading := regexp.MustCompile(`^## \[([^]]+)\] - [0-9]{4}-[0-9]{2}-[0-9]{2}\r?$`)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "## [") || line == "## [Unreleased]" {
+			continue
+		}
+		match := releaseHeading.FindStringSubmatch(line)
+		if len(match) != 2 {
+			t.Fatalf("latest CHANGELOG release heading %q is malformed", line)
+		}
+		want := "v" + match[1]
+		if scaffoldSDKVersionFallback != want {
+			t.Errorf("scaffoldSDKVersionFallback = %q, want latest CHANGELOG release %q", scaffoldSDKVersionFallback, want)
+		}
+		return
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan CHANGELOG.md: %v", err)
+	}
+	t.Fatal("CHANGELOG.md contains no dated release heading")
+}
+
+func TestInitUsesBuildVersionForSDKDependency(t *testing.T) {
+	originalVersion := Version
+	Version = "v0.18.0"
+	t.Cleanup(func() { Version = originalVersion })
+
+	projectPath := filepath.Join(t.TempDir(), "scaffold")
+	if err := runInitWithPath(projectPath, "openai"); err != nil {
+		t.Fatalf("runInitWithPath() error = %v", err)
+	}
+	content, err := os.ReadFile(filepath.Join(projectPath, "go.mod"))
+	if err != nil {
+		t.Fatalf("read generated go.mod: %v", err)
+	}
+	want := "require github.com/petal-labs/iris v0.18.0"
+	if !strings.Contains(string(content), want) {
+		t.Errorf("generated go.mod missing %q:\n%s", want, content)
 	}
 }
 

--- a/cli/commands/version.go
+++ b/cli/commands/version.go
@@ -42,11 +42,14 @@ func (a *App) newVersionCommand() *cobra.Command {
 }
 
 func resolvedVersion() string {
-	moduleVersion := ""
+	return resolveVersion(Version, mainModuleVersion())
+}
+
+func mainModuleVersion() string {
 	if info, ok := debug.ReadBuildInfo(); ok {
-		moduleVersion = info.Main.Version
+		return info.Main.Version
 	}
-	return resolveVersion(Version, moduleVersion)
+	return ""
 }
 
 func resolveVersion(linkedVersion, moduleVersion string) string {

--- a/cli/commands/version_test.go
+++ b/cli/commands/version_test.go
@@ -1,7 +1,11 @@
 package commands
 
 import (
+	"bytes"
+	"strings"
 	"testing"
+
+	"github.com/petal-labs/iris/cli/config"
 )
 
 func TestVersionVariables(t *testing.T) {
@@ -57,6 +61,50 @@ func TestResolveVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := resolveVersion(tt.linkedVersion, tt.moduleVersion); got != tt.want {
 				t.Errorf("resolveVersion(%q, %q) = %q, want %q", tt.linkedVersion, tt.moduleVersion, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionCommandOutput(t *testing.T) {
+	originalVersion, originalCommit, originalBuildDate := Version, Commit, BuildDate
+	Version, Commit, BuildDate = "v1.2.3", "abc1234", "2026-08-28T12:00:00Z"
+	t.Cleanup(func() {
+		Version, Commit, BuildDate = originalVersion, originalCommit, originalBuildDate
+	})
+
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "text",
+			args: []string{"version"},
+			want: []string{"iris v1.2.3", "commit:     abc1234", "built:      2026-08-28T12:00:00Z"},
+		},
+		{
+			name: "json",
+			args: []string{"--json", "version"},
+			want: []string{`"version":"v1.2.3"`, `"commit":"abc1234"`, `"buildDate":"2026-08-28T12:00:00Z"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			app := NewApp(
+				WithConfigLoader(func(string) (*config.Config, error) { return &config.Config{}, nil }),
+				WithIO(strings.NewReader(""), &stdout, &bytes.Buffer{}),
+			)
+			app.root.SetArgs(tt.args)
+			if err := app.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(stdout.String(), want) {
+					t.Errorf("version output missing %q:\n%s", want, stdout.String())
+				}
 			}
 		})
 	}

--- a/docs/changes/2026-08-28_v0.0.0-dev_issue-110-scaffold-sdk-version.md
+++ b/docs/changes/2026-08-28_v0.0.0-dev_issue-110-scaffold-sdk-version.md
@@ -1,0 +1,86 @@
+---
+date: 2026-08-28
+version: v0.0.0-dev
+feature: Keep scaffolded SDK dependencies current
+product: iris
+change_type: bugfix
+affected_components: [cli/commands/init.go, cli/commands/init_test.go, cli/commands/version.go, cli/commands/version_test.go, CONTRIBUTING.md]
+related_frds: []
+---
+
+## Summary
+
+Issue #110 prevents `iris init` from silently pinning generated projects to an SDK release older than the CLI that created them. The scaffold now derives its Iris dependency from validated build metadata and uses a changelog-guarded fallback only when a development build has no resolvable module version.
+
+## Motivation
+
+`cli/commands/init.go` previously hardcoded `scaffoldSDKVersion = "v0.17.0"`. That value was correct when added, but no release automation or test required it to move with the next release. A newer CLI could therefore keep generating `go.mod` files pinned to an older SDK without an error or warning.
+
+The guard must also work in shallow clones and forks where repository tags may be absent. Reading the checked-in changelog provides the release reference without relying on Git history or network access.
+
+## What Changed
+
+### New Additions
+
+- `scaffoldSDKVersion()` selects the dependency version used by generated `go.mod` files.
+- `resolveScaffoldSDKVersion(linkedVersion, moduleVersion string)` applies deterministic precedence and fallback rules.
+- Focused tests cover release builds, tagged and pseudo-version `go install` builds, local development builds, malformed versions, generated-file wiring, fallback consistency with `CHANGELOG.md`, and text/JSON version output.
+
+### Modifications
+
+- `createProject` now calls `scaffoldSDKVersion()` instead of reading a fixed SDK constant.
+- The fixed value is retained as `scaffoldSDKVersionFallback` for development builds with no resolvable version.
+- `mainModuleVersion()` centralizes access to `debug.ReadBuildInfo().Main.Version` for both `iris version` and scaffold generation.
+- The release-preparation instructions require the fallback to move with the newest dated changelog release.
+
+### Removals
+
+- Removed the unconditional use of `v0.17.0` in every generated project.
+- Removed reliance on an unenforced manual convention for keeping scaffold dependencies current.
+
+## Technical Specification
+
+Scaffold version resolution uses the first valid candidate in this order:
+
+1. `cli/commands.Version`, injected by release linker flags.
+2. `debug.ReadBuildInfo().Main.Version`, recorded by Go for tagged or pseudo-version installs.
+3. `scaffoldSDKVersionFallback`, for local development builds without a resolvable module version.
+
+Candidates must be v-prefixed semantic versions. Numeric prerelease identifiers with leading zeroes, malformed values, `dev`, `(devel)`, and `git describe` development strings such as `v0.17.0-74-g243be7c` are rejected. The latter resembles semantic version syntax but is not a published Go module version and would make the generated dependency impossible to resolve.
+
+`TestScaffoldSDKVersionFallbackMatchesLatestChangelogRelease` reads the first dated `## [X.Y.Z] - YYYY-MM-DD` heading and requires the fallback to equal `vX.Y.Z`. It does not invoke Git, inspect tags, or access the network, so tagless and shallow checkouts do not fail spuriously.
+
+## Usage Examples
+
+A release binary tagged `v0.18.0` now generates:
+
+```go
+require github.com/petal-labs/iris v0.18.0
+```
+
+A CLI installed with `go install github.com/petal-labs/iris/cmd/iris@v0.18.0` uses the same version from Go build information. A local development binary with no usable module version uses the latest released fallback recorded in `cli/commands/init.go`.
+
+## Integration Notes
+
+The release workflow already injects `cli/commands.Version`, so no workflow or linker-flag change is required. Release-preparation pull requests update the changelog and fallback together; the command-package test fails in normal CI if they diverge.
+
+`TestGeneratedProjectsCompile` remains the integration check for all ten providers. Its local test binaries resolve to the fallback, producing a stable and downloadable Iris requirement before the existing local `replace` directive is applied.
+
+## Breaking Changes & Migration
+
+No command, flag, exported Go API, scaffold layout, or file set changes. Generated projects continue to contain an explicit Iris requirement; only its version source changes. Release and tagged-install CLIs now pin the SDK version corresponding to their own build instead of an independently maintained constant.
+
+## Deferred / Out of Scope
+
+- `scaffoldGoVersion` is unchanged.
+- Scaffold templates and generated files other than the Iris requirement version are unchanged.
+- The scaffold continues to emit an explicit version rather than resolving `@latest` over the network.
+- Release workflow structure is unchanged because its existing linker metadata is sufficient.
+
+## Testing Notes
+
+- Added resolution and changelog-fallback tests first and confirmed they failed before implementation because the new resolver and fallback did not exist.
+- Focused command tests cover valid release, tagged-install, and pseudo-version inputs plus development, missing, malformed, and leading-zero error paths.
+- An integration assertion reads a generated `go.mod` and verifies the linker-derived version reaches the `require` line.
+- Nearby template and project-file error paths plus text and JSON version command output keep `cli/commands` statement coverage at 80.0%.
+- Full command, generated-provider, repository, race, vet, build, lint, formatting, and whitespace checks are run before completion.


### PR DESCRIPTION
Closes #110.

## Issue

`iris init` wrote a fixed `v0.17.0` Iris requirement into every generated `go.mod`. Although that was the current release, nothing automatically kept the constant synchronized with future releases.

## Cause and user impact

The scaffold dependency version was maintained independently from the CLI's existing linker and Go module build metadata. A newly released CLI could therefore keep generating projects pinned to an older SDK without an error or warning, leaving users on stale behavior immediately after scaffolding a project.

## Fix

- derive the scaffold SDK requirement from a valid linker-injected release version
- fall back to Go's embedded main-module version for tagged and pseudo-version `go install` builds
- retain a stable released fallback only for development builds without resolvable metadata
- reject malformed, dirty, and `git describe` development versions that cannot be downloaded as Go module requirements
- add a CI test requiring the fallback to match the newest dated `CHANGELOG.md` release without relying on Git tags, so shallow clones and forks work normally
- document the enforced fallback update in the release process and add the required change record

## Validation

- `go test ./... ./contrib/otel/...`
- `go test -race ./... ./contrib/otel/...`
- `go vet ./... ./contrib/otel/...`
- `go build ./... ./contrib/otel/...`
- `golangci-lint run ./... ./contrib/otel/...` with the repository-pinned v2.5.0: 0 issues
- `go test -cover ./cli/commands`: 80.0% statement coverage
- `gofmt -l .`
- `git diff --check`

The command tests also compile generated projects for all ten supported providers and verify that the build-derived SDK version reaches the generated `require github.com/petal-labs/iris` line.
