### PR TITLE
ci(release): keyless sign artifacts with Sigstore Cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -65,6 +66,23 @@ jobs:
           cd dist
           sha256sum iris-* > checksums.txt
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Keyless sign release artifacts
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cd dist
+          for file in iris-linux-amd64 iris-darwin-amd64 iris-darwin-arm64 \
+                      iris-windows-amd64.exe iris-${GITHUB_REF_NAME}.spdx.json \
+                      checksums.txt; do
+            cosign sign-blob \
+              --output-signature "${file}.sig" \
+              --output-certificate "${file}.crt" \
+              "${file}"
+          done
+
       - name: Upload release assets
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
@@ -75,4 +93,6 @@ jobs:
             dist/iris-windows-amd64.exe
             dist/iris-${{ github.ref_name }}.spdx.json
             dist/checksums.txt
+            dist/*.sig
+            dist/*.crt
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -65,6 +65,29 @@ module or VCS-derived pseudo-version when Go records one, falling back to `dev`
 when build information is unavailable; commit and build date remain unknown
 without release linker flags.
 
+### Verifying release binaries
+
+Every release binary, the SBOM, and `checksums.txt` are keyless-signed with
+[Sigstore](https://docs.sigstore.dev/) Cosign using GitHub Actions OIDC. Each
+artifact ships with a `.sig` (signature) and `.crt` (Fulcio certificate) file.
+Install Cosign from the [official guide](https://docs.sigstore.dev/cosign/installation/),
+then verify a downloaded binary:
+
+```bash
+cosign verify-blob \
+  --certificate iris-linux-amd64.crt \
+  --signature iris-linux-amd64.sig \
+  --certificate-identity "https://github.com/petal-labs/iris/.github/workflows/release.yml@refs/tags/v1.2.3" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  iris-linux-amd64
+```
+
+Replace `v1.2.3` with the tag you downloaded. The command exits `0` only when
+the signature is valid **and** the certificate was issued to the
+`petal-labs/iris` release workflow at that exact tag. Always verify both the
+`--certificate-identity` and `--certificate-oidc-issuer`; checking only the
+issuer would accept signatures from any GitHub Actions workflow.
+
 ## 🚀 Quick Start
 
 ### Using the SDK


### PR DESCRIPTION
## Summary

Release artifacts are currently distributed without cryptographic signatures — consumers can only verify integrity via the unsigned `checksums.txt`, with no proof tying a binary to the GitHub workflow that produced it. This PR adds **keyless signing** with [Sigstore](https://docs.sigstore.dev/) Cosign backed by GitHub Actions OIDC, so each released `iris` binary (plus the SBOM and checksums) carries a short-lived Fulcio certificate bound to the workflow identity, recorded in the Rekor transparency log.

Closes #118.

Reference guide: https://www.qcecuring.com/blog/sigstore-cosign-keyless-github-actions

## Changes

- **`.github/workflows/release.yml`**
  - Add `id-token: write` permission (required for the GitHub Actions OIDC token used by Fulcio).
  - Install Cosign via `sigstore/cosign-installer@v4.1.2` (SHA-pinned to match repo convention).
  - Keyless-sign every release artifact with `cosign sign-blob`, emitting `.sig` (signature) and `.crt` (Fulcio certificate) per artifact.
  - Upload `*.sig` and `*.crt` alongside the binaries as release assets.
- **`README.md`**
  - New "Verifying release binaries" section with a copy-pasteable `cosign verify-blob` command.
  - Note that both `--certificate-identity` and `--certificate-oidc-issuer` must always be checked (checking only the issuer would accept any GitHub Actions workflow signature).

## Verification

- [x] Workflow YAML parses (`yaml.safe_load`).
- [x] `go vet ./...` passes.
- [x] `gofmt -l .` — all files formatted correctly.
- [x] SHA pin for `cosign-installer` matches `v4.1.2` release tag.

End-to-end signing will be exercised on the next tag push; the acceptance criteria in #118 can be fully checked then.

## Notes

- The linked guide also covers SLSA provenance attestations and SBOM attestation; out of scope here but candidate follow-ups.
- A fork at `attacker/iris` cannot forge signatures — the OIDC `subject` claim is scoped to `petal-labs/iris`, and verification requires the full `--certificate-identity` (org/repo + workflow + ref).